### PR TITLE
API: rename `published_at` to `publish_at` to make more sense!

### DIFF
--- a/platform-hub-api/app/controllers/announcements_controller.rb
+++ b/platform-hub-api/app/controllers/announcements_controller.rb
@@ -78,7 +78,7 @@ class AnnouncementsController < ApiJsonController
 
   # Only allow a trusted parameter "white list" through
   def announcement_params
-    allowed_params = params.require(:announcement).permit(:level, :title, :text, :is_global, :is_sticky, :published_at)
+    allowed_params = params.require(:announcement).permit(:level, :title, :text, :is_global, :is_sticky, :publish_at)
 
     # Below is a workaround until Rails 5.1 lands and we can use the `foo: [{}]` syntax to permit the whole array of hashes
     if params[:announcement][:deliver_to]

--- a/platform-hub-api/app/models/announcement.rb
+++ b/platform-hub-api/app/models/announcement.rb
@@ -35,7 +35,7 @@ class Announcement < ApplicationRecord
       message: '%{value} should not be nil'
     }
 
-  validates :published_at,
+  validates :publish_at,
     presence: true
 
   validates :status,
@@ -52,12 +52,12 @@ class Announcement < ApplicationRecord
   after_update :update_protections
 
   scope :global, -> { where(is_global: true) }
-  scope :published, -> { where('published_at <= ?', DateTime.now.utc).order(published_at: :desc) }
+  scope :published, -> { where('publish_at <= ?', DateTime.now.utc).order(publish_at: :desc) }
 
   private
 
   def update_protections
-    if !self.waiting_delivery? || self.published_at <= DateTime.now.utc
+    if !self.waiting_delivery? || self.publish_at <= DateTime.now.utc
       readonly!
     end
   end

--- a/platform-hub-api/app/serializers/announcement_serializer.rb
+++ b/platform-hub-api/app/serializers/announcement_serializer.rb
@@ -6,7 +6,7 @@ class AnnouncementSerializer < BaseSerializer
     :text,
     :is_global,
     :is_sticky,
-    :published_at,
+    :publish_at,
     :created_at,
     :updated_at
   )

--- a/platform-hub-api/db/migrate/20170602101700_create_announcements.rb
+++ b/platform-hub-api/db/migrate/20170602101700_create_announcements.rb
@@ -7,7 +7,7 @@ class CreateAnnouncements < ActiveRecord::Migration[5.0]
       t.boolean :is_global, null: false, default: false
       t.boolean :is_sticky, null: false, default: false
       t.json :deliver_to, null: false
-      t.datetime :published_at, null: false
+      t.datetime :publish_at, null: false
       t.string :status, null: false
 
       t.timestamps

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -74,7 +74,7 @@ CREATE TABLE announcements (
     is_global boolean DEFAULT false NOT NULL,
     is_sticky boolean DEFAULT false NOT NULL,
     deliver_to json NOT NULL,
-    published_at timestamp without time zone NOT NULL,
+    publish_at timestamp without time zone NOT NULL,
     status character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL

--- a/platform-hub-api/spec/controllers/announcements_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/announcements_controller_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe AnnouncementsController, type: :controller do
     it_behaves_like 'authenticated' do
 
       before do
-        @a1 = create :announcement, is_global: true, published_at: (now - 1.second)
-        @a2 = create :announcement, is_global: true, published_at: (now + 1.hour)
-        @a3 = create :announcement, is_global: false, published_at: (now + 1.hour)
-        @a4 = create :announcement, is_global: true, published_at: (now - 1.hour)
-        @a5 = create :announcement, is_global: false, published_at: (now - 1.hour)
+        @a1 = create :announcement, is_global: true, publish_at: (now - 1.second)
+        @a2 = create :announcement, is_global: true, publish_at: (now + 1.hour)
+        @a3 = create :announcement, is_global: false, publish_at: (now + 1.hour)
+        @a4 = create :announcement, is_global: true, publish_at: (now - 1.hour)
+        @a5 = create :announcement, is_global: false, publish_at: (now - 1.hour)
       end
 
       it 'should return a list of global and published announcements only and ordered by published date (desc)' do
@@ -103,7 +103,7 @@ RSpec.describe AnnouncementsController, type: :controller do
             'text' => @announcement.text,
             'is_global' => @announcement.is_global,
             'is_sticky' => @announcement.is_sticky,
-            'published_at' => @announcement.published_at.iso8601,
+            'publish_at' => @announcement.publish_at.iso8601,
             'created_at' => now_json_value,
             'updated_at' => now_json_value
           })
