### PR TITLE
Initial work on app settings and Platform Themes!

### DIFF
--- a/platform-hub-api/README.md
+++ b/platform-hub-api/README.md
@@ -1,4 +1,4 @@
-# HODDAT PaaS Hub – API Server & Backend
+# Platform Hub – API Server & Backend
 
 ## Tech summary
 

--- a/platform-hub-api/app/controllers/app_settings_controller.rb
+++ b/platform-hub-api/app/controllers/app_settings_controller.rb
@@ -1,0 +1,38 @@
+class AppSettingsController < ApiJsonController
+
+  before_action :load_app_settings_hash_record
+
+  skip_before_action :require_authentication, only: :show
+
+  skip_authorization_check only: [ :show ]
+
+  # GET /app_settings
+  def show
+    render json: @app_settings.data
+  end
+
+  # PATCH/PUT /app_settings
+  def update
+    authorize! :update, :app_settings
+
+    if @app_settings.update(data: params[:app_setting])
+      AuditService.log(
+        context: audit_context,
+        action: 'update_app_settings'
+      )
+
+      render json: @app_settings.data
+    else
+      render_model_errors @app_settings.errors
+    end
+  end
+
+  private
+
+  def load_app_settings_hash_record
+    @app_settings = HashRecord.find_or_create_by!(id: 'app_settings', scope: 'webapp') do |r|
+      r.data = {}
+    end
+  end
+
+end

--- a/platform-hub-api/app/controllers/platform_themes_controller.rb
+++ b/platform-hub-api/app/controllers/platform_themes_controller.rb
@@ -1,0 +1,75 @@
+class PlatformThemesController < ApiJsonController
+
+  before_action :find_platform_theme, only: [ :show, :update, :destroy ]
+
+  skip_authorization_check :only => [ :index, :show ]
+  authorize_resource except: [ :index, :show ]
+
+  # GET /platform_themes
+  def index
+    @platform_themes = PlatformTheme.order(:title)
+
+    render json: @platform_themes
+  end
+
+  # GET /platform_themes/1
+  def show
+    render json: @platform_theme
+  end
+
+  # POST /platform_themes
+  def create
+    @platform_theme = PlatformTheme.new(platform_theme_params)
+
+    if @platform_theme.save
+      AuditService.log(
+        context: audit_context,
+        action: 'create',
+        auditable: @platform_theme
+      )
+
+      render json: @platform_theme, status: :created
+    else
+      render_model_errors @platform_theme.errors
+    end
+  end
+
+  # PATCH/PUT /platform_themes/1
+  def update
+    if @platform_theme.update(platform_theme_params)
+      AuditService.log(
+        context: audit_context,
+        action: 'update',
+        auditable: @platform_theme
+      )
+
+      render json: @platform_theme
+    else
+      render_model_errors @platform_theme.errors
+    end
+  end
+
+  # DELETE /platform_themes/1
+  def destroy
+    title = @platform_theme.title
+
+    @platform_theme.destroy
+
+    AuditService.log(
+      context: audit_context,
+      action: 'destroy',
+      comment: "User '#{current_user.email}' deleted platform theme: #{title}"
+    )
+  end
+
+  private
+
+  def find_platform_theme
+    @platform_theme = PlatformTheme.friendly.find params[:id]
+  end
+
+  # Only allow a trusted parameter "white list" through
+  def platform_theme_params
+    params.require(:platform_theme).permit(:title, :description, :image_url, :colour)
+  end
+end

--- a/platform-hub-api/app/controllers/projects_controller.rb
+++ b/platform-hub-api/app/controllers/projects_controller.rb
@@ -3,7 +3,7 @@ class ProjectsController < ApiJsonController
   before_action :find_project, only: [ :show, :update, :destroy, :memberships, :add_membership, :remove_membership, :set_role, :unset_role ]
   before_action :find_user, only: [ :add_membership, :remove_membership, :set_role, :unset_role ]
 
-  skip_authorization_check :only => [ :index, :show, :memberships ]
+  skip_authorization_check only: [ :index, :show, :memberships ]
   authorize_resource except: [ :index, :show, :memberships ]
 
   # GET /projects

--- a/platform-hub-api/app/models/hash_record.rb
+++ b/platform-hub-api/app/models/hash_record.rb
@@ -5,7 +5,11 @@ class HashRecord < ApplicationRecord
   audited descriptor_field: :id
 
   enum scope: {
-    general: 'general'
+    general: 'general',
+    webapp: 'webapp'
   }
+
+  validates :scope,
+    presence: true
 
 end

--- a/platform-hub-api/app/models/platform_theme.rb
+++ b/platform-hub-api/app/models/platform_theme.rb
@@ -1,0 +1,30 @@
+class PlatformTheme < ApplicationRecord
+
+  include FriendlyId
+  include Audited
+
+  audited descriptor_field: :title
+
+  friendly_id :title, :use => :slugged
+
+  def should_generate_new_friendly_id?
+    title_changed? || super
+  end
+
+  validates :title,
+    presence: true,
+    uniqueness: { case_sensitive: false }
+
+  validates :title,
+    presence: true
+
+  validates :description,
+    presence: true
+
+  validates :image_url,
+    presence: true
+
+  validates :colour,
+    presence: true
+
+end

--- a/platform-hub-api/app/models/project.rb
+++ b/platform-hub-api/app/models/project.rb
@@ -8,6 +8,10 @@ class Project < ApplicationRecord
 
   friendly_id :shortname, :use => :slugged
 
+  def should_generate_new_friendly_id?
+    shortname_changed? || super
+  end
+
   validates :shortname,
     presence: true,
     uniqueness: { case_sensitive: false }

--- a/platform-hub-api/app/models/support_request_template.rb
+++ b/platform-hub-api/app/models/support_request_template.rb
@@ -7,6 +7,10 @@ class SupportRequestTemplate < ApplicationRecord
 
   friendly_id :shortname, :use => :slugged
 
+  def should_generate_new_friendly_id?
+    shortname_changed? || super
+  end
+
   validates :shortname,
     presence: true,
     uniqueness: { case_sensitive: false }

--- a/platform-hub-api/app/serializers/platform_theme_serializer.rb
+++ b/platform-hub-api/app/serializers/platform_theme_serializer.rb
@@ -1,0 +1,15 @@
+class PlatformThemeSerializer < ActiveModel::Serializer
+  attributes(
+    :id,
+    :title,
+    :description,
+    :image_url,
+    :colour,
+    :created_at,
+    :updated_at
+  )
+
+  def id
+    object.friendly_id
+  end
+end

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -51,6 +51,10 @@ Rails.application.routes.draw do
 
     resources :support_requests, only: [ :create ]
 
+    resources :platform_themes
+
+    resource :app_settings, only: [ :show, :update ]
+
   end
 
 end

