### PR TITLE
Platform themes now have a list of "resources" (aka "actions") that can be configured by an admin

### DIFF
--- a/platform-hub-api/app/controllers/platform_themes_controller.rb
+++ b/platform-hub-api/app/controllers/platform_themes_controller.rb
@@ -70,6 +70,10 @@ class PlatformThemesController < ApiJsonController
 
   # Only allow a trusted parameter "white list" through
   def platform_theme_params
-    params.require(:platform_theme).permit(:title, :description, :image_url, :colour)
+    allowed_params = params.require(:platform_theme).permit(:title, :description, :image_url, :colour)
+
+    # Below is a workaround until Rails 5.1 lands and we can use the `foo: [{}]` syntax to permit the whole array of hashes
+    allowed_params[:resources] = params[:platform_theme][:resources]
+    allowed_params.permit!
   end
 end

--- a/platform-hub-api/app/serializers/platform_theme_serializer.rb
+++ b/platform-hub-api/app/serializers/platform_theme_serializer.rb
@@ -5,11 +5,16 @@ class PlatformThemeSerializer < ActiveModel::Serializer
     :description,
     :image_url,
     :colour,
+    :resources,
     :created_at,
     :updated_at
   )
 
   def id
     object.friendly_id
+  end
+
+  def resources
+    object.resources || []
   end
 end

--- a/platform-hub-api/db/migrate/20170410142703_add_resources_field_to_platform_themes.rb
+++ b/platform-hub-api/db/migrate/20170410142703_add_resources_field_to_platform_themes.rb
@@ -1,0 +1,5 @@
+class AddResourcesFieldToPlatformThemes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :platform_themes, :resources, :json
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -160,7 +160,8 @@ CREATE TABLE platform_themes (
     image_url character varying NOT NULL,
     colour character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    resources json
 );
 
 
@@ -485,6 +486,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170221134425'),
 ('20170301114421'),
 ('20170322132009'),
-('20170322143551');
+('20170322143551'),
+('20170410142703');
 
 

--- a/platform-hub-api/spec/controllers/platform_themes_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/platform_themes_controller_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe PlatformThemesController, type: :controller do
             'description' => @platform_theme.description,
             'image_url' => @platform_theme.image_url,
             'colour' => @platform_theme.colour,
+            'resources' => @platform_theme.resources,
             'created_at' => now_json_value,
             'updated_at' => now_json_value
           })
@@ -83,7 +84,8 @@ RSpec.describe PlatformThemesController, type: :controller do
           title: source_data.title,
           description: source_data.description,
           image_url: source_data.image_url,
-          colour: source_data.colour
+          colour: source_data.colour,
+          resources: source_data.resources
         }
       }
     end
@@ -119,6 +121,7 @@ RSpec.describe PlatformThemesController, type: :controller do
             'description' => post_data[:platform_theme][:description],
             'image_url' => post_data[:platform_theme][:image_url],
             'colour' => post_data[:platform_theme][:colour],
+            'resources' => post_data[:platform_theme][:resources],
             'created_at' => now_json_value,
             'updated_at' => now_json_value
           });

--- a/platform-hub-api/spec/factories/platform_themes.rb
+++ b/platform-hub-api/spec/factories/platform_themes.rb
@@ -12,5 +12,7 @@ FactoryGirl.define do
 
     colour 'red'
 
+    resources []
+
   end
 end

--- a/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-form.component.js
+++ b/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-form.component.js
@@ -6,7 +6,7 @@ export const PlatformThemesEditorFormComponent = {
   controller: PlatformThemesEditorFormController
 };
 
