### PR TITLE
Support requests improvements

### DIFF
--- a/platform-hub-api/app/controllers/support_request_templates_controller.rb
+++ b/platform-hub-api/app/controllers/support_request_templates_controller.rb
@@ -2,8 +2,8 @@ class SupportRequestTemplatesController < ApiJsonController
 
   before_action :find_support_request_template, only: [ :show, :update, :destroy ]
 
-  skip_authorization_check :only => [ :index, :show ]
-  authorize_resource except: [ :index, :show ]
+  skip_authorization_check :only => [ :index, :show, :form_field_types, :git_hub_repos ]
+  authorize_resource except: [ :index, :show, :form_field_types, :git_hub_repos ]
 
   # GET /support_request_templates
   def index
@@ -67,6 +67,11 @@ class SupportRequestTemplatesController < ApiJsonController
   # GET /support_request_templates/form_field_types
   def form_field_types
     render json: SupportRequestTemplate.form_field_types
+  end
+
+  # GET /support_request_templates/git_hub_repos
+  def git_hub_repos
+    render json: SupportRequestTemplate.git_hub_repos
   end
 
   private

--- a/platform-hub-api/app/models/support_request_template.rb
+++ b/platform-hub-api/app/models/support_request_template.rb
@@ -71,6 +71,10 @@ class SupportRequestTemplate < ApplicationRecord
     }
   }.freeze
 
+  def self.git_hub_repos
+    SupportRequestTemplate.pluck(:git_hub_repo).uniq.sort
+  end
+
   private
 
   def check_schemas

--- a/platform-hub-api/app/services/support_request_formatter_service.rb
+++ b/platform-hub-api/app/services/support_request_formatter_service.rb
@@ -22,7 +22,9 @@ module SupportRequestFormatterService
       body_text_lines << "| #{spec['label']} | #{data[spec['id']] || '--'} |"
     end
 
-    Result.new title: template['git_hub_issue_spec']['title_text'], body: body_text_lines.join("\n");
+    title_text = template['git_hub_issue_spec']['title_text'] + " [#{submitter_text}]"
+
+    Result.new title: title_text, body: body_text_lines.join("\n");
   end
 
 

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
 
     resources :support_request_templates do
       get '/form_field_types', to: 'support_request_templates#form_field_types', on: :collection
+      get '/git_hub_repos', to: 'support_request_templates#git_hub_repos', on: :collection
     end
 
     resources :support_requests, only: [ :create ]

--- a/platform-hub-api/spec/controllers/support_request_templates_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/support_request_templates_controller_spec.rb
@@ -238,4 +238,49 @@ RSpec.describe SupportRequestTemplatesController, type: :controller do
     end
   end
 
+  describe 'GET #form_field_types' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        get :form_field_types
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it 'should return the available form field types' do
+        get :form_field_types
+        expect(response).to be_success
+        expect(json_response).to eq SupportRequestTemplate.form_field_types.to_a
+      end
+
+    end
+  end
+
+  describe 'GET #git_hub_repos' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        get :git_hub_repos
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      let(:foo_repo) { 'http://example.com/foo' }
+      let(:bar_repo) { 'http://example.com/bar' }
+
+      before do
+        create :support_request_template, :git_hub_repo => foo_repo
+        create :support_request_template, :git_hub_repo => bar_repo
+        create :support_request_template, :git_hub_repo => foo_repo
+      end
+
+      it 'should return a unique and sorted list of the possible GitHub repo URLs' do
+        get :git_hub_repos
+        expect(response).to be_success
+        expect(json_response).to eq [ bar_repo, foo_repo ]
+      end
+
+    end
+  end
+
 end

--- a/platform-hub-api/spec/routing/support_request_templates_routing_spec.rb
+++ b/platform-hub-api/spec/routing/support_request_templates_routing_spec.rb
@@ -31,5 +31,9 @@ RSpec.describe SupportRequestTemplatesController, type: :routing do
       expect(:get => '/support_request_templates/form_field_types').to route_to('support_request_templates#form_field_types')
     end
 
+    it 'routes to #git_hub_repos' do
+      expect(:get => '/support_request_templates/git_hub_repos').to route_to('support_request_templates#git_hub_repos')
+    end
+
   end
 end

--- a/platform-hub-web/src/app/help/support/requests/support-requests-form.component.js
+++ b/platform-hub-web/src/app/help/support/requests/support-requests-form.component.js
@@ -6,7 +6,7 @@ export const SupportRequestsFormComponent = {
   controller: SupportRequestsFormController
 };
 