@@ -124,7 +124,7 @@ RSpec.describe AnnouncementsController, type: :controller do
           text: source_data.text,
           is_global: source_data.is_global,
           is_sticky: source_data.is_sticky,
-          published_at: source_data.published_at,
+          publish_at: source_data.publish_at,
           deliver_to: source_data.deliver_to
         }
       }
@@ -161,7 +161,7 @@ RSpec.describe AnnouncementsController, type: :controller do
             'text' => post_data[:announcement][:text],
             'is_global' => post_data[:announcement][:is_global],
             'is_sticky' => post_data[:announcement][:is_sticky],
-            'published_at' => post_data[:announcement][:published_at].iso8601,
+            'publish_at' => post_data[:announcement][:publish_at].iso8601,
             'created_at' => now_json_value,
             'updated_at' => now_json_value,
             'deliver_to' => post_data[:announcement][:deliver_to],
@@ -187,7 +187,7 @@ RSpec.describe AnnouncementsController, type: :controller do
           level: 'critical',
           text: @announcement.text + ' foobar',
           is_sticky: !@announcement.is_sticky,
-          published_at: now + 100.hours
+          publish_at: now + 100.hours
         }
       }
     end
@@ -225,7 +225,7 @@ RSpec.describe AnnouncementsController, type: :controller do
             expect(updated.text).to eq put_data[:announcement][:text]
             expect(updated.is_global).to eq @announcement.is_global
             expect(updated.is_sticky).to eq put_data[:announcement][:is_sticky]
-            expect(updated.published_at).to eq put_data[:announcement][:published_at].iso8601
+            expect(updated.publish_at).to eq put_data[:announcement][:publish_at].iso8601
             expect(Audit.count).to eq 1
             audit = Audit.first
             expect(audit.action).to eq 'update'

--- a/platform-hub-api/spec/factories/announcements.rb
+++ b/platform-hub-api/spec/factories/announcements.rb
@@ -8,6 +8,6 @@ FactoryGirl.define do
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ullamcorper erat orci, a imperdiet neque viverra laoreet. Nulla consequat nisl id sem dictum, sit amet scelerisque mauris faucibus. Nulla laoreet ligula eu ex tristique ornare. Mauris viverra dui varius libero gravida, ut lobortis ante fringilla. Quisque volutpat sit amet leo at vehicula. Quisque iaculis iaculis nibh, nec convallis mauris viverra eu. Proin gravida enim ut elit blandit rhoncus. Praesent ac est varius, mollis urna in, hendrerit dui.'
     end
     is_global false
-    published_at { DateTime.now.utc + 1.hour }
+    publish_at { DateTime.now.utc + 1.hour }
   end
 end

--- a/platform-hub-api/spec/models/announcement_spec.rb
+++ b/platform-hub-api/spec/models/announcement_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe Announcement, type: :model do
       }.to raise_error(ActiveRecord::ReadOnlyRecord)
     end
 
-    it 'should not allow updates after published_at has been reached' do
-      a = create :announcement, title: 'foo', published_at: now + 1.hour
+    it 'should not allow updates after publish_at has been reached' do
+      a = create :announcement, title: 'foo', publish_at: now + 1.hour
       expect(a.title).to eq 'foo'
 
       a.update title: 'bar'
       expect(a.title).to eq 'bar'
 
-      a.update published_at: now - 1.hour
+      a.update publish_at: now - 1.hour
 
       expect {
         a.update title: 'baz'
@@ -36,9 +36,9 @@ RSpec.describe Announcement, type: :model do
 
   describe 'scope: published' do
     before do
-      @a1 = create :announcement, published_at: (now - 1.second)
-      @a2 = create :announcement, published_at: (now + 1.hour)
-      @a3 = create :announcement, published_at: (now - 1.hour)
+      @a1 = create :announcement, publish_at: (now - 1.second)
+      @a2 = create :announcement, publish_at: (now + 1.hour)
+      @a3 = create :announcement, publish_at: (now - 1.hour)
     end
 
     it 'should only show announcements that are currently published and ordered by published date (desc)' do


### PR DESCRIPTION
Given the original code for this was merged in earlier today, hopefully this cheeky rename won't affect anything (as it hasn't yet been deployed to persistent environment).