### PR TITLE
Web: fix ordering bug in the platform themes list

### DIFF
--- a/platform-hub-web/src/.eslintrc.js
+++ b/platform-hub-web/src/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
   ],
   rules: {
     'max-params': 0,
+    'max-nested-callbacks': ["warn", 10],
     'angular/no-service-method': 0
   }
 }

--- a/platform-hub-web/src/app/shared/model/platform-themes-list.js
+++ b/platform-hub-web/src/app/shared/model/platform-themes-list.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 
-export const PlatformThemesList = function ($window, $q, AppSettings, apiBackoffTimeMs, hubApiService, _) {
+export const PlatformThemesList = function ($window, $q, AppSettings, apiBackoffTimeMs, hubApiService, arrayUtilsService, _) {
   'ngInject';
 
   const model = {};
@@ -43,19 +43,8 @@ export const PlatformThemesList = function ($window, $q, AppSettings, apiBackoff
 
     angular.copy(themes, model.all);
 
-    const visible = _.times(visibleIds.length, _.constant(null));
-    const hidden = [];
-
-    themes.forEach(t => {
-      const ix = _.indexOf(visibleIds, t.id);
-      if (ix >= 0) {
-        visible.splice(ix, 0, t);
-      } else {
-        hidden.push(t);
-      }
-    });
-
-    angular.copy(_.compact(visible), model.visible);
-    angular.copy(hidden, model.hidden);
+    const [left, right] = arrayUtilsService.splitBySortedIds(themes, visibleIds);
+    angular.copy(left, model.visible);
+    angular.copy(right, model.hidden);
   }
 };

--- a/platform-hub-web/src/app/shared/util/array-util.service.spec.js
+++ b/platform-hub-web/src/app/shared/util/array-util.service.spec.js
@@ -1,0 +1,123 @@
+import angular from 'angular';
+
+import 'angular-mocks';
+
+import {UtilModule} from './util.module';
+
+describe('arrayUtilsService', () => {
+  let service = null;
+
+  beforeEach(() => {
+    const moduleName = `${UtilModule}.arrayUtilsService.spec`;
+    angular.module(moduleName, ['app']);
+    angular.mock.module(moduleName);
+  });
+
+  beforeEach(angular.mock.inject(arrayUtilsService => {
+    service = arrayUtilsService;
+  }));
+
+  describe('.splitBySortedIds', () => {
+    describe('given an empty source list', () => {
+      const source = [];
+      const sortedIds = ['a', 'b'];
+
+      it('should return empty lists back', () => {
+        const [left, right] = service.splitBySortedIds(source, sortedIds);
+        expect(left).toEqual([]);
+        expect(right).toEqual([]);
+      });
+    });
+
+    describe('given a non-empty source list', () => {
+      const source = [
+        {id: 'b'},
+        {id: 'c'},
+        {id: 'a'},
+        {id: 'e'},
+        {id: 'd'}
+      ];
+
+      describe('given empty sorted IDs', () => {
+        const sortedIds = [];
+
+        it('should not return an empty list on the left and all items on the right', () => {
+          const [left, right] = service.splitBySortedIds(source, sortedIds);
+          expect(left).toEqual([]);
+          expect(right).toEqual(source);
+        });
+      });
+
+      describe('given some sorted IDs that all exist', () => {
+        const sortedIds = ['c', 'd', 'e'];
+
+        it('should split and reorder accordingly', () => {
+          const expectedLeft = [
+            {id: 'c'},
+            {id: 'd'},
+            {id: 'e'}
+          ];
+
+          const expectedRight = [
+            {id: 'b'},
+            {id: 'a'}
+          ];
+
+          const [left, right] = service.splitBySortedIds(source, sortedIds);
+          expect(left).toEqual(expectedLeft);
+          expect(right).toEqual(expectedRight);
+        });
+      });
+
+      describe('given some sorted IDs with some that don\'t exist', () => {
+        const sortedIds = ['e', 'bar', 'c', 'foo'];
+
+        it('should split and reorder accordingly', () => {
+          const expectedLeft = [
+            {id: 'e'},
+            {id: 'c'}
+          ];
+
+          const expectedRight = [
+            {id: 'b'},
+            {id: 'a'},
+            {id: 'd'}
+          ];
+
+          const [left, right] = service.splitBySortedIds(source, sortedIds);
+          expect(left).toEqual(expectedLeft);
+          expect(right).toEqual(expectedRight);
+        });
+      });
+    });
+
+    describe('the specific example that was failing before', () => {
+      const source = [
+        {id: 'build'},
+        {id: 'deploy'},
+        {id: 'develop'},
+        {id: 'manage'}
+      ];
+
+      const sortedIds = [
+        'develop',
+        'build',
+        'deploy',
+        'manage'
+      ];
+
+      it('should split and reorder accordingly', () => {
+        const expectedLeft = [
+          {id: 'develop'},
+          {id: 'build'},
+          {id: 'deploy'},
+          {id: 'manage'}
+        ];
+
+        const [left, right] = service.splitBySortedIds(source, sortedIds);
+        expect(left).toEqual(expectedLeft);
+        expect(right).toEqual([]);
+      });
+    });
+  });
+});

--- a/platform-hub-web/src/app/shared/util/array-utils.service.js
+++ b/platform-hub-web/src/app/shared/util/array-utils.service.js
@@ -1,0 +1,25 @@
+export const arrayUtilsService = function (_) {
+  'ngInject';
+
+  const service = {};
+
+  service.splitBySortedIds = splitBySortedIds;
+
+  return service;
+
+  function splitBySortedIds(source, sortedIds) {
+    const left = _.times(sortedIds.length, _.constant(null));
+    const right = [];
+
+    source.forEach(i => {
+      const ix = _.indexOf(sortedIds, i.id);
+      if (ix >= 0) {
+        left.splice(ix, 1, i);
+      } else {
+        right.push(i);
+      }
+    });
+
+    return [_.compact(left), right];
+  }
+};

--- a/platform-hub-web/src/app/shared/util/util.module.js
+++ b/platform-hub-web/src/app/shared/util/util.module.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 
 import 'angular-toastr';
 
+import {arrayUtilsService} from './array-utils.service';
 import {logger} from './logger.service';
 import {windowPopupService} from './window-popup.service';
 
@@ -11,6 +12,7 @@ export const UtilModule = angular
   .module('app.shared.util', [
     'toastr'
   ])
+  .service('arrayUtilsService', arrayUtilsService)
   .service('logger', logger)
   .service('windowPopupService', windowPopupService)
   .name;


### PR DESCRIPTION
Took this opportunity to move the array-splitting-and-sorting-by-specified-ids functionality into it's own service, and writing tests for it.