### PR TITLE
API: fix the error handling in the `IdentityFlowsController`

### DIFF
--- a/platform-hub-api/app/controllers/identity_flows_controller.rb
+++ b/platform-hub-api/app/controllers/identity_flows_controller.rb
@@ -16,13 +16,12 @@ class IdentityFlowsController < AuthenticatedController
 
     code = params[:code]
     if code.blank?
-      head :unprocessable_entity
-      return
+      head :unprocessable_entity and return
     end
 
     state = params[:state]
     if state.blank?
-      head :unprocessable_entity
+      head :unprocessable_entity and return
     end
 
     begin
@@ -36,13 +35,13 @@ class IdentityFlowsController < AuthenticatedController
       )
     rescue GitHubIdentityService::Errors::InvalidCallbackState => ex
       logger.error "Github identity flow callback was called with an invalid 'state' = #{state}"
-      head :forbidden
+      head :forbidden and return
     rescue GitHubIdentityService::Errors::NoAccessToken => ex
       logger.error "Github identity flow was unable to get an access token"
-      head :forbidden
+      head :forbidden and return
     rescue GitHubIdentityService::Errors::UserMismatch => ex
       logger.error "Github identity flow with mismatched users: the Github auth flow was carried out with a different user to the user assigned to an existing matching Github identity"
-      head :forbidden
+      head :forbidden and return
     end
 
     redirect_to Rails.application.config.app_base_url

--- a/platform-hub-api/spec/controllers/identity_flows_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/identity_flows_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe IdentityFlowsController, type: :controller do
 
-  describe "GET #start_auth_flow" do
+  describe 'GET #start_auth_flow' do
     it_behaves_like 'unauthenticated not allowed'  do
       before do
         get :start_auth_flow, params: { service: 'github' }
@@ -10,10 +10,35 @@ RSpec.describe IdentityFlowsController, type: :controller do
     end
   end
 
-  describe "GET #callback" do
-    it 'should allow unauthenticated access but cannot process the request due to a missing param' do
+  describe 'GET #callback' do
+    it 'should allow unauthenticated access but handle a missing "code" param' do
       get :callback, params: { service: 'github' }
       expect(response).to have_http_status(422)
+    end
+
+    it 'should allow unauthenticated access but handle a missing "state" param' do
+      get :callback, params: { service: 'github', code: 'foo' }
+      expect(response).to have_http_status(422)
+    end
+
+    context 'the GitHubIdentityService throws a NoAccessToken error' do
+      let(:code) { 'code' }
+
+      let(:state) { 'state' }
+
+      let :git_hub_identity_service do
+        instance_double('GitHubIdentityService')
+      end
+
+      before do
+        expect(controller).to receive(:git_hub_identity_service).and_return(git_hub_identity_service)
+        expect(git_hub_identity_service).to receive(:connect_identity).with(code, state).and_raise(GitHubIdentityService::Errors::NoAccessToken)
+      end
+
+      it 'should handle the error and respond with an HTTP 403' do
+        get :callback, params: { service: 'github', code: code, state: state }
+        expect(response).to have_http_status(403)
+      end
     end
   end
 


### PR DESCRIPTION
Previously, we would end up with a Rails "double render" error since we didn't return early after catching the error and setting up the error response.