-function PlatformThemesEditorFormController($state, $mdColorPalette, hubApiService, logger, _) {
+function PlatformThemesEditorFormController($state, $mdColorPalette, hubApiService, PlatformThemesResourceKinds, logger, _) {
   'ngInject';
 
   const ctrl = this;
@@ -16,12 +16,19 @@ function PlatformThemesEditorFormController($state, $mdColorPalette, hubApiServi
   // Colours from the material design spec
   ctrl.colours = Object.keys($mdColorPalette);
 
+  ctrl.resourceKinds = PlatformThemesResourceKinds.all;
+
   ctrl.loading = true;
   ctrl.saving = false;
   ctrl.isNew = true;
   ctrl.theme = null;
 
   ctrl.createOrUpdate = createOrUpdate;
+  ctrl.addResource = addResource;
+  ctrl.removeResource = removeResource;
+  ctrl.handleResourceKindChange = handleResourceKindChange;
+  ctrl.moveResourceDown = moveResourceDown;
+  ctrl.moveResourceUp = moveResourceUp;
 
   init();
 
@@ -38,7 +45,8 @@ function PlatformThemesEditorFormController($state, $mdColorPalette, hubApiServi
 
   function initEmptyTheme() {
     return {
-      colour: _.sample(ctrl.colours)
+      colour: _.sample(ctrl.colours),
+      resources: []
     };
   }
 
@@ -95,5 +103,44 @@ function PlatformThemesEditorFormController($state, $mdColorPalette, hubApiServi
 
   function validate() {
     return [];
+  }
+
+  function addResource() {
+    if (!ctrl.theme.resources) {
+      ctrl.theme.resources = [];
+    }
+    ctrl.theme.resources.push({
+      visible: true
+    });
+  }
+
+  function removeResource(ix) {
+    if (!_.isEmpty(ctrl.theme.resources)) {
+      ctrl.theme.resources.splice(ix, 1);
+    }
+  }
+
+  function handleResourceKindChange(ix) {
+    const resource = ctrl.theme.resources[ix];
+    if (resource) {
+      ctrl.resourceKinds.forEach(k => {
+        delete resource[k.kind];
+      });
+      resource[resource.kind] = {};
+    }
+  }
+
+  function moveResourceDown(ix) {
+    const resources = ctrl.theme.resources;
+    const resource1 = resources[ix];
+    const resource2 = resources[ix + 1];
+    resources.splice(ix, 2, resource2, resource1);
+  }
+
+  function moveResourceUp(ix) {
+    const resources = ctrl.theme.resources;
+    const resource1 = resources[ix - 1];
+    const resource2 = resources[ix];
+    resources.splice(ix - 1, 2, resource2, resource1);
   }
 }

--- a/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-form.html
+++ b/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-form.html
@@ -75,6 +75,117 @@
             </md-select>
           </md-input-container>
 
+          <br />
+
+          <div>
+
+            <label class="md-body-2">
+              Resources
+              ({{$ctrl.theme.resources.length}})
+            </label>
+
+            <p class="none-text" ng-if="$ctrl.theme.resources.length == 0">
+              No resources specified yet – why not add one?
+            </p>
+
+            <md-card ng-repeat="resource in $ctrl.theme.resources">
+              <md-card-content>
+
+                <div layout="row" flex>
+                  <md-input-container class="md-block md-icon-float" flex>
+                    <label>Type of resource:</label>
+                    <md-select
+                      ng-model="resource.kind"
+                      ng-change="$ctrl.handleResourceKindChange($index)"
+                      required>
+                      <md-option
+                        ng-repeat="k in $ctrl.resourceKinds"
+                        value="{{k.kind}}">
+                        {{k.name}}
+                      </md-option>
+                    </md-select>
+                  </md-input-container>
+                  <md-button
+                    class="md-icon-button input-button-end"
+                    aria-label="Remove this resource"
+                    ng-click="$ctrl.removeResource($index)">
+                    <md-icon md-colors="{color: 'accent'}">delete</md-icon>
+                    <md-tooltip md-direction="bottom">
+                      Remove this resource
+                    </md-tooltip>
+                  </md-button>
+                </div>
+
+                <md-input-container class="md-block">
+                  <md-checkbox
+                    name="resource{{$index}}-visible"
+                    ng-model="resource.visible"
+                    aria-label="Is this resource visible in the app?">
+                    Visible?
+                  </md-checkbox>
+                </md-input-container>
+
+                <md-input-container class="md-block" flex>
+                  <label for="resource{{$index}}-title">Title:</label>
+                  <input
+                    name="resource{{$index}}-title"
+                    ng-model="resource.title"
+                    placeholder="e.g. Getting started guide"
+                    required>
+                  <div ng-messages="$ctrl.themeForm['resource' + $index + '-title'].$error">
+                    <div ng-message="required">This is required.</div>
+                  </div>
+                </md-input-container>
+
+                <md-input-container class="md-block" flex>
+                  <label for="resource{{$index}}-description">Short description (optional):</label>
+                  <textarea
+                    name="resource{{$index}}-description"
+                    ng-model="resource.description"
+                    rows="2"
+                    md-select-on-focus>
+                  </textarea>
+                </md-input-container>
+
+                <platform-themes-resource-kind-fields
+                  ng-if="resource.kind"
+                  index="$index"
+                  resource="resource"
+                  form="$ctrl.themeForm">
+                </platform-themes-resource-kind-fields>
+
+              </md-card-content>
+
+              <md-card-actions layout="row" layout-align="end center">
+                <md-button
+                  ng-disabled="$index == ($ctrl.theme.resources.length - 1) || $ctrl.theme.resources.length == 1"
+                  ng-click="$ctrl.moveResourceDown($index)">
+                  <md-icon>arrow_downward</md-icon>
+                  Move down
+                </md-button>
+                <md-button
+                  ng-disabled="$index == 0 || $ctrl.theme.resources.length == 1"
+                  ng-click="$ctrl.moveResourceUp($index)">
+                  <md-icon>arrow_upward</md-icon>
+                  Move up
+                </md-button>
+              </md-card-actions>
+            </md-card>
+
+            <div>
+              <md-button
+                class="md-raised"
+                aria-label="Add new resource to this platform theme"
+                ng-click="$ctrl.addResource()">
+                <md-icon>add_box</md-icon>
+                Add new resource
+              </md-button>
+            </div>
+
+          </div>
+
+          <br />
+
           <div>
             <md-button
               type="submit"

--- a/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-list.html
+++ b/platform-hub-web/src/app/platform-themes/editor/platform-themes-editor-list.html
@@ -56,6 +56,15 @@
           </span>
           {{t.colour}}
         </p>
+
+        <p class="md-body-1">
+          <ng-pluralize
+            count="t.resources.length"
+            when="{'0': 'No resources specified',
+                   '1': '1 resource specified',
+                   'other': '{} resources specified'}">
+          </ng-pluralize>
+        </p>
       </md-card-content>
 
       <md-card-actions layout="row" layout-align="start center">

--- a/platform-hub-web/src/app/platform-themes/editor/platform-themes-resource-kind-fields.component.js
+++ b/platform-hub-web/src/app/platform-themes/editor/platform-themes-resource-kind-fields.component.js
@@ -1,0 +1,8 @@
+export const PlatformThemesResourceKindFieldsComponent = {
+  bindings: {
+    index: '<',
+    resource: '=',
+    form: '<'
+  },
+  template: require('./platform-themes-resource-kind-fields.html')
+};

--- a/platform-hub-web/src/app/platform-themes/editor/platform-themes-resource-kind-fields.html
+++ b/platform-hub-web/src/app/platform-themes/editor/platform-themes-resource-kind-fields.html
@@ -1,0 +1,68 @@
+<div
+  class="platform-themes-resource-kind-fields"
+  ng-switch="$ctrl.resource.kind">
+
+  <div ng-switch-default class="md-body-1 none-text">
+    The resource kind <em>{{$ctrl.resource.kind}}</em> is not currently supported in the app
+  </div>
+
+  <div ng-switch-when="internal_route">
+    <md-input-container class="md-block" flex>
+      <label for="resource{{$ctrl.index}}-internal_route-state">Router state:</label>
+      <input
+        name="resource{{$ctrl.index}}-internal_route-state"
+        ng-model="$ctrl.resource.internal_route.state"
+        placeholder="Should match a non-abstract state in the app.routes.js file"
+        required>
+      <div ng-messages="$ctrl.form['resource' + $ctrl.index + '-internal_route-state'].$error">
+        <div ng-message="required">This is required.</div>
+      </div>
+    </md-input-container>
+  </div>
+
+  <div ng-switch-when="external_link">
+    <md-input-container class="md-block" flex>
+      <label for="resource{{$ctrl.index}}-external_link-url">URL:</label>
+      <input
+        type="url"
+        name="resource{{$ctrl.index}}-external_link-url"
+        ng-model="$ctrl.resource.external_link.url"
+        required>
+      <div ng-messages="$ctrl.form['resource' + $ctrl.index + '-external_link-url'].$error">
+        <div ng-message="required">This is required.</div>
+        <div ng-message="url">Not a valid URL.</div>
+      </div>
+    </md-input-container>
+  </div>
+
+  <div ng-switch-when="support_request">
+    <md-input-container class="md-block" flex>
+      <label for="resource{{$ctrl.index}}-support_request-id">Support Request Form ID:</label>
+      <input
+        name="resource{{$ctrl.index}}-support_request-id"
+        ng-model="$ctrl.resource.support_request.id"
+        placeholder="Find the ID in the URL of the support request form"
+        required>
+      <div ng-messages="$ctrl.form['resource' + $ctrl.index + '-support_request-id'].$error">
+        <div ng-message="required">This is required.</div>
+      </div>
+    </md-input-container>
+  </div>
+
+  <div ng-switch-when="plain_text">
+    <md-input-container class="md-block" flex>
+      <label for="resource{{$ctrl.index}}-plain_text-text">Text:</label>
+      <textarea
+        name="resource{{$ctrl.index}}-plain_text-text"
+        ng-model="$ctrl.resource.plain_text.text"
+        rows="4"
+        required
+        md-select-on-focus>
+      </textarea>
+      <div ng-messages="$ctrl.form['resource' + $ctrl.index + '-plain_text-text'].$error">
+        <div ng-message="required">This is required.</div>
+      </div>
+    </md-input-container>
+  </div>
+
+</div>

--- a/platform-hub-web/src/app/platform-themes/platform-themes-page.component.js
+++ b/platform-hub-web/src/app/platform-themes/platform-themes-page.component.js
@@ -1,3 +1,5 @@
+/* eslint camelcase: 0 */
+
 export const PlatformThemesPageComponent = {
   bindings: {
     transition: '<'
@@ -6,12 +8,19 @@ export const PlatformThemesPageComponent = {
   controller: PlatformThemesPageController
 };
 
-function PlatformThemesPageController(hubApiService, _) {
+function PlatformThemesPageController(hubApiService, icons, _) {
   'ngInject';
 
   const ctrl = this;
 
   const id = ctrl.transition.params().id;
+
+  ctrl.icons = {
+    internal_route: icons.internalLink,
+    external_link: icons.externalLink,
+    support_request: icons.supportRequests,
+    plain_text: icons.text
+  };
 
   ctrl.loading = true;
   ctrl.theme = null;

--- a/platform-hub-web/src/app/platform-themes/platform-themes-page.html
+++ b/platform-hub-web/src/app/platform-themes/platform-themes-page.html
@@ -13,13 +13,91 @@
             alt="{{t.title}} icon" />
         </div>
 
-        <h2 class="md-display-2">
+        <h1 class="md-display-2">
           {{$ctrl.theme.title}}
-        </h2>
+        </h1>
 
         <p class="md-body-1">
           {{$ctrl.theme.description}}
         </p>
+
+        <div ng-if="$ctrl.theme.resources && $ctrl.theme.resources.length > 0">
+          <br />
+
+          <h2 class="md-title">
+            Tasks, actions and resources
+          </h2>
+
+          <md-list flex>
+            <ng-switch
+              ng-repeat="resource in $ctrl.theme.resources"
+              ng-if="resource.visible"
+              on="resource.kind">
+
+              <!-- internal_route -->
+              <md-list-item
+                ng-switch-when="internal_route"
+                class="md-2-line"
+                ui-sref="{{resource.internal_route.state}}">
+                <md-icon class="md-avatar-icon">{{$ctrl.icons[resource.kind]}}</md-icon>
+                <div class="md-list-item-text" layout="column">
+                  <h3>{{resource.title}}</h3>
+                  <h4>{{resource.description}}</h4>
+                </div>
+                <md-divider ng-if="!$last"></md-divider>
+              </md-list-item>
+
+              <!-- external_link -->
+              <md-list-item
+                ng-switch-when="external_link"
+                class="md-2-line"
+                ng-href="{{resource.external_link.url}}"
+                target="_blank">
+                <md-icon class="md-avatar-icon">{{$ctrl.icons[resource.kind]}}</md-icon>
+                <div class="md-list-item-text" layout="column">
+                  <h3>{{resource.title}}</h3>
+                  <p ng-if="resource.description">
+                    {{resource.description}}
+                  </p>
+                </div>
+                <md-divider ng-if="!$last"></md-divider>
+              </md-list-item>
+
+              <!-- support_request -->
+              <md-list-item
+                ng-switch-when="support_request"
+                class="md-2-line"
+                ui-sref="help.support.requests.new({id: resource.support_request.id})">
+                <md-icon class="md-avatar-icon">{{$ctrl.icons[resource.kind]}}</md-icon>
+                <div class="md-list-item-text" layout="column">
+                  <h3>{{resource.title}}</h3>
+                  <p ng-if="resource.description">
+                    {{resource.description}}
+                  </p>
+                </div>
+                <md-divider ng-if="!$last"></md-divider>
+              </md-list-item>
+
+              <!-- plain_text -->
+              <md-list-item
+                ng-switch-when="plain_text"
+                class="md-3-line md-long-text">
+                <md-icon class="md-avatar-icon">{{$ctrl.icons[resource.kind]}}</md-icon>
+                <div class="md-list-item-text" layout="column">
+                  <h3>{{resource.title}}</h3>
+                  <h4 ng-if="resource.description">
+                    {{resource.description}}
+                  </h4>
+                  <p>
+                    {{resource.plain_text.text}}
+                  </p>
+                </div>
+                <md-divider ng-if="!$last"></md-divider>
+              </md-list-item>
+
+            </ng-switch>
+          </md-list>
+        </div>
       </md-content>
     </div>
 

--- a/platform-hub-web/src/app/platform-themes/platform-themes.module.js
+++ b/platform-hub-web/src/app/platform-themes/platform-themes.module.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 
 import {PlatformThemesEditorFormComponent} from './editor/platform-themes-editor-form.component';
 import {PlatformThemesEditorListComponent} from './editor/platform-themes-editor-list.component';
+import {PlatformThemesResourceKindFieldsComponent} from './editor/platform-themes-resource-kind-fields.component';
 import {PlatformThemesPageComponent} from './platform-themes-page.component';
 
 // Main section component names
@@ -13,5 +14,6 @@ export const PlatformThemesModule = angular
   .module('app.platform-themes', [])
   .component(PlatformThemesEditorForm, PlatformThemesEditorFormComponent)
   .component(PlatformThemesEditorList, PlatformThemesEditorListComponent)
+  .component('platformThemesResourceKindFields', PlatformThemesResourceKindFieldsComponent)
   .component(PlatformThemesPage, PlatformThemesPageComponent)
   .name;

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -38,6 +38,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.getSupportRequestTemplateGitHubRepos = buildSimpleFetcher('support_request_templates/git_hub_repos', 'GitHub repos for support requests');
 
   service.createSupportRequest = createSupportRequest;
+
   service.getPlatformThemes = buildCollectionFetcher('platform_themes');
   service.getPlatformTheme = buildResourceFetcher('platform_themes');
   service.createPlatformTheme = buildResourceCreator('platform_themes');

--- a/platform-hub-web/src/app/shared/icons.factory.js
+++ b/platform-hub-web/src/app/shared/icons.factory.js
@@ -5,9 +5,12 @@ export const icons = function () {
     appSettings: 'settings',
     faq: 'question_answer',
     identities: 'account_box',
+    internalLink: 'input',
+    externalLink: 'link',
     platformThemes: 'lens',
     projects: 'group_work',
     supportRequests: 'feedback',
+    text: 'short_text',
     users: 'perm_identity'
   };
 };

--- a/platform-hub-web/src/app/shared/model/model.module.js
+++ b/platform-hub-web/src/app/shared/model/model.module.js
@@ -4,6 +4,7 @@ import {HubApiModule} from '../hub-api/hub-api.module';
 
 import {AppSettings} from './app-settings';
 import {PlatformThemesList} from './platform-themes-list';
+import {PlatformThemesResourceKinds} from './platform-themes-resource-kinds';
 
 export const ModelModule = angular
   .module('app.shared.model', [
@@ -11,4 +12,5 @@ export const ModelModule = angular
   ])
   .service('AppSettings', AppSettings)
   .service('PlatformThemesList', PlatformThemesList)
+  .service('PlatformThemesResourceKinds', PlatformThemesResourceKinds)
   .name;

--- a/platform-hub-web/src/app/shared/model/platform-themes-resource-kinds.js
+++ b/platform-hub-web/src/app/shared/model/platform-themes-resource-kinds.js
@@ -1,0 +1,14 @@
+export const PlatformThemesResourceKinds = function () {
+  'ngInject';
+
+  const model = {};
+
+  model.all = [
+    {name: 'Internal route', kind: 'internal_route'},
+    {name: 'External link', kind: 'external_link'},
+    {name: 'Support request form', kind: 'support_request'},
+    {name: 'Plain text', kind: 'plain_text'}
+  ];
+
+  return model;
+};


### PR DESCRIPTION
- Admins can fully manage (create, edit and delete) all actions (aka "resources") for a particular platform theme, within the hub.
- Actions can link to an existing support request form.
- Actions can link to pages within the hub.
- Actions can link to external resources.
- Actions can be plain text (e.g. a placeholder for something upcoming, or informational text).
- Actions have a descriptor to show to users when they see it in the platform theme (set by admins).
- Admins can switch an action from one type to another (to help easily migrate to new functionality / external resources).
- Admins can reorder actions within a platform theme.

---

**TODO**:

- [x] Test that it works!
- [x] Review if we need other kinds of resources at the moment