### PR TITLE
Provide a very simple Hash (a.k.a. dictionary) record store, for arbitrary chunks of data

### DIFF
--- a/platform-hub-api/app/models/hash_record.rb
+++ b/platform-hub-api/app/models/hash_record.rb
@@ -1,0 +1,11 @@
+class HashRecord < ApplicationRecord
+
+  include Audited
+
+  audited descriptor_field: :id
+
+  enum scope: {
+    general: 'general'
+  }
+
+end

--- a/platform-hub-api/db/migrate/20170322132009_create_hash_records.rb
+++ b/platform-hub-api/db/migrate/20170322132009_create_hash_records.rb
@@ -1,0 +1,12 @@
+class CreateHashRecords < ActiveRecord::Migration[5.0]
+  def change
+    create_table :hash_records, id: :string do |t|
+      t.string :scope, null: false
+      t.json :data, null: false
+
+      t.timestamps
+
+      t.index :scope
+    end
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -118,6 +118,19 @@ ALTER SEQUENCE audits_id_seq OWNED BY audits.id;
 
 
 --
+-- Name: hash_records; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE hash_records (
+    id character varying NOT NULL,
+    scope character varying NOT NULL,
+    data json NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
 -- Name: identities; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -229,6 +242,14 @@ ALTER TABLE ONLY audits
 
 
 --
+-- Name: hash_records hash_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY hash_records
+    ADD CONSTRAINT hash_records_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: identities identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -325,6 +346,13 @@ CREATE INDEX index_audits_on_user_name ON audits USING btree (user_name);
 
 
 --
+-- Name: index_hash_records_on_scope; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_hash_records_on_scope ON hash_records USING btree (scope);
+
+
+--
 -- Name: index_identities_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -417,6 +445,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170201102040'),
 ('20170209100930'),
 ('20170221134425'),
-('20170301114421');
+('20170301114421'),
+('20170322132009');
 
 

--- a/platform-hub-api/spec/factories/hash_records.rb
+++ b/platform-hub-api/spec/factories/hash_records.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :hash_record do
+    id 'foo'
+    scope 'general'
+    data do
+      { bar: 'baz' }
+    end
+  end
+end

--- a/platform-hub-api/spec/models/hash_record_spec.rb
+++ b/platform-hub-api/spec/models/hash_record_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe HashRecord, type: :model do
+
+  describe 'a valid HashRecord instance' do
+
+    before do
+      @record = create :hash_record
+    end
+
+    it 'should persist as expected' do
+
+      expect(HashRecord.count).to eq 1
+
+      record = HashRecord.first
+      expect(record.id).to eq @record.id
+      expect(record.scope).to eq @record.scope
+      expect(record.data).not_to be_empty
+      expect(record.data).to eq @record.data
+
+    end
+
+  end
+
+end

--- a/platform-hub-api/spec/models/support_request_template_spec.rb
+++ b/platform-hub-api/spec/models/support_request_template_spec.rb
@@ -21,14 +21,10 @@ RSpec.describe SupportRequestTemplate, type: :model do
       expect(srt.description).to eq @srt.description
 
       expect(srt.form_spec).not_to be_empty
-      expected_form_spec = Hashie::Mash.new @srt.form_spec
-      loaded_form_spec = Hashie::Mash.new srt.form_spec
-      expect(loaded_form_spec).to eq expected_form_spec
+      expect(srt.form_spec).to eq @srt.form_spec
 
       expect(srt.git_hub_issue_spec).not_to be_empty
-      expected_git_hub_issue_spec = Hashie::Mash.new @srt.git_hub_issue_spec
-      loaded_git_hub_issue_spec = Hashie::Mash.new srt.git_hub_issue_spec
-      expect(loaded_git_hub_issue_spec).to eq expected_git_hub_issue_spec
+      expect(srt.git_hub_issue_spec).to eq @srt.git_hub_issue_spec
 
     end
   end


### PR DESCRIPTION
We'll be using this in upcoming features, for two particular use cases:

1. The server needs to store some data in a black box fashion and doesn't care about the contents and schema of that data – e.g. application config specifically for the client, only allowed to be set by admins.
1. The server needs to store some JSON data that doesn't need dedicated table(s).