### PR TITLE
API: handle expired auth tokens

### DIFF
--- a/platform-hub-api/app/controllers/app_settings_controller.rb
+++ b/platform-hub-api/app/controllers/app_settings_controller.rb
@@ -1,10 +1,10 @@
 class AppSettingsController < ApiJsonController
 
-  before_action :load_app_settings_hash_record
-
   skip_before_action :require_authentication, only: :show
 
-  skip_authorization_check only: [ :show ]
+  before_action :load_app_settings_hash_record
+
+  skip_authorization_check only: :show
 
   # GET /app_settings
   def show

--- a/platform-hub-api/app/controllers/concerns/authentication.rb
+++ b/platform-hub-api/app/controllers/concerns/authentication.rb
@@ -24,7 +24,9 @@ module Authentication
     # - it is already verified by the auth proxy in front
     # - expiry has already been checked by the auth proxy in front (TODO: perhaps recheck here)
     begin
-      payload, _ = JWT.decode(token, nil, false)
+      payload, _ = JWT.decode token, nil, false
+    rescue JWT::ExpiredSignature
+      return nil
     rescue => e
       logger.error "Failed to parse JWT token: #{token}. Error: #{e.message}"
       return nil


### PR DESCRIPTION
I.e.: don't log as an error!