-function SupportRequestsFormController(hubApiService) {
+function SupportRequestsFormController($mdDialog, hubApiService) {
   'ngInject';
 
   const ctrl = this;
@@ -48,9 +48,22 @@ function SupportRequestsFormController(hubApiService) {
       .createSupportRequest(ctrl.template.id, ctrl.data)
       .then(result => {
         ctrl.issueUrl = result.url;
+
+        showIssueUrlDialog();
       })
       .finally(() => {
         ctrl.sending = false;
       });
+  }
+
+  function showIssueUrlDialog() {
+    $mdDialog.show(
+      $mdDialog.alert()
+        .clickOutsideToClose(true)
+        .title('Your support request has been submitted')
+        .htmlContent(`<p class="md-body-1">See the following GitHub issue for details and updates:</p><p class="md-body-1"><strong><a href="${ctrl.issueUrl}" target="_blank">${ctrl.issueUrl}</a></strong></p>`)
+        .ariaLabel('Support request GitHub issue URL')
+        .ok('Got it')
+    );
   }
 }

--- a/platform-hub-web/src/app/help/support/requests/support-requests-form.html
+++ b/platform-hub-web/src/app/help/support/requests/support-requests-form.html
@@ -28,10 +28,10 @@
           class="md-body-1"
           md-colors="{background: 'green-50'}"
           ng-if="$ctrl.issueUrl">
-          Your issue has been submitted!
+          Your support request has been submitted…
           <br />
-          See:
-          <a ng-href="{{$ctrl.issueUrl}}" target="_blank">{{$ctrl.issueUrl}}</a>
+          See the following GitHub issue for details and updates:
+          <strong><a ng-href="{{$ctrl.issueUrl}}" target="_blank">{{$ctrl.issueUrl}}</a></strong>
         </p>
 
         <form name="$ctrl.requestForm" role="form" ng-submit="$ctrl.sendRequest()" ng-if="!$ctrl.issueUrl">

--- a/platform-hub-web/src/app/help/support/requests/support-requests-overview.component.js
+++ b/platform-hub-web/src/app/help/support/requests/support-requests-overview.component.js
@@ -3,29 +3,40 @@ export const SupportRequestsOverviewComponent = {
   controller: SupportRequestsOverviewController
 };
 
-function SupportRequestsOverviewController(hubApiService) {
+function SupportRequestsOverviewController($q, hubApiService) {
   'ngInject';
 
   const ctrl = this;
 
   ctrl.loading = this;
   ctrl.templates = [];
+  ctrl.gitHubRepos = [];
 
   init();
 
   function init() {
-    loadTemplates();
+    loadData();
   }
 
-  function loadTemplates() {
+  function loadData() {
     ctrl.loading = true;
     ctrl.templates = [];
+    ctrl.gitHubRepos = [];
 
-    hubApiService
+    const templatesFetcher = hubApiService
       .getSupportRequestTemplates()
       .then(templates => {
         ctrl.templates = templates;
-      })
+      });
+
+    const reposFetcher = hubApiService
+      .getSupportRequestTemplateGitHubRepos()
+      .then(repos => {
+        ctrl.gitHubRepos = repos;
+      });
+
+    $q
+      .all([templatesFetcher, reposFetcher])
       .finally(() => {
         ctrl.loading = false;
       });

--- a/platform-hub-web/src/app/help/support/requests/support-requests-overview.html
+++ b/platform-hub-web/src/app/help/support/requests/support-requests-overview.html
@@ -9,7 +9,43 @@
 
   <loading-indicator loading="$ctrl.loading"></loading-indicator>
 
-  <md-content layout-padding ng-if="!$ctrl.loading && $ctrl.templates.length > 0">
+  <md-content layout-padding ng-if="!$ctrl.loading && $ctrl.gitHubRepos.length > 0">
+
+    <h4 class="md-title">My support requests</h4>
+
+    <p class="md-body-1">
+      Support requests can be found in the 'Issues' tab of the following GitHub
+      <ng-pluralize
+        count="$ctrl.gitHubRepos.length"
+        when="{'1': 'repository', 'other': 'repositories'}">
+      </ng-pluralize>:
+    </p>
+
+    <md-list flex>
+      <md-list-item
+        ng-repeat="r in $ctrl.gitHubRepos"
+        ng-href="{{r}}/issues" target="_blank">
+        <div class="md-list-item-text" layout="column">
+          <p>
+            {{r}}/issues
+          </p>
+        </div>
+      </md-list-item>
+    </md-list>
+
+    <p class="md-body-1" md-colors="{background: 'blue-grey-50'}">
+      <strong>Tip:</strong>
+      you can filter the issues list to show only the issues mentioning you,
+      through the "Filters" dropdown next to the issues search bar.
+    </p>
+
+    <br />
+
+    <md-divider></md-divider>
+
+  </md-content>
+
+  <md-content layout-padding ng-if="!$ctrl.loading">
 
     <h4 class="md-title">Submit a new support request</h4>
 
@@ -22,6 +58,10 @@
     </p>
 
     <br />
+
+    <p class="md-body-1 none-text" ng-if="$ctrl.templates.length == 0">
+      No forms available
+    </p>
 
     <md-card
       ng-repeat="t in $ctrl.templates track by t.id"

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -30,7 +30,8 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.createSupportRequestTemplate = buildResourceCreator('support_request_templates');
   service.updateSupportRequestTemplate = buildResourceUpdater('support_request_templates');
   service.deleteSupportRequestTemplate = buildResourceDeletor('support_request_templates');
-  service.getSupportRequestTemplateFormFieldTypes = getSupportRequestTemplateFormFieldTypes;
+  service.getSupportRequestTemplateFormFieldTypes = buildSimpleFetcher('support_request_templates/form_field_types', 'field types');
+  service.getSupportRequestTemplateGitHubRepos = buildSimpleFetcher('support_request_templates/git_hub_repos', 'GitHub repos for support requests');
   service.createSupportRequest = createSupportRequest;
 
   return service;
@@ -171,16 +172,18 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       });
   }
 
-  function getSupportRequestTemplateFormFieldTypes() {
-    return $http
-      .get(`${apiEndpoint}/support_request_templates/form_field_types`)
-      .then(response => {
-        return response.data;
-      })
-      .catch(response => {
-        logger.error(buildErrorMessageFromResponse('Failed to fetch field types', response));
-        return $q.reject(response);
-      });
+  function buildSimpleFetcher(path, errorDescriptor) {
+    return function () {
+      return $http
+        .get(`${apiEndpoint}/${path}`)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse(`Failed to fetch ${errorDescriptor}`, response));
+          return $q.reject(response);
+        });
+    };
   }
 
   function createSupportRequest(templateId, data) {


### PR DESCRIPTION
- Web: pop up a dialog with a link to the GitHub issue, after submitting a support request
- Make it clearer to the user how to get to their support requests
- API: when submitting a support request to GitHub, add the user's details in the title text