### PR TITLE
[ACPBoard #378] Bugfix 500 Server Error deleting missing identities

### DIFF
--- a/platform-hub-api/app/controllers/me_controller.rb
+++ b/platform-hub-api/app/controllers/me_controller.rb
@@ -12,15 +12,20 @@ class MeController < ApiJsonController
 
   def delete_identity
     # We assume that the `service` param has been validated by the route constraints
-    current_user.identity(params[:service]).destroy
+    user_identity = current_user.identity(params[:service])
+    if user_identity.present?
+      user_identity.destroy!
 
-    AuditService.log(
-      context: audit_context,
-      action: 'delete_identity',
-      comment: "User '#{current_user.email}' removed their #{params[:service]} identity"
-    )
+      AuditService.log(
+        context: audit_context,
+        action: 'delete_identity',
+        comment: "User '#{current_user.email}' removed their #{params[:service]} identity"
+      )
 
-    head :no_content
+      head :no_content
+    else
+      raise ActiveRecord::RecordNotFound
+    end
   end
 
   def agree_terms_of_service

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 9.6.1
--- Dumped by pg_dump version 9.6.2
+-- Dumped by pg_dump version 9.6.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
- Added additional route to show identity, returning a json object
- Added 'before_action' on delete and show identity, to first attempt a get and return 404 on failure
- Updated controller tests