### PR TITLE
Admins can now configure some overview text for the homepage

### DIFF
--- a/platform-hub-web/package.json
+++ b/platform-hub-web/package.json
@@ -24,6 +24,7 @@
     "angular-loading-bar": "0.9.x",
     "angular-material": "^1.1.3",
     "angular-material-sidemenu": "^1.0.2",
+    "angular-medium-editor": "^1.2.1",
     "angular-messages": "1.5.11",
     "angular-sanitize": "1.5.11",
     "angular-sortable-view": "jits/angular-sortable-view#754d087f079075f126c4a38eb7041c7fa69fbd55",
@@ -32,6 +33,7 @@
     "angular-url-encode": "^1.0.0",
     "bourbon": "^4.3.2",
     "lodash": "^4.17.4",
+    "medium-editor": "^5.23.0",
     "moment": "2.17.x",
     "normalize.css": "^5.0.0"
   },

--- a/platform-hub-web/src/app/app-settings/app-settings-form.component.js
+++ b/platform-hub-web/src/app/app-settings/app-settings-form.component.js
@@ -8,6 +8,15 @@ function AppSettingsFormController($state, AppSettings, PlatformThemesList, _) {
 
   const ctrl = this;
 
+  // See https://github.com/yabwe/medium-editor#mediumeditor-options
+  ctrl.editorOptions = {
+    toolbar: {
+      buttons: ['bold', 'italic', 'underline', 'anchor', 'image', 'h2', 'h3', 'h4', 'orderedlist', 'unorderedlist', 'indent', 'outdent', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'subscript', 'superscript', 'removeFormat']
+    },
+    targetBlank: true,
+    imageDragging: false
+  };
+
   ctrl.loading = true;
   ctrl.saving = false;
   ctrl.settings = {};

--- a/platform-hub-web/src/app/app-settings/app-settings-form.html
+++ b/platform-hub-web/src/app/app-settings/app-settings-form.html
@@ -20,6 +20,8 @@
 
       <md-content>
         <form name="$ctrl.settingsForm" role="form" ng-submit="$ctrl.update()">
+
+          <!-- Platform name -->
           <md-input-container class="md-block">
             <label for="platformName">Platform Name:</label>
             <input
@@ -32,6 +34,7 @@
             </div>
           </md-input-container>
 
+          <!-- Platform themes config -->
           <div>
             <h3 class="md-subhead">Platform Themes</h3>
             <div
@@ -73,6 +76,37 @@
             </div>
           </div>
 
+          <br />
+          <br />
+
+          <!-- Platform overview -->
+          <div>
+            <h3 class="md-subhead">Platform Overview</h3>
+
+            <div layout-padding>
+              <p class="md-body-1" md-colors="{background: 'accent-50'}">
+                <strong>Important:</strong>
+                this overview text (and any images in it) will be shown on the homepage for both logged in users AND visitors. Please don't put anything confidential in here!
+              </p>
+
+              <br />
+
+              <div layout-padding md-colors="{background: 'blue-grey-50'}">
+                <div
+                  medium-editor
+                  bind-options="$ctrl.editorOptions"
+                  ng-model="$ctrl.settings.platform_overview">
+                </div>
+              </div>
+
+              <p class="md-body-1">
+                <span><strong>Tip:</strong></span>
+                this is a rich text editor – try highlighting some text for options
+              </p>
+            </div>
+          </div>
+
+          <br />
           <br />
 
           <div>

--- a/platform-hub-web/src/app/app.module.js
+++ b/platform-hub-web/src/app/app.module.js
@@ -19,6 +19,9 @@ import 'angular-url-encode';
 import moment from 'moment';
 import lodash from 'lodash';
 
+window.MediumEditor = require('medium-editor/dist/js/medium-editor.js');
+import 'angular-medium-editor';
+
 import {AppSettingsModule} from './app-settings/app-settings.module';
 import {HelpModule} from './help/help.module';
 import {HomeModule} from './home/home.module';
@@ -37,6 +40,8 @@ import {appRun} from './app.run';
 import 'normalize.css';
 import 'angular-material/angular-material.css';  // Make sure this is available across the app
 import 'angular-material-sidemenu/dest/angular-material-sidemenu.css';
+import 'medium-editor/dist/css/medium-editor.css';
+import 'medium-editor/dist/css/themes/beagle.css';
 import './app.scss';
 
 const name = 'app';
@@ -56,6 +61,7 @@ angular
     UsersModule,
     'angular-jwt',
     'angular-loading-bar',
+    'angular-medium-editor',
     'angular-sortable-view',
     'base64',
     'bc.AngularUrlEncode',

--- a/platform-hub-web/src/app/home/home.component.js
+++ b/platform-hub-web/src/app/home/home.component.js
@@ -3,13 +3,15 @@ export const HomeComponent = {
   controller: HomeController
 };
 
-function HomeController($scope, events, authService, onboardingTrigger, AppSettings, PlatformThemesList) {
+function HomeController($scope, $sce, events, authService, onboardingTrigger, AppSettings, PlatformThemesList) {
   'ngInject';
 
   const ctrl = this;
 
   ctrl.AppSettings = AppSettings;
   ctrl.PlatformThemesList = PlatformThemesList;
+
+  ctrl.platformOverviewText = '';
 
   ctrl.login = login;
   ctrl.isAuthenticated = isAuthenticated;
@@ -27,6 +29,12 @@ function HomeController($scope, events, authService, onboardingTrigger, AppSetti
     if (isAuthenticated()) {
       refresh();
     }
+
+    AppSettings
+      .refresh()
+      .then(() => {
+        ctrl.platformOverviewText = $sce.trustAsHtml(AppSettings.getPlatformOverviewText());
+      });
   }
 
   function refresh() {

--- a/platform-hub-web/src/app/home/home.html
+++ b/platform-hub-web/src/app/home/home.html
@@ -1,15 +1,26 @@
 <div class="app-home">
   <md-content layout-padding>
 
-    <h2 class="md-display-1 text-center">
+    <h1 class="md-display-1 text-center">
       Welcome to the {{$ctrl.AppSettings.getAppTitle()}}
-    </h2>
+    </h1>
 
     <div ng-if="!$ctrl.isAuthenticated()" layout="row" layout-align="center center">
       <md-button class="md-primary md-raised" ng-click="$ctrl.login()">
         <md-icon>person</md-icon>
         Login
       </md-button>
+    </div>
+
+    <div ng-if="$ctrl.platformOverviewText">
+      <br ng-if="!$ctrl.isAuthenticated()" />
+      <div
+        ng-if="$ctrl.platformOverviewText"
+        layout-padding
+        md-colors="{background: 'blue-grey-50'}">
+        <div ng-bind-html="$ctrl.platformOverviewText"></div>
+      </div>
+      <br />
     </div>
 
     <div

--- a/platform-hub-web/src/app/shared/model/app-settings.js
+++ b/platform-hub-web/src/app/shared/model/app-settings.js
@@ -13,6 +13,7 @@ export const AppSettings = function ($window, hubApiService, apiBackoffTimeMs, l
   model.update = update;
   model.getAppTitle = getAppTitle;
   model.getPlatformName = getPlatformName;
+  model.getPlatformOverviewText = getPlatformOverviewText;
 
   return model;
 
@@ -50,5 +51,9 @@ export const AppSettings = function ($window, hubApiService, apiBackoffTimeMs, l
 
   function getPlatformName() {
     return model.data.platformName || 'Platform';
+  }
+
+  function getPlatformOverviewText() {
+    return model.data.platform_overview || '';
   }
 };

--- a/platform-hub-web/yarn.lock
+++ b/platform-hub-web/yarn.lock
@@ -123,6 +123,10 @@ angular-material@^1.0.6, angular-material@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/angular-material/-/angular-material-1.1.3.tgz#b466d53aaa42c1555766a1ded53a28baeb7b2fe6"
 
+angular-medium-editor@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/angular-medium-editor/-/angular-medium-editor-1.2.1.tgz#3f336d0fffb26f0948e49b6cf50682f8b90d68fa"
+
 angular-messages@1.5.11:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular-messages/-/angular-messages-1.5.11.tgz#ea99f0163594fcb0a2db701b3038339250decc90"
@@ -4586,6 +4590,10 @@ math-expression-evaluator@^1.2.14:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+medium-editor@^5.23.0:
+  version "5.23.0"
+  resolved "https://registry.yarnpkg.com/medium-editor/-/medium-editor-5.23.0.tgz#7d16c15cdf152b95ced2a583bf07203e8539a3c6"
 
 memoizee@~0.3.8:
   version "0.3.10"


### PR DESCRIPTION
- This can be used to provide some high level information about the platform, complimenting the platform theme boxes
- Shown to both logged in users and visitors (i.e. public)
- Hyperlinks, external images and rich text are supported (via the [medium-editor](http://yabwe.github.io/medium-editor/) component)