--- a/platform-hub-api/db/migrate/20170322143551_create_platform_themes.rb
+++ b/platform-hub-api/db/migrate/20170322143551_create_platform_themes.rb
@@ -1,0 +1,16 @@
+class CreatePlatformThemes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :platform_themes, id: :uuid do |t|
+      t.string :title, null: false
+      t.string :slug, null: false
+      t.text :description, null: false
+      t.string :image_url, null: false
+      t.string :colour, null: false
+
+      t.timestamps
+
+      t.index :title, unique: true
+      t.index :slug, unique: true
+    end
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -149,6 +149,22 @@ CREATE TABLE identities (
 
 
 --
+-- Name: platform_themes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE platform_themes (
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    title character varying NOT NULL,
+    slug character varying NOT NULL,
+    description text NOT NULL,
+    image_url character varying NOT NULL,
+    colour character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
 -- Name: project_memberships; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -258,6 +274,14 @@ ALTER TABLE ONLY identities
 
 
 --
+-- Name: platform_themes platform_themes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY platform_themes
+    ADD CONSTRAINT platform_themes_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -360,6 +384,20 @@ CREATE INDEX index_identities_on_user_id ON identities USING btree (user_id);
 
 
 --
+-- Name: index_platform_themes_on_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_platform_themes_on_slug ON platform_themes USING btree (slug);
+
+
+--
+-- Name: index_platform_themes_on_title; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_platform_themes_on_title ON platform_themes USING btree (title);
+
+
+--
 -- Name: index_project_memberships_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -446,6 +484,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170209100930'),
 ('20170221134425'),
 ('20170301114421'),
-('20170322132009');
+('20170322132009'),
+('20170322143551');
 
 

--- a/platform-hub-api/spec/controllers/app_settings_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/app_settings_controller_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe AppSettingsController, type: :controller do
+
+  let(:key) { 'app_settings' }
+
+  describe 'GET #show' do
+
+    context 'when no app settings exist' do
+      it 'creates an empty app settings under the hood and returns it' do
+        expect(HashRecord.webapp.where(id: key).count).to eq 0
+        get :show
+        expect(response).to be_success
+        expect(json_response).to eq({})
+        expect(HashRecord.webapp.where(id: key).count).to eq 1
+      end
+    end
+
+    context 'when app settings already exist' do
+      let :data do
+        { 'foo' => 'bar' }
+      end
+
+      before do
+        @app_settings = create :hash_record, id: key, scope: 'webapp', data: data
+      end
+
+      it 'returns the existing app settings data' do
+        get :show
+        expect(response).to be_success
+        expect(json_response).to eq data
+      end
+    end
+    
+  end
+
+  describe 'PUT #update' do
+    let :put_data do
+      { 'foo' => 'bar' }
+    end
+
+    before do
+      @app_settings = create :hash_record, id: key, scope: 'webapp', data: {}
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        put :update, params: put_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          put :update, params: put_data
+        end
+      end
+
+      it_behaves_like 'an admin' do
+        it 'allows updating of the whole app settings data' do
+          expect(HashRecord.webapp.where(id: key).count).to eq 1
+          put :update, params: put_data
+          expect(response).to be_success
+          expect(json_response).to eq put_data
+          expect(HashRecord.webapp.where(id: key).count).to eq 1
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'update_app_settings'
+          expect(audit.user.id).to eq current_user_id
+        end
+      end
+
+    end
+  end
+
+end

--- a/platform-hub-api/spec/controllers/platform_themes_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/platform_themes_controller_spec.rb
@@ -1,0 +1,228 @@
+require 'rails_helper'
+
+RSpec.describe PlatformThemesController, type: :controller do
+
+  include_context 'time helpers'
+
+  describe 'GET #index' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        get :index
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      before do
+        @platform_themes = create_list :platform_theme, 3
+      end
+
+      let :total_platform_themes do
+        @platform_themes.length
+      end
+
+      let :platform_theme_ids do
+        @platform_themes.map(&:friendly_id)
+      end
+
+      it 'should return a list of all platform themes' do
+        get :index
+        expect(response).to be_success
+        expect(json_response.length).to eq total_platform_themes
+        expect(pluck_from_json_response('id')).to match_array platform_theme_ids
+      end
+
+    end
+  end
+
+  describe 'GET #show' do
+    before do
+      @platform_theme = create :platform_theme
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        get :show, params: { id: @platform_theme.friendly_id }
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      context 'for a non-existent platform theme' do
+        it 'should return a 404' do
+          get :show, params: { id: 'unknown' }
+          expect(response).to have_http_status(404)
+        end
+      end
+
+      context 'for a platform theme that exists' do
+        it 'should return the specified platform theme resource' do
+          get :show, params: { id: @platform_theme.friendly_id }
+          expect(response).to be_success
+          expect(json_response).to eq({
+            'id' => @platform_theme.friendly_id,
+            'title' => @platform_theme.title,
+            'description' => @platform_theme.description,
+            'image_url' => @platform_theme.image_url,
+            'colour' => @platform_theme.colour,
+            'created_at' => now_json_value,
+            'updated_at' => now_json_value
+          })
+        end
+      end
+
+    end
+  end
+
+  describe 'POST #create' do
+    let :post_data do
+      source_data = build :platform_theme
+
+      {
+        platform_theme: {
+          title: source_data.title,
+          description: source_data.description,
+          image_url: source_data.image_url,
+          colour: source_data.colour
+        }
+      }
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        post :create, params: post_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          post :create, params: post_data
+        end
+      end
+
+      it_behaves_like 'an admin' do
+
+        it 'creates a new platform theme as expected' do
+          expect(PlatformTheme.count).to eq 0
+          expect(Audit.count).to eq 0
+          post :create, params: post_data
+          expect(response).to be_success
+          expect(PlatformTheme.count).to eq 1
+          platform_theme = PlatformTheme.first
+          new_platform_theme_external_id = platform_theme.friendly_id
+          new_platform_theme_internal_id = platform_theme.id
+          expect(json_response).to eq({
+            'id' => new_platform_theme_external_id,
+            'title' => post_data[:platform_theme][:title],
+            'description' => post_data[:platform_theme][:description],
+            'image_url' => post_data[:platform_theme][:image_url],
+            'colour' => post_data[:platform_theme][:colour],
+            'created_at' => now_json_value,
+            'updated_at' => now_json_value
+          });
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'create'
+          expect(audit.auditable.id).to eq new_platform_theme_internal_id
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+  describe 'PUT #update' do
+    let :put_data do
+      {
+        id: @platform_theme.friendly_id,
+        platform_theme: {
+          description: @platform_theme.description + 'foobar',
+          colour: 'this is a new colour'
+        }
+      }
+    end
+
+    before do
+      @platform_theme = create :platform_theme
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        put :update, params: put_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          put :update, params: put_data
+        end
+      end
+
+      it_behaves_like 'an admin' do
+
+        it 'updates the specified platform theme' do
+          expect(PlatformTheme.count).to eq 1
+          expect(Audit.count).to eq 0
+          put :update, params: put_data
+          expect(response).to be_success
+          expect(PlatformTheme.count).to eq 1
+          updated = PlatformTheme.first
+          expect(updated.title).to eq @platform_theme.title
+          expect(updated.description).to eq put_data[:platform_theme][:description]
+          expect(updated.colour).to eq put_data[:platform_theme][:colour]
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'update'
+          expect(audit.auditable.id).to eq @platform_theme.id
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before do
+      @platform_theme = create :platform_theme
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        delete :destroy, params: { id: @platform_theme.id }
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          delete :destroy, params: { id: @platform_theme.id }
+        end
+      end
+
+      it_behaves_like 'an admin' do
+
+        it 'should delete the specified platform theme' do
+          expect(PlatformTheme.exists?(@platform_theme.id)).to be true
+          expect(Audit.count).to eq 0
+          delete :destroy, params: { id: @platform_theme.id }
+          expect(response).to be_success
+          expect(PlatformTheme.exists?(@platform_theme.id)).to be false
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'destroy'
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+end

--- a/platform-hub-api/spec/factories/platform_themes.rb
+++ b/platform-hub-api/spec/factories/platform_themes.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :platform_theme do
+    id { SecureRandom.uuid }
+
+    sequence :title do |n|
+      "Platform Theme #{n}"
+    end
+
+    description 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+
+    image_url 'http//example.org/image.png'
+
+    colour 'red'
+
+  end
+end

--- a/platform-hub-api/spec/routing/app_settings_routing_spec.rb
+++ b/platform-hub-api/spec/routing/app_settings_routing_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe AppSettingsController, type: :routing do
+  describe 'routing' do
+
+    it 'routes to #show' do
+      expect(:get => '/app_settings').to route_to('app_settings#show')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(:put => '/app_settings').to route_to('app_settings#update')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(:patch => '/app_settings').to route_to('app_settings#update')
+    end
+
+  end
+end

--- a/platform-hub-api/spec/routing/platform_themes_routing_spec.rb
+++ b/platform-hub-api/spec/routing/platform_themes_routing_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe PlatformThemesController, type: :routing do
+  describe 'routing' do
+
+    it 'routes to #index' do
+      expect(:get => '/platform_themes').to route_to('platform_themes#index')
+    end
+
+    it 'routes to #show' do
+      expect(:get => '/platform_themes/1').to route_to('platform_themes#show', :id => '1')
+    end
+
+    it 'routes to #create' do
+      expect(:post => '/platform_themes').to route_to('platform_themes#create')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(:put => '/platform_themes/1').to route_to('platform_themes#update', :id => '1')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(:patch => '/platform_themes/1').to route_to('platform_themes#update', :id => '1')
+    end
+
+    it 'routes to #destroy' do
+      expect(:delete => '/platform_themes/1').to route_to('platform_themes#destroy', :id => '1')
+    end
+
+  end
+end

--- a/platform-hub-auth-proxy/README.md
+++ b/platform-hub-auth-proxy/README.md
@@ -1,4 +1,4 @@
-# # HODDAT PaaS Hub – Local Auth Proxy
+# Platform Hub – Local Auth Proxy
 
 Uses [keycloak-proxy](https://github.com/gambol99/keycloak-proxy)
 
@@ -25,4 +25,3 @@ Note: make sure you run scripts from the root of auth proxy.
   - `local/start`
 - _Destroy_ the container if you want to recreate it or just don't need it anymore
   - `local/destroy`
-

--- a/platform-hub-auth-proxy/local/data/config.yml
+++ b/platform-hub-auth-proxy/local/data/config.yml
@@ -16,6 +16,10 @@ log-json-format: false
 resources:
 - uri: /identity_flows/callback
   white-listed: true
+- uri: /app_settings
+  white-listed: true
+  methods:
+  - GET
 - uri: /
 
 verbose: false

--- a/platform-hub-web/README.md
+++ b/platform-hub-web/README.md
@@ -1,4 +1,4 @@
-# HODDAT PaaS Hub – Web App
+# Platform Hub – Web App
 
 ## Tech summary
 

--- a/platform-hub-web/package.json
+++ b/platform-hub-web/package.json
@@ -26,6 +26,7 @@
     "angular-material-sidemenu": "^1.0.2",
     "angular-messages": "1.5.11",
     "angular-sanitize": "1.5.11",
+    "angular-sortable-view": "jits/angular-sortable-view#754d087f079075f126c4a38eb7041c7fa69fbd55",
     "angular-toastr": "2.1.x",
     "angular-ui-router": "1.0.0-rc.1",
     "angular-url-encode": "^1.0.0",

--- a/platform-hub-web/src/app/app-settings/app-settings-form.component.js
+++ b/platform-hub-web/src/app/app-settings/app-settings-form.component.js
@@ -1,0 +1,61 @@
+export const AppSettingsFormComponent = {
+  template: require('./app-settings-form.html'),
+  controller: AppSettingsFormController
+};
+
+function AppSettingsFormController($state, AppSettings, PlatformThemesList, _) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.loading = true;
+  ctrl.saving = false;
+  ctrl.settings = {};
+  ctrl.visiblePlatformThemes = [];
+  ctrl.hiddenPlatformThemes = [];
+
+  ctrl.update = update;
+
+  init();
+
+  function init() {
+    AppSettings
+      .refresh()
+      .then(settings => {
+        // Make sure to store a copy as we may be mutating this!
+        angular.copy(settings, ctrl.settings);
+
+        return refreshPlatformThemesLists()
+          .then(() => {
+            // Only stop loading if it's a successful fetch
+            // (i.e. the following doesn't go into a .finally handler)
+            ctrl.loading = false;
+          });
+      });
+  }
+
+  function update() {
+    ctrl.saving = true;
+
+    ctrl.settings.visiblePlatformThemes = _.map(ctrl.visiblePlatformThemes, 'id');
+
+    AppSettings
+      .update(ctrl.settings)
+      .then(() => {
+        $state.go('home');
+      })
+      .finally(() => {
+        ctrl.saving = false;
+      });
+  }
+
+  function refreshPlatformThemesLists() {
+    return PlatformThemesList
+      .refresh()
+      .then(() => {
+        // Make sure to store copies as we may be mutating these!
+        angular.copy(PlatformThemesList.visible, ctrl.visiblePlatformThemes);
+        angular.copy(PlatformThemesList.hidden, ctrl.hiddenPlatformThemes);
+      });
+  }
+}

--- a/platform-hub-web/src/app/app-settings/app-settings-form.html
+++ b/platform-hub-web/src/app/app-settings/app-settings-form.html
@@ -1,0 +1,94 @@
+<div class="app-settings-form">
+  <md-toolbar md-scroll-shrink>
+    <div class="md-toolbar-tools">
+      <h3>
+        Edit App Settings
+      </h3>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading || $ctrl.saving"></loading-indicator>
+
+  <md-content layout-padding ng-if="!$ctrl.loading">
+
+    <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z2" layout-padding>
+      <p class="md-body-1" md-colors="{background: 'accent-50'}">
+        <strong>Note:</strong>
+        everything you set here is available publicly (via the API).
+        Please don't put anything confidential in these app settings.
+      </p>
+
+      <md-content>
+        <form name="$ctrl.settingsForm" role="form" ng-submit="$ctrl.update()">
+          <md-input-container class="md-block">
+            <label for="platformName">Platform Name:</label>
+            <input
+              name="platformName"
+              ng-model="$ctrl.settings.platformName"
+              required
+              autofocus>
+            <div ng-messages="$ctrl.settingsForm.platformName.$error">
+              <div ng-message="required">This is required.</div>
+            </div>
+          </md-input-container>
+
+          <div>
+            <h3 class="md-subhead">Platform Themes</h3>
+            <div
+              sv-root class="multi-sortable"
+              layout="row"
+              layout-align="center start"
+              layout-margin
+              layout-padding>
+            	<div
+                flex
+                class="sortable-container"
+                sv-part="$ctrl.visiblePlatformThemes"
+                md-colors="{background: 'blue-grey-50'}">
+                <h4 class="text-center">Visible</h4>
+                <div
+                  ng-repeat="t in $ctrl.visiblePlatformThemes"
+                  md-colors="{background: '{{t.colour}}'}"
+                  sv-element
+                  md-whiteframe="1"
+                  class="item">
+            			{{t.title}}
+            		</div>
+            	</div>
+            	<div
+                flex
+                class="sortable-container"
+                sv-part="$ctrl.hiddenPlatformThemes"
+                md-colors="{background: 'blue-grey-50'}">
+                <h4 class="text-center">Hidden</h4>
+                <div
+                  ng-repeat="t in $ctrl.hiddenPlatformThemes"
+                  md-colors="{background: '{{t.colour}}'}"
+                  sv-element
+                  md-whiteframe="1"
+                  class="item">
+            			{{t.title}}
+            		</div>
+            	</div>
+            </div>
+          </div>
+
+          <br />
+
+          <div>
+            <md-button
+              type="submit"
+              class="md-primary"
+              ng-disabled="$ctrl.saving || !$ctrl.settingsForm.$valid"
+              ng-class="{'md-raised': ($ctrl.settingsForm.$dirty && $ctrl.settingsForm.$valid) }"
+              aria-label="Save app settings">
+              Update
+            </md-button>
+            <md-button ui-sref="home" ng-disabled="$ctrl.saving">Cancel</md-button>
+          </div>
+        </form>
+      </md-content>
+    </div>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/app-settings/app-settings.module.js
+++ b/platform-hub-web/src/app/app-settings/app-settings.module.js
@@ -1,0 +1,13 @@
+import angular from 'angular';
+
+import {AppSettingsFormComponent} from './app-settings-form.component';
+
+// Main section component names
+export const AppSettingsForm = 'appSettingsForm';
+
+export const AppSettingsModule = angular
+  .module('app.app-settings', [
+    'angular-sortable-view'
+  ])
+  .component(AppSettingsForm, AppSettingsFormComponent)
+  .name;

--- a/platform-hub-web/src/app/app.module.js
+++ b/platform-hub-web/src/app/app.module.js
@@ -12,16 +12,19 @@ import 'angular-material';
 import 'angular-material-sidemenu';
 import 'angular-messages';
 import 'angular-sanitize';
+import 'angular-sortable-view';
 import 'angular-ui-router';
 import 'angular-url-encode';
 
 import moment from 'moment';
 import lodash from 'lodash';
 
+import {AppSettingsModule} from './app-settings/app-settings.module';
 import {HelpModule} from './help/help.module';
 import {HomeModule} from './home/home.module';
 import {IdentitiesModule} from './identities/identities.module';
 import {LayoutModule} from './layout/layout.module';
+import {PlatformThemesModule} from './platform-themes/platform-themes.module';
 import {ProjectsModule} from './projects/projects.module';
 import {SharedModule} from './shared/shared.module';
 import {UsersModule} from './users/users.module';
@@ -40,15 +43,18 @@ const name = 'app';
 // Config + routes
 angular
   .module(name, [
+    AppSettingsModule,
     HelpModule,
     HomeModule,
     IdentitiesModule,
     LayoutModule,
+    PlatformThemesModule,
     ProjectsModule,
     SharedModule,
     UsersModule,
     'angular-jwt',
     'angular-loading-bar',
+    'angular-sortable-view',
     'base64',
     'bc.AngularUrlEncode',
     'ngAnimate',
@@ -73,7 +79,8 @@ angular
 const apiEndpoint = '/api';
 angular
   .module(name)
-  .constant('apiEndpoint', apiEndpoint);
+  .constant('apiEndpoint', apiEndpoint)
+  .constant('apiBackoffTimeMs', 1000);
 
 // Run function
 angular

--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -1,3 +1,4 @@
+import {AppSettingsForm} from './app-settings/app-settings.module';
 import {
   Faq,
   SupportRequestsForm,
@@ -8,6 +9,11 @@ import {
 } from './help/help.module';
 import {AppHome} from './home/home.module';
 import {IdentitiesManager} from './identities/identities.module';
+import {
+  PlatformThemesEditorForm,
+  PlatformThemesEditorList,
+  PlatformThemesPage
+} from './platform-themes/platform-themes.module';
 import {
   ProjectsForm,
   ProjectsDetail,
@@ -166,5 +172,60 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
               authenticate: true,
               rolePermitted: 'admin'
             }
-          });
+          })
+    .state('platform-themes', {
+      abstract: true,
+      url: '/platform-themes',
+      template: '<ui-view></ui-view>'
+    })
+      .state('platform-themes.editor', {
+        abstract: true,
+        url: '/editor',
+        template: '<ui-view></ui-view>'
+      })
+        .state('platform-themes.editor.list', {
+          url: '/list',
+          component: PlatformThemesEditorList,
+          data: {
+            authenticate: true,
+            rolePermitted: 'admin'
+          }
+        })
+        .state('platform-themes.editor.new', {
+          url: '/new',
+          component: PlatformThemesEditorForm,
+          data: {
+            authenticate: true,
+            rolePermitted: 'admin'
+          }
+        })
+        .state('platform-themes.editor.edit', {
+          url: '/edit/:id',
+          component: PlatformThemesEditorForm,
+          resolve: {
+            transition: '$transition$'
+          },
+          data: {
+            authenticate: true,
+            rolePermitted: 'admin'
+          }
+        })
+      .state('platform-themes.page', {
+        url: '/page/:id',
+        component: PlatformThemesPage,
+        resolve: {
+          transition: '$transition$'
+        },
+        data: {
+          authenticate: true
+        }
+      })
+    .state('app-settings', {
+      url: '/app-settings/edit',
+      component: AppSettingsForm,
+      data: {
+        authenticate: true,
+        rolePermitted: 'admin'
+      }
+    });
 };

