### PR TITLE
Logging and security updates

### DIFF
--- a/platform-hub-api/config/environments/production.rb
+++ b/platform-hub-api/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/platform-hub-api/config/initializers/filter_parameter_logging.rb
+++ b/platform-hub-api/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,16 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [
+  :password,
+  :token,
+  :access_token,
+  :auth_token,
+  :secret_key_base,
+  :secret_token,
+  :secret,
+  :session,
+  :cookie,
+  :csrf,
+  :salt
+]


### PR DESCRIPTION
- API: in `production` environments only log INFO and above
- API: filter out some commonly used fields during logging to prevent values showing up in logs

@marcinc (and anyone else) – can you think of any more fields that should be filtered out during logging?