### PR TITLE
Web: collapse the list of "other services" on the services onboarding page

### DIFF
--- a/platform-hub-web/src/app/identities/identities-manager.html
+++ b/platform-hub-web/src/app/identities/identities-manager.html
@@ -10,6 +10,6 @@
   <loading-indicator loading="$ctrl.busy"></loading-indicator>
 
   <md-content>
-    <identities-list busy="$ctrl.busy"></identities-list>
+    <identities-list busy="$ctrl.busy" expand-other-services="true"></identities-list>
   </md-content>
 </div>

--- a/platform-hub-web/src/app/onboarding/services-onboarding.html
+++ b/platform-hub-web/src/app/onboarding/services-onboarding.html
@@ -17,7 +17,7 @@
         <h3 class="md-title">
           First, connect up your external identities to the hub:
         </h3>
-        <identities-list busy="$ctrl.busy" only-self-service="true"></identities-list>
+        <identities-list busy="$ctrl.busy" only-self-service="true" expand-other-services="false"></identities-list>
 
         <br />
         <br />

--- a/platform-hub-web/src/app/shared/identities/identities-list.component.js
+++ b/platform-hub-web/src/app/shared/identities/identities-list.component.js
@@ -1,7 +1,8 @@
 export const IdentitiesListComponent = {
   bindings: {
     busy: '=',
-    onlySelfService: '<'
+    onlySelfService: '<',
+    expandOtherServices: '<'
   },
   template: require('./identities-list.html'),
   controller: IdentitiesListController
@@ -18,7 +19,6 @@ function IdentitiesListController($mdDialog, Identities, Me, _, logger, hubApiSe
 
   ctrl.userIdentities = {};
 
-  ctrl.busy = false;
   ctrl.connect = connect;
   ctrl.disconnect = disconnect;
   ctrl.showKubeTokens = false;

--- a/platform-hub-web/src/app/shared/identities/identities-list.html
+++ b/platform-hub-web/src/app/shared/identities/identities-list.html
@@ -102,7 +102,13 @@
           May be managed by the hub in the future.
         </p>
 
-        <md-list flex>
+        <div ng-if="!$ctrl.expandOtherServices" layout="row" layout-align="end center">
+          <md-button class="md-primary" ng-click="$ctrl.expandOtherServices = true;">
+            Show
+          </md-button>
+        </div>
+
+        <md-list flex ng-if="$ctrl.expandOtherServices">
           <div ng-repeat="i in $ctrl.Identities.getOther() track by i.title">
             <md-list-item
               ng-if="i.url"


### PR DESCRIPTION
This is so the final and important step of the flow is shown to the user more prominently – before this, a long "other services" list would hide the section below unless the user rememebered to scroll.