--- a/platform-hub-web/src/app/app.run.js
+++ b/platform-hub-web/src/app/app.run.js
@@ -1,10 +1,17 @@
-export const appRun = function ($rootScope, $transitions, $state, authService, loginDialogService, roleCheckerService, hubApiService, events, logger, _) {
+export const appRun = function ($rootScope, $transitions, $state, authService, loginDialogService, roleCheckerService, hubApiService, events, AppSettings, logger, _) {
   'ngInject';
 
   logger.debug('Starting app…');
 
-  // Inject lodash into views
+  // Inject lodash into templates that have rootScope access
   $rootScope._ = _;
+
+  // Fetch AppSettings and inject into templates that have rootScope access
+  AppSettings
+    .refresh()
+    .then(() => {
+      $rootScope.AppSettings = AppSettings;
+    });
 
   // Auth handling
 

--- a/platform-hub-web/src/app/app.scss
+++ b/platform-hub-web/src/app/app.scss
@@ -32,10 +32,59 @@ h1, h2, h3, h4, h5, h6, p {
   color: #777;
 }
 
+.text-center,
 .centred {
   text-align: center;
 }
 
 .md-button.md-icon-button.input-button-end {
   margin-top: 1em;
+}
+
+
+.tinted-bar {
+  height: 1em;
+}
+
+md-card,
+.md-card {
+  .tinted-bar {
+    border-radius: 2px 2px 0 0;
+  }
+}
+
+.layout-padding > * > .tinted-bar {
+  margin: -8px -8px 0 -8px;
+}
+
+
+.floated-image-container-right {
+  float: right;
+  width: 120px;
+
+  > img {
+    width: 100%;
+    height: auto;
+  }
+}
+
+.multi-sortable {
+  height: 400px;
+
+  .sortable-container {
+    overflow: auto;
+    height: 100%;
+    border-radius: 3px;
+
+    .item {
+      background: white;
+      cursor: grab;
+      border-radius: 3px;
+      padding: 0.5em 0.75em;
+
+      &:not(:last-child) {
+        margin-bottom: 0.65em;
+      }
+    }
+  }
 }

--- a/platform-hub-web/src/app/help/faq/faq-entries.component.js
+++ b/platform-hub-web/src/app/help/faq/faq-entries.component.js
@@ -1,3 +1,12 @@
 export const FaqEntriesComponent = {
-  template: require('./faq-entries.html')
+  template: require('./faq-entries.html'),
+  controller: FaqEntriesController
 };
+
+function FaqEntriesController(AppSettings) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.AppSettings = AppSettings;
+}

--- a/platform-hub-web/src/app/help/faq/faq-entries.html
+++ b/platform-hub-web/src/app/help/faq/faq-entries.html
@@ -3,12 +3,12 @@
   <md-card>
     <md-card-title>
       <md-card-title-text>
-        <span class="md-title">What is the HODDaT PaaS Hub?</span>
+        <span class="md-title">What is the {{$ctrl.AppSettings.getAppTitle()}}?</span>
       </md-card-title-text>
     </md-card-title>
     <md-card-content>
       <p class="md-body-1">
-        A portal for users of the HODDaT PaaS (aka DSP hosting platform) currently providing self-serve tools for identity, onboarding and offboarding. With plans to provide more self-serve tools, docs, status and updates for the hosting platform, in one central place.
+        A portal for users of the {{$ctrl.AppSettings.getPlatformName()}}, currently providing self-serve tools for identity, onboarding and offboarding. With plans to provide more self-serve tools, docs, status and updates for the hosting platform, in one central place.
       </p>
     </md-card-content>
   </md-card>

--- a/platform-hub-web/src/app/home/home.component.js
+++ b/platform-hub-web/src/app/home/home.component.js
@@ -3,13 +3,35 @@ export const HomeComponent = {
   controller: HomeController
 };
 
-function HomeController(authService) {
+function HomeController($scope, events, authService, AppSettings, PlatformThemesList, _) {
   'ngInject';
 
   const ctrl = this;
 
+  ctrl.AppSettings = AppSettings;
+  ctrl.PlatformThemesList = PlatformThemesList;
+
   ctrl.login = login;
   ctrl.isAuthenticated = isAuthenticated;
+
+  init();
+
+  function init() {
+    // Listen for changes to the Me profile data
+    $scope.$on(events.auth.updated, (event, authData) => {
+      if (!_.isNull(authData) && !_.isEmpty(authData)) {
+        refresh();
+      }
+    });
+
+    if (isAuthenticated()) {
+      refresh();
+    }
+  }
+
+  function refresh() {
+    PlatformThemesList.refresh();
+  }
 
   function isAuthenticated() {
     return authService.isAuthenticated();

--- a/platform-hub-web/src/app/home/home.html
+++ b/platform-hub-web/src/app/home/home.html
@@ -1,11 +1,14 @@
 <div class="app-home">
   <md-content layout-padding>
 
-    <h2 class="md-display-1">
-      Welcome to the HODDAT PaaS Hub
+    <h2 class="md-display-1 text-center">
+      Welcome to the {{$ctrl.AppSettings.getAppTitle()}}
     </h2>
 
-    <div ng-if="!$ctrl.isAuthenticated()" md-whiteframe="1" md-colors="{background: 'primary-50'}">
+    <div
+      ng-if="!$ctrl.isAuthenticated()"
+      md-whiteframe="1"
+      md-colors="{background: 'primary-50'}">
       <p class="md-body-1">
         If you're new, just
         <a href="#" ng-click="$ctrl.login()">login</a>
@@ -13,8 +16,38 @@
       </p>
     </div>
 
+    <div
+      layout="row" layout-wrap layout-align="center center"
+      ng-if="$ctrl.isAuthenticated() && $ctrl.PlatformThemesList.visible.length > 0">
+      <md-card
+        ng-repeat="t in $ctrl.PlatformThemesList.visible track by t.id"
+        ui-sref="platform-themes.page({id: t.id})"
+        style="width: 250px; cursor: pointer;">
+        <div class="tinted-bar" md-colors="{background: '{{t.colour}}'}"></div>
+        <img
+          ng-src="{{t.image_url}}"
+          class="md-card-image"
+          alt="{{t.title}} icon" />
+        <md-card-title>
+          <md-card-title-text>
+            <span class="md-headline">{{t.title}}</span>
+          </md-card-title-text>
+        </md-card-title>
+        <md-card-content>
+          <p class="md-body-1">
+            {{t.description}}
+          </p>
+        </md-card-content>
+      </md-card>
+    </div>
+
+    <br />
+    <md-divider></md-divider>
+
     <div>
-      <h3 class="md-headline">Frequently Asked Questions (FAQ)</h3>
+      <h3 class="md-headline text-center">
+        Frequently Asked Questions (FAQ)
+      </h3>
       <faq-entries></faq-entries>
     </div>
 

--- a/platform-hub-web/src/app/home/home.spec.js
+++ b/platform-hub-web/src/app/home/home.spec.js
@@ -5,11 +5,21 @@ import 'angular-mocks';
 import {HomeModule} from './home.module';
 
 describe('appHome component', () => {
+  let $httpBackend;
+
   beforeEach(() => {
     const moduleName = `${HomeModule}.appHome.spec`;
     angular.module(moduleName, ['app']);
     angular.mock.module(moduleName);
   });
+
+  beforeEach(angular.mock.inject(_$httpBackend_ => {
+    $httpBackend = _$httpBackend_;
+
+    $httpBackend
+      .whenGET(/.+/)
+      .respond('{}');
+  }));
 
   it('should render content', angular.mock.inject(($rootScope, $compile) => {
     const element = $compile('<app-home></app-home>')($rootScope);

--- a/platform-hub-web/src/app/layout/shell.component.js
+++ b/platform-hub-web/src/app/layout/shell.component.js
@@ -3,10 +3,14 @@ export const ShellComponent = {
   controller: ShellController
 };
 
-function ShellController($scope, $mdSidenav, authService, roleCheckerService, events) {
+function ShellController($scope, $mdSidenav, authService, roleCheckerService, events, icons, AppSettings, PlatformThemesList, _) {
   'ngInject';
 
   const ctrl = this;
+
+  ctrl.AppSettings = AppSettings;
+  ctrl.PlatformThemesList = PlatformThemesList;
+  ctrl.platformThemeIcon = icons.platformThemes;
 
   ctrl.isAdmin = false;
 
@@ -14,16 +18,16 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
     {
       title: 'Connected Identities',
       state: 'identities',
-      icon: 'account_box'
+      icon: icons.identities
     }
   ];
 
-  ctrl.hubNavStates = [
+  ctrl.orgNavStates = [
     {
       title: 'Projects',
       state: 'projects.list',
       activeState: 'projects',
-      icon: 'book'
+      icon: icons.projects
     }
   ];
 
@@ -31,13 +35,13 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
     {
       title: 'FAQ',
       state: 'help.faq',
-      icon: 'question_answer'
+      icon: icons.faq
     },
     {
       title: 'Support Requests',
       state: 'help.support.requests.overview',
       activeState: 'help.support.requests',
-      icon: 'note'
+      icon: icons.supportRequests
     }
   ];
 
@@ -45,13 +49,24 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
     {
       title: 'Users',
       state: 'users',
-      icon: 'perm_identity'
+      icon: icons.users
+    },
+    {
+      title: 'App Settings',
+      state: 'app-settings',
+      icon: icons.appSettings
+    },
+    {
+      title: 'Platform Themes',
+      state: 'platform-themes.editor.list',
+      activeState: 'platform-themes.editor',
+      icon: ctrl.platformThemeIcon
     },
     {
       title: 'Support Request Templates',
       state: 'help.support.request-templates.list',
       activeState: 'help.support.request-templates',
-      icon: 'note'
+      icon: icons.supportRequests
     }
   ];
 
@@ -62,11 +77,20 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
 
   function init() {
     // Listen for changes to the Me profile data
-    $scope.$on(events.api.me.updated, loadAdminStatus);
+    $scope.$on(events.api.me.updated, (event, meData) => {
+      if (!_.isNull(meData) && !_.isEmpty(meData)) {
+        refresh();
+      }
+    });
 
     if (isAuthenticated()) {
-      loadAdminStatus();
+      refresh();
     }
+  }
+
+  function refresh() {
+    loadAdminStatus();
+    PlatformThemesList.refresh();
   }
 
   function loadAdminStatus() {

--- a/platform-hub-web/src/app/layout/shell.html
+++ b/platform-hub-web/src/app/layout/shell.html
@@ -11,7 +11,7 @@
         <md-icon md-svg-icon="menu"></md-icon>
         Menu
       </md-button>
-      <h1 flex>HODDAT PaaS Hub</h1>
+      <h1 flex>{{$ctrl.AppSettings.getAppTitle()}}</h1>
     </div>
   </md-toolbar>
 
@@ -36,6 +36,14 @@
               <md-icon>home</md-icon>
               <span>Home</span>
             </md-sidemenu-button>
+
+            <md-sidemenu-button
+              ng-repeat="t in $ctrl.PlatformThemesList.visible track by t.id"
+              ui-sref="platform-themes.page({id: t.id})"
+              ui-sref-active="active">
+              <md-icon md-colors="{color: '{{t.colour}}'}">{{$ctrl.platformThemeIcon}}</md-icon>
+              <span>{{t.title}}</span>
+            </md-sidemenu-button>
           </md-sidemenu-group>
 
           <md-sidemenu-group>
@@ -51,10 +59,10 @@
           </md-sidemenu-group>
 
           <md-sidemenu-group>
-            <md-subheader class="md-no-sticky">Hub</md-subheader>
+            <md-subheader class="md-no-sticky">Org</md-subheader>
 
             <md-sidemenu-button
-              ng-repeat="item in $ctrl.hubNavStates"
+              ng-repeat="item in $ctrl.orgNavStates"
               ui-sref="{{item.state}}"
               ui-sref-active="{ 'active': item.activeState || item.state }">
               <md-icon ng-if="item.icon">{{item.icon}}</md-icon>

--- a/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-form.component.js
+++ b/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-form.component.js
@@ -1,0 +1,99 @@
+export const PlatformThemesEditorFormComponent = {
+  bindings: {
+    transition: '<'
+  },
+  template: require('./platform-themes-editor-form.html'),
+  controller: PlatformThemesEditorFormController
+};
+
+function PlatformThemesEditorFormController($state, $mdColorPalette, hubApiService, logger, _) {
+  'ngInject';
+
+  const ctrl = this;
+
+  const id = ctrl.transition && ctrl.transition.params().id;
+
+  // Colours from the material design spec
+  ctrl.colours = Object.keys($mdColorPalette);
+
+  ctrl.loading = true;
+  ctrl.saving = false;
+  ctrl.isNew = true;
+  ctrl.theme = null;
+
+  ctrl.createOrUpdate = createOrUpdate;
+
+  init();
+
+  function init() {
+    ctrl.isNew = !id;
+
+    if (ctrl.isNew) {
+      ctrl.theme = initEmptyTheme();
+      ctrl.loading = false;
+    } else {
+      loadTheme();
+    }
+  }
+
+  function initEmptyTheme() {
+    return {
+      colour: _.sample(ctrl.colours)
+    };
+  }
+
+  function loadTheme() {
+    ctrl.loading = true;
+    ctrl.theme = null;
+
+    hubApiService
+      .getPlatformTheme(id)
+      .then(theme => {
+        ctrl.theme = theme;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function createOrUpdate() {
+    if (ctrl.themeForm.$invalid) {
+      logger.error('Check the form for issues before saving');
+      return;
+    }
+
+    const errors = validate(ctrl.theme);
+    if (errors.length > 0) {
+      logger.error(errors.join('<br />'));
+      return;
+    }
+
+    ctrl.saving = true;
+
+    if (ctrl.isNew) {
+      hubApiService
+        .createPlatformTheme(ctrl.theme)
+        .then(() => {
+          logger.success('Platform theme created');
+          $state.go('platform-themes.editor.list');
+        })
+        .finally(() => {
+          ctrl.saving = false;
+        });
+    } else {
+      hubApiService
+        .updatePlatformTheme(ctrl.theme.id, ctrl.theme)
+        .then(() => {
+          logger.success('Platform theme updated');
+          $state.go('platform-themes.editor.list');
+        })
+        .finally(() => {
+          ctrl.saving = false;
+        });
+    }
+  }
+
+  function validate() {
+    return [];
+  }
+}

--- a/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-form.html
+++ b/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-form.html
@@ -1,0 +1,95 @@
+<div class="platform-themes-editor-form">
+  <md-toolbar md-scroll-shrink>
+    <div class="md-toolbar-tools">
+      <h3>
+        <span ng-if="$ctrl.isNew">New Platform Theme</span>
+        <span ng-if="!$ctrl.isNew">Edit Platform Theme</span>
+      </h3>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading || $ctrl.saving"></loading-indicator>
+
+  <md-content layout-padding ng-if="!$ctrl.loading">
+
+    <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z2" layout-padding>
+      <md-content>
+        <form name="$ctrl.themeForm" role="form" ng-submit="$ctrl.createOrUpdate()">
+
+          <md-input-container class="md-block">
+            <label for="title">Title:</label>
+            <input
+              name="title"
+              ng-model="$ctrl.theme.title"
+              required
+              placeholder="A short title for this theme – e.g. 'Deploy'"
+              aria-label="Set a title for this platform theme">
+            <div ng-messages="$ctrl.themeForm.title.$error">
+              <div ng-message="required">This is required.</div>
+            </div>
+          </md-input-container>
+
+          <md-input-container class="md-block">
+            <label for="description">Description:</label>
+            <textarea
+              name="description"
+              ng-model="$ctrl.theme.description"
+              rows="4"
+              required
+              aria-label="Set a description for this platform theme"
+              md-select-on-focus>
+            </textarea>
+            <div ng-messages="$ctrl.themeForm.description.$error">
+              <div ng-message="required">This is required.</div>
+            </div>
+          </md-input-container>
+
+          <md-input-container class="md-block">
+            <label for="image_url">Image URL:</label>
+            <input
+              type="url"
+              name="image_url"
+              ng-model="$ctrl.theme.image_url"
+              required
+              aria-label="Set an image URL for this platform theme">
+            <div ng-messages="$ctrl.themeForm.image_url.$error">
+              <div ng-message="required">This is required.</div>
+              <div ng-message="url">Not a valid URL.</div>
+            </div>
+          </md-input-container>
+
+          <md-input-container class="md-block">
+            <label for="colour">Colour:</label>
+            <md-select
+              name="colour"
+              ng-model="$ctrl.theme.colour"
+              md-colors="{background: '{{$ctrl.theme.colour}}'}"
+              aria-label="Set a colour for this platform theme">
+              <md-option
+                ng-repeat="c in $ctrl.colours"
+                md-colors="{background: '{{c}}'}"
+                md-colors-watch="false"
+                value="{{c}}">
+                {{c}}
+              </md-option>
+            </md-select>
+          </md-input-container>
+
+          <div>
+            <md-button
+              type="submit"
+              class="md-primary"
+              ng-disabled="$ctrl.saving || $ctrl.themeForm.$invalid"
+              ng-class="{'md-raised': ($ctrl.themeForm.$dirty && $ctrl.themeForm.$valid) }"
+              aria-label="Save platform theme">
+              <span ng-if="$ctrl.isNew">Create</span>
+              <span ng-if="!$ctrl.isNew">Update</span>
+            </md-button>
+            <md-button ui-sref="platform-themes.editor.list" ng-disabled="$ctrl.saving">Cancel</md-button>
+          </div>
+        </form>
+      </md-content>
+    </div>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-list.component.js
+++ b/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-list.component.js
@@ -1,0 +1,59 @@
+export const PlatformThemesEditorListComponent = {
+  template: require('./platform-themes-editor-list.html'),
+  controller: PlatformThemesEditorListController
+};
+
+function PlatformThemesEditorListController($mdDialog, PlatformThemesList, icons, hubApiService, logger) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.PlatformThemesList = PlatformThemesList;
+  ctrl.platformThemeIcon = icons.platformThemes;
+
+  ctrl.loading = true;
+
+  ctrl.deleteTheme = deleteTheme;
+
+  init();
+
+  function init() {
+    refreshThemes();
+  }
+
+  function refreshThemes() {
+    ctrl.loading = true;
+
+    PlatformThemesList
+      .refresh()
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function deleteTheme(theme, targetEvent) {
+    const confirm = $mdDialog.confirm()
+      .title('Are you sure?')
+      .textContent('This will delete the platform theme permanently from the hub.')
+      .ariaLabel('Confirm deletion of platform theme')
+      .targetEvent(targetEvent)
+      .ok('Do it')
+      .cancel('Cancel');
+
+    $mdDialog
+      .show(confirm)
+      .then(() => {
+        ctrl.loading = true;
+
+        hubApiService
+          .deletePlatformTheme(theme.id)
+          .then(() => {
+            logger.success('Platform theme deleted');
+            refreshThemes();
+          })
+          .finally(() => {
+            ctrl.loading = false;
+          });
+      });
+  }
+}

--- a/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-list.html
+++ b/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-list.html
@@ -1,0 +1,82 @@
+<div class="platform-themes-editor-list">
+  <md-toolbar md-scroll-shrink>
+    <div class="md-toolbar-tools">
+      <h3>
+        <span>All Platform Themes</span>
+      </h3>
+      <span flex></span>
+      <md-button
+        aria-label="Add new platform theme"
+        ui-sref="platform-themes.editor.new">
+        <md-icon>add_box</md-icon>
+        New
+      </md-button>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading"></loading-indicator>
+
+  <md-content layout-padding ng-if="!$ctrl.loading && $ctrl.PlatformThemesList.all.length > 0">
+
+    <md-card ng-repeat="t in $ctrl.PlatformThemesList.all track by t.id">
+      <div class="tinted-bar" md-colors="{background: '{{t.colour}}'}"></div>
+      <md-card-title>
+        <md-card-title-text>
+          <span class="md-headline">
+            <md-icon md-colors="{color: '{{t.colour}}'}">{{$ctrl.platformThemeIcon}}</md-icon>
+            <span>{{t.title}}</span>
+          </span>
+        </md-card-title-text>
+        <md-card-title-media>
+          <div class="md-media-sm">
+            <img ng-src="{{t.image_url}}" />
+          </div>
+        </md-card-title-media>
+      </md-card-title>
+
+      <md-card-content>
+        <p class="md-body-1">
+          <span md-colors="{color: 'blue-grey-700'}">
+            Description
+          </span>
+          <br />
+          {{t.description}}
+        </p>
+
+        <p class="md-body-1">
+          <span md-colors="{color: 'blue-grey-700'}">
+            Image URL:
+          </span>
+          <a ng-href="{{t.image_url}}" target="_blank">{{t.image_url}}</a>
+        </p>
+
+        <p class="md-body-1">
+          <span md-colors="{color: 'blue-grey-700'}">
+            Colour:
+          </span>
+          {{t.colour}}
+        </p>
+      </md-card-content>
+
+      <md-card-actions layout="row" layout-align="start center">
+        <md-button
+          class="md-primary"
+          aria-label="View the page for this platform theme"
+          ui-sref="platform-themes.page({id: t.id})">
+          View page
+        </md-button>
+        <md-button
+          aria-label="Edit this platform theme"
+          ui-sref="platform-themes.editor.edit({id: t.id})">
+          Edit
+        </md-button>
+        <md-button
+          aria-label="Delete this platform theme"
+          ng-click="$ctrl.deleteTheme(t, $event)">
+          Delete
+        </md-button>
+      </md-card-actions>
+    </md-card>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/platform-themes/platform-themes-page.component.js
+++ b/platform-hub-web/src/app/platform-themes/platform-themes-page.component.js
@@ -1,0 +1,43 @@
+export const PlatformThemesPageComponent = {
+  bindings: {
+    transition: '<'
+  },
+  template: require('./platform-themes-page.html'),
+  controller: PlatformThemesPageController
+};
+
+function PlatformThemesPageController(hubApiService, _) {
+  'ngInject';
+
+  const ctrl = this;
+
+  const id = ctrl.transition.params().id;
+
+  ctrl.loading = true;
+  ctrl.theme = null;
+
+  init();
+
+  function init() {
+    loadTheme();
+  }
+
+  function loadTheme() {
+    if (_.isNull(id) || _.isEmpty(id)) {
+      ctrl.loading = false;
+      return;
+    }
+
+    ctrl.loading = true;
+    ctrl.theme = null;
+
+    hubApiService
+      .getPlatformTheme(id)
+      .then(theme => {
+        ctrl.theme = theme;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+}

--- a/platform-hub-web/src/app/platform-themes/platform-themes-page.html
+++ b/platform-hub-web/src/app/platform-themes/platform-themes-page.html
@@ -1,0 +1,27 @@
+<div class="platform-themes-page">
+  <loading-indicator loading="$ctrl.loading"></loading-indicator>
+
+  <md-content layout-padding ng-if="!$ctrl.loading && $ctrl.theme">
+
+    <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z2">
+      <div class="tinted-bar" md-colors="{background: '{{$ctrl.theme.colour}}'}"></div>
+
+      <md-content layout-padding>
+        <div class="floated-image-container-right">
+          <img
+            ng-src="{{$ctrl.theme.image_url}}"
+            alt="{{t.title}} icon" />
+        </div>
+
+        <h2 class="md-display-2">
+          {{$ctrl.theme.title}}
+        </h2>
+
+        <p class="md-body-1">
+          {{$ctrl.theme.description}}
+        </p>
+      </md-content>
+    </div>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/platform-themes/platform-themes.module.js
+++ b/platform-hub-web/src/app/platform-themes/platform-themes.module.js
@@ -1,0 +1,17 @@
+import angular from 'angular';
+
+import {PlatformThemesEditorFormComponent} from './editor/platform-themes-editor-form.component';
+import {PlatformThemesEditorListComponent} from './editor/platform-themes-editor-list.component';
+import {PlatformThemesPageComponent} from './platform-themes-page.component';
+
+// Main section component names
+export const PlatformThemesEditorForm = 'platformThemesEditorForm';
+export const PlatformThemesEditorList = 'platformThemesEditorList';
+export const PlatformThemesPage = 'platformThemesPage';
+
+export const PlatformThemesModule = angular
+  .module('app.platform-themes', [])
+  .component(PlatformThemesEditorForm, PlatformThemesEditorFormComponent)
+  .component(PlatformThemesEditorList, PlatformThemesEditorListComponent)
+  .component(PlatformThemesPage, PlatformThemesPageComponent)
+  .name;

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -9,10 +9,12 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
   service.getMe = getMe;
   service.deleteMeIdentity = deleteMeIdentity;
+
   service.getUsers = buildCollectionFetcher('users');
   service.searchUsers = searchUsers;
   service.makeAdmin = makeAdmin;
   service.revokeAdmin = revokeAdmin;
+
   service.getProjects = buildCollectionFetcher('projects');
   service.getProject = buildResourceFetcher('projects');
   service.createProject = buildResourceCreator('projects');
@@ -23,8 +25,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.removeProjectMembership = removeProjectMembership;
   service.projectSetRole = projectSetRole;
   service.projectUnsetRole = projectUnsetRole;
+
   service.userOnboardGitHub = userOnboardGitHub;
   service.userOffboardGitHub = userOffboardGitHub;
+
   service.getSupportRequestTemplates = buildCollectionFetcher('support_request_templates');
   service.getSupportRequestTemplate = buildResourceFetcher('support_request_templates');
   service.createSupportRequestTemplate = buildResourceCreator('support_request_templates');
@@ -32,7 +36,16 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.deleteSupportRequestTemplate = buildResourceDeletor('support_request_templates');
   service.getSupportRequestTemplateFormFieldTypes = buildSimpleFetcher('support_request_templates/form_field_types', 'field types');
   service.getSupportRequestTemplateGitHubRepos = buildSimpleFetcher('support_request_templates/git_hub_repos', 'GitHub repos for support requests');
+
   service.createSupportRequest = createSupportRequest;
+  service.getPlatformThemes = buildCollectionFetcher('platform_themes');
+  service.getPlatformTheme = buildResourceFetcher('platform_themes');
+  service.createPlatformTheme = buildResourceCreator('platform_themes');
+  service.updatePlatformTheme = buildResourceUpdater('platform_themes');
+  service.deletePlatformTheme = buildResourceDeletor('platform_themes');
+
+  service.getAppSettings = buildSimpleFetcher('app_settings', 'app settings');
+  service.updateAppSettings = buildSimpleUpdater('app_settings', 'app settings');
 
   return service;
 
@@ -59,6 +72,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function deleteMeIdentity(provider) {
+    if (_.isNull(provider) || _.isEmpty(provider)) {
+      throw new Error('"provider" argument not specified or empty');
+    }
+
     return $http
       .delete(`${apiEndpoint}/me/identities/${provider}`)
       .catch(response => {
@@ -68,6 +85,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function searchUsers(query) {
+    if (_.isNull(query) || _.isEmpty(query)) {
+      throw new Error('"query" argument not specified or empty');
+    }
+
     return $http
       .get(`${apiEndpoint}/users/search/${query}`)
       .then(response => {
@@ -80,6 +101,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function makeAdmin(userId) {
+    if (_.isNull(userId) || _.isEmpty(userId)) {
+      throw new Error('"userId" argument not specified or empty');
+    }
+
     return $http
       .post(`${apiEndpoint}/users/${userId}/make_admin`)
       .catch(response => {
@@ -89,6 +114,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function revokeAdmin(userId) {
+    if (_.isNull(userId) || _.isEmpty(userId)) {
+      throw new Error('"userId" argument not specified or empty');
+    }
+
     return $http
       .post(`${apiEndpoint}/users/${userId}/revoke_admin`)
       .catch(response => {
@@ -98,6 +127,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function getProjectMemberships(projectId) {
+    if (_.isNull(projectId) || _.isEmpty(projectId)) {
+      throw new Error('"projectId" argument not specified or empty');
+    }
+
     return $http
       .get(`${apiEndpoint}/projects/${projectId}/memberships`)
       .then(response => {
@@ -110,6 +143,13 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function addProjectMembership(projectId, userId) {
+    if (_.isNull(projectId) || _.isEmpty(projectId)) {
+      throw new Error('"projectId" argument not specified or empty');
+    }
+    if (_.isNull(userId) || _.isEmpty(userId)) {
+      throw new Error('"userId" argument not specified or empty');
+    }
+
     return $http
       .put(`${apiEndpoint}/projects/${projectId}/memberships/${userId}`)
       .then(response => {
@@ -122,6 +162,13 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function removeProjectMembership(projectId, userId) {
+    if (_.isNull(projectId) || _.isEmpty(projectId)) {
+      throw new Error('"projectId" argument not specified or empty');
+    }
+    if (_.isNull(userId) || _.isEmpty(userId)) {
+      throw new Error('"userId" argument not specified or empty');
+    }
+
     return $http
       .delete(`${apiEndpoint}/projects/${projectId}/memberships/${userId}`)
       .catch(response => {
@@ -131,6 +178,16 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function projectSetRole(projectId, userId, role) {
+    if (_.isNull(projectId) || _.isEmpty(projectId)) {
+      throw new Error('"projectId" argument not specified or empty');
+    }
+    if (_.isNull(userId) || _.isEmpty(userId)) {
+      throw new Error('"userId" argument not specified or empty');
+    }
+    if (_.isNull(role) || _.isEmpty(role)) {
+      throw new Error('"role" argument not specified or empty');
+    }
+
     return $http
       .put(`${apiEndpoint}/projects/${projectId}/memberships/${userId}/role/${role}`)
       .then(response => {
@@ -143,6 +200,16 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function projectUnsetRole(projectId, userId, role) {
+    if (_.isNull(projectId) || _.isEmpty(projectId)) {
+      throw new Error('"projectId" argument not specified or empty');
+    }
+    if (_.isNull(userId) || _.isEmpty(userId)) {
+      throw new Error('"userId" argument not specified or empty');
+    }
+    if (_.isNull(role) || _.isEmpty(role)) {
+      throw new Error('"role" argument not specified or empty');
+    }
+
     return $http
       .delete(`${apiEndpoint}/projects/${projectId}/memberships/${userId}/role/${role}`)
       .then(response => {
@@ -155,6 +222,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function userOnboardGitHub(userId) {
+    if (_.isNull(userId) || _.isEmpty(userId)) {
+      throw new Error('"userId" argument not specified or empty');
+    }
+
     return $http
       .post(`${apiEndpoint}/users/${userId}/onboard_github`)
       .catch(response => {
@@ -164,10 +235,29 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   }
 
   function userOffboardGitHub(userId) {
+    if (_.isNull(userId) || _.isEmpty(userId)) {
+      throw new Error('"userId" argument not specified or empty');
+    }
+
     return $http
       .post(`${apiEndpoint}/users/${userId}/offboard_github`)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to offboard user from GitHub', response));
+        return $q.reject(response);
+      });
+  }
+
+  function createSupportRequest(templateId, data) {
+    return $http
+      .post(`${apiEndpoint}/support_requests`, {
+        template_id: templateId,
+        data: data
+      })
+      .then(response => {
+        return response.data;
+      })
+      .catch(response => {
+        logger.error(buildErrorMessageFromResponse('Failed to create support request', response));
         return $q.reject(response);
       });
   }
@@ -186,19 +276,22 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
     };
   }
 
-  function createSupportRequest(templateId, data) {
-    return $http
-      .post(`${apiEndpoint}/support_requests`, {
-        template_id: templateId,
-        data: data
-      })
-      .then(response => {
-        return response.data;
-      })
-      .catch(response => {
-        logger.error(buildErrorMessageFromResponse('Failed to create support request', response));
-        return $q.reject(response);
-      });
+  function buildSimpleUpdater(path, errorDescriptor) {
+    return function (data) {
+      if (_.isNull(data) || _.isEmpty(data)) {
+        throw new Error('"data" argument not specified or empty');
+      }
+
+      return $http
+        .put(`${apiEndpoint}/${path}`, data)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse(`Failed to update ${errorDescriptor}`, response));
+          return $q.reject(response);
+        });
+    };
   }
 
   function buildCollectionFetcher(name) {
@@ -217,6 +310,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
   function buildResourceFetcher(resource) {
     return function (id) {
+      if (_.isNull(id) || _.isEmpty(id)) {
+        throw new Error('"id" argument not specified or empty');
+      }
+
       return $http
         .get(`${apiEndpoint}/${resource}/${id}`)
         .then(response => {
@@ -231,6 +328,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
   function buildResourceCreator(resource) {
     return function (data) {
+      if (_.isNull(data) || _.isEmpty(data)) {
+        throw new Error('"data" argument not specified or empty');
+      }
+
       return $http
         .post(`${apiEndpoint}/${resource}`, data)
         .then(response => {
@@ -245,6 +346,13 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
   function buildResourceUpdater(resource) {
     return function (id, data) {
+      if (_.isNull(id) || _.isEmpty(id)) {
+        throw new Error('"id" argument not specified or empty');
+      }
+      if (_.isNull(data) || _.isEmpty(data)) {
+        throw new Error('"data" argument not specified or empty');
+      }
+
       return $http
         .put(`${apiEndpoint}/${resource}/${id}`, data)
         .then(response => {
@@ -259,6 +367,10 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
   function buildResourceDeletor(resource) {
     return function (id) {
+      if (_.isNull(id) || _.isEmpty(id)) {
+        throw new Error('"id" argument not specified or empty');
+      }
+
       return $http
       .delete(`${apiEndpoint}/${resource}/${id}`)
       .catch(response => {

--- a/platform-hub-web/src/app/shared/icons.factory.js
+++ b/platform-hub-web/src/app/shared/icons.factory.js
@@ -1,0 +1,13 @@
+export const icons = function () {
+  'ngInject';
+
+  return {
+    appSettings: 'settings',
+    faq: 'question_answer',
+    identities: 'account_box',
+    platformThemes: 'lens',
+    projects: 'group_work',
+    supportRequests: 'feedback',
+    users: 'perm_identity'
+  };
+};

--- a/platform-hub-web/src/app/shared/model/app-settings.js
+++ b/platform-hub-web/src/app/shared/model/app-settings.js
@@ -1,0 +1,54 @@
+import angular from 'angular';
+
+export const AppSettings = function ($window, hubApiService, apiBackoffTimeMs, logger, _) {
+  'ngInject';
+
+  const model = {};
+
+  let fetcherPromise = null;
+
+  model.data = {};
+
+  model.refresh = refresh;
+  model.update = update;
+  model.getAppTitle = getAppTitle;
+  model.getPlatformName = getPlatformName;
+
+  return model;
+
+  function refresh() {
+    if (_.isNull(fetcherPromise)) {
+      fetcherPromise = hubApiService
+        .getAppSettings()
+        .then(settings => {
+          angular.copy(settings, model.data);
+          return model.data;
+        })
+        .finally(() => {
+          // Reuse the same promise for some time, to prevent smashing the API
+          $window.setTimeout(() => {
+            fetcherPromise = null;
+          }, apiBackoffTimeMs);
+        });
+    }
+    return fetcherPromise;
+  }
+
+  function update(data) {
+    return hubApiService
+      .updateAppSettings(data)
+      .then(settings => {
+        angular.copy(settings, model.data);
+        logger.info('Sucessfully updated app settings');
+        return model.data;
+      });
+  }
+
+  function getAppTitle() {
+    return `${getPlatformName()} Hub`;
+  }
+
+  function getPlatformName() {
+    return model.data.platformName || 'Platform';
+  }
+};

--- a/platform-hub-web/src/app/shared/model/model.module.js
+++ b/platform-hub-web/src/app/shared/model/model.module.js
@@ -1,0 +1,14 @@
+import angular from 'angular';
+
+import {HubApiModule} from '../hub-api/hub-api.module';
+
+import {AppSettings} from './app-settings';
+import {PlatformThemesList} from './platform-themes-list';
+
+export const ModelModule = angular
+  .module('app.shared.model', [
+    HubApiModule
+  ])
+  .service('AppSettings', AppSettings)
+  .service('PlatformThemesList', PlatformThemesList)
+  .name;

--- a/platform-hub-web/src/app/shared/model/platform-themes-list.js
+++ b/platform-hub-web/src/app/shared/model/platform-themes-list.js
@@ -1,0 +1,61 @@
+import angular from 'angular';
+
+export const PlatformThemesList = function ($window, $q, AppSettings, apiBackoffTimeMs, hubApiService, _) {
+  'ngInject';
+
+  const model = {};
+
+  let fetcherPromise = null;
+
+  model.all = [];
+  model.visible = [];
+  model.hidden = [];
+
+  model.refresh = refresh;
+
+  return model;
+
+  function refresh() {
+    if (_.isNull(fetcherPromise)) {
+      const themesPromise = hubApiService.getPlatformThemes();
+      const settingsPromise = AppSettings.refresh();
+
+      fetcherPromise = $q.all([
+        themesPromise,
+        settingsPromise
+      ]).then(results => {
+        buildLists(results[0], AppSettings.data.visiblePlatformThemes || []);
+        return model.all;
+      }).finally(() => {
+        // Reuse the same promise for some time, to prevent smashing the API
+        $window.setTimeout(() => {
+          fetcherPromise = null;
+        }, apiBackoffTimeMs);
+      });
+    }
+    return fetcherPromise;
+  }
+
+  function buildLists(themes, visibleIds) {
+    // IMPORTANT: we need to ensure two things for the visible list
+    // 1. The ordering is the same as the visibleIds provided
+    // 2. We need to take into account entries in visibleIds that may not exist anymore
+
+    angular.copy(themes, model.all);
+
+    const visible = _.times(visibleIds.length, _.constant(null));
+    const hidden = [];
+
+    themes.forEach(t => {
+      const ix = _.indexOf(visibleIds, t.id);
+      if (ix >= 0) {
+        visible.splice(ix, 0, t);
+      } else {
+        hidden.push(t);
+      }
+    });
+
+    angular.copy(_.compact(visible), model.visible);
+    angular.copy(hidden, model.hidden);
+  }
+};

--- a/platform-hub-web/src/app/shared/shared.module.js
+++ b/platform-hub-web/src/app/shared/shared.module.js
@@ -2,21 +2,25 @@ import angular from 'angular';
 
 import {AuthModule} from './auth/auth.module';
 import {HubApiModule} from './hub-api/hub-api.module';
+import {ModelModule} from './model/model.module';
 import {UiModule} from './ui/ui.module';
 import {UtilModule} from './util/util.module';
 
 import {events} from './events.factory';
 import {homeEndpoint} from './home-endpoint.factory';
+import {icons} from './icons.factory';
 import {roleCheckerService} from './role-checker.service';
 
 export const SharedModule = angular
   .module('app.shared', [
     AuthModule,
     HubApiModule,
+    ModelModule,
     UiModule,
     UtilModule
   ])
   .factory('events', events)
   .factory('homeEndpoint', homeEndpoint)
+  .factory('icons', icons)
   .service('roleCheckerService', roleCheckerService)
   .name;

--- a/platform-hub-web/src/index.html
+++ b/platform-hub-web/src/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html>
+<html ng-app="app">
   <head>
     <base href="/">
     <meta charset="utf-8">
-    <title>HODDAT PaaS Hub</title>
+    <title ng-cloak>{{AppSettings.getAppTitle()}}</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   </head>
 
-  <body ng-app="app" ng-cloak>
+  <body ng-cloak>
     <app-shell></app-shell>
   </body>
 </html>

--- a/platform-hub-web/yarn.lock
+++ b/platform-hub-web/yarn.lock
@@ -135,6 +135,10 @@ angular-sanitize@1.5.11:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.5.11.tgz#ebfb3f343e543f9b2ef050fb4c2e9ee048d1772f"
 
+angular-sortable-view@jits/angular-sortable-view#754d087f079075f126c4a38eb7041c7fa69fbd55:
+  version "0.0.15"
+  resolved "https://codeload.github.com/jits/angular-sortable-view/tar.gz/754d087f079075f126c4a38eb7041c7fa69fbd55"
+
 angular-toastr@2.1.x:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/angular-toastr/-/angular-toastr-2.1.1.tgz#9f8350ca482145a44d011a755b8fb3623d60544c"
@@ -825,11 +829,11 @@ babel-types@^6.15.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0:
+babylon@^6.11.0, babylon@^6.13.0:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
 
-babylon@^6.13.0, babylon@^6.15.0:
+babylon@^6.15.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
 


### PR DESCRIPTION
- Admins can set the title of the app.
- Admins can define new "Platform Themes" that provide top level sections / groups in the app – both in the sidebar menu and on the homepage – currently these are purely informational, but we can layer in various links/resources/actions/etc. in the future.
- Admins can choose which themes are visible, and in what order (using the new app settings page).