### PR TITLE
Initial support for announcement templates

### DIFF
--- a/platform-hub-api/app/controllers/announcement_templates_controller.rb
+++ b/platform-hub-api/app/controllers/announcement_templates_controller.rb
@@ -69,6 +69,13 @@ class AnnouncementTemplatesController < ApiJsonController
     render json: AnnouncementTemplate.form_field_types
   end
 
+  # POST /announcement_templates/preview
+  def preview
+    templates, data = params.require([:templates, :data])
+    results = AnnouncementFormatterService.format templates, data
+    render json: results
+  end
+
   private
 
   def find_announcement_template

--- a/platform-hub-api/app/controllers/announcement_templates_controller.rb
+++ b/platform-hub-api/app/controllers/announcement_templates_controller.rb
@@ -1,0 +1,88 @@
+class AnnouncementTemplatesController < ApiJsonController
+
+  before_action :find_announcement_template, only: [ :show, :update, :destroy ]
+
+  authorize_resource
+
+  # GET /announcement_templates
+  def index
+    @announcement_templates = AnnouncementTemplate.order(:shortname)
+
+    render json: @announcement_templates
+  end
+
+  # GET /announcement_templates/1
+  def show
+    render json: @announcement_template
+  end
+
+  # POST /announcement_templates
+  def create
+    @announcement_template = AnnouncementTemplate.new(announcement_template_params)
+
+    if @announcement_template.save
+      AuditService.log(
+        context: audit_context,
+        action: 'create',
+        auditable: @announcement_template
+      )
+
+      render json: @announcement_template, status: :created
+    else
+      render_model_errors @announcement_template.errors
+    end
+  end
+
+  # PATCH/PUT /announcement_templates/1
+  def update
+    if @announcement_template.update(announcement_template_params)
+      AuditService.log(
+        context: audit_context,
+        action: 'update',
+        auditable: @announcement_template
+      )
+
+      render json: @announcement_template
+    else
+      render_model_errors @announcement_template.errors
+    end
+  end
+
+  # DELETE /announcement_templates/1
+  def destroy
+    id = @announcement_template.id
+    shortname = @announcement_template.shortname
+
+    @announcement_template.destroy
+
+    AuditService.log(
+      context: audit_context,
+      action: 'destroy',
+      comment: "User '#{current_user.email}' deleted announcement template: '#{shortname}' (ID: #{id})"
+    )
+
+    head :no_content
+  end
+
+  # GET /announcement_templates/form_field_types
+  def form_field_types
+    render json: AnnouncementTemplate.form_field_types
+  end
+
+  private
+
+  def find_announcement_template
+    @announcement_template = AnnouncementTemplate.friendly.find params[:id]
+  end
+
+  # Only allow a trusted parameter "white list" through.
+  def announcement_template_params
+    allowed_params = params.require(:announcement_template).permit(:shortname, :description)
+
+    # Below is a workaround until Rails 5.1 lands and we can use the `foo: {}` syntax to permit the whole hash
+    if params[:announcement_template][:spec]
+      allowed_params[:spec] = params[:announcement_template][:spec]
+    end
+    allowed_params.permit!
+  end
+end

--- a/platform-hub-api/app/controllers/concerns/api_json_error_handler.rb
+++ b/platform-hub-api/app/controllers/concerns/api_json_error_handler.rb
@@ -4,6 +4,7 @@ module ApiJsonErrorHandler
   included do
     rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
     rescue_from ActiveRecord::ReadOnlyRecord, with: :readonly_error
+    rescue_from ActionController::ParameterMissing, with: :missing_parameter_error
   end
 
   def render_error message, status
@@ -27,6 +28,10 @@ module ApiJsonErrorHandler
 
   def readonly_error
     render_error 'Resource is readonly', :unprocessable_entity
+  end
+
+  def missing_parameter_error err
+    render_error err.message, :unprocessable_entity
   end
 
 end

--- a/platform-hub-api/app/controllers/identity_flows_controller.rb
+++ b/platform-hub-api/app/controllers/identity_flows_controller.rb
@@ -1,5 +1,7 @@
 class IdentityFlowsController < AuthenticatedController
 
+  include ApiJsonErrorHandler
+
   skip_before_action :require_authentication, only: :callback
 
   # Note: only Github auth is supported for now
@@ -14,15 +16,7 @@ class IdentityFlowsController < AuthenticatedController
   def callback
     # Callback from external service's OAuth2 flow
 
-    code = params[:code]
-    if code.blank?
-      head :unprocessable_entity and return
-    end
-
-    state = params[:state]
-    if state.blank?
-      head :unprocessable_entity and return
-    end
+    code, state = params.require([:code, :state])
 
     begin
       identity = git_hub_identity_service.connect_identity code, state

--- a/platform-hub-api/app/controllers/support_requests_controller.rb
+++ b/platform-hub-api/app/controllers/support_requests_controller.rb
@@ -8,11 +8,7 @@ class SupportRequestsController < ApiJsonController
   def create
     template = SupportRequestTemplate.friendly.find params[:template_id]
 
-    data = params[:data]
-    if data.blank?
-      render_error "Missing 'data' field", :unprocessable_entity
-      return
-    end
+    data = params.require(:data)
 
     formatted_result = SupportRequestFormatterService.format template, data, current_user
 

--- a/platform-hub-api/app/models/announcement_template.rb
+++ b/platform-hub-api/app/models/announcement_template.rb
@@ -1,0 +1,58 @@
+class AnnouncementTemplate < ApplicationRecord
+
+  include FriendlyId
+  include Audited
+  include ValidateHashes
+
+  audited descriptor_field: :shortname
+
+  friendly_id :shortname, :use => :slugged
+
+  def should_generate_new_friendly_id?
+    shortname_changed? || super
+  end
+
+  validates :shortname,
+    presence: true,
+    uniqueness: { case_sensitive: false }
+
+  validates :description,
+    presence: true
+
+  validates :spec,
+    presence: true
+
+  class << self
+    attr_reader :form_field_types
+  end
+
+  @form_field_types = FormFieldsService.validate_types(Set[
+    'text',
+    'textarea',
+    'number',
+    'select',
+    'email',
+    'url'
+  ])
+
+  validate_hashes(
+    spec: {
+      schema: {
+        'fields' => [[
+          FormFieldsService.field_schema(AnnouncementTemplate.form_field_types)
+        ]],
+        'templates' => {
+          'title' => String,
+          'on_hub' => String,
+          'email_html' => String,
+          'email_text' => String,
+          'slack' => String
+        }
+      },
+      unique_checks: [
+        { array_path: 'fields', obj_key: 'id' }
+      ]
+    }
+  )
+
+end

--- a/platform-hub-api/app/serializers/announcement_template_serializer.rb
+++ b/platform-hub-api/app/serializers/announcement_template_serializer.rb
@@ -1,0 +1,15 @@
+class AnnouncementTemplateSerializer < ActiveModel::Serializer
+  attributes(
+    :id,
+    :shortname,
+    :description,
+    :created_at,
+    :updated_at
+  )
+
+  attribute :spec
+
+  def id
+    object.friendly_id
+  end
+end

--- a/platform-hub-api/app/services/announcement_formatter_service.rb
+++ b/platform-hub-api/app/services/announcement_formatter_service.rb
@@ -1,0 +1,37 @@
+module AnnouncementFormatterService
+
+  def self.format templates, data
+    results = {
+      title: templates['title'].clone,
+      on_hub: templates['on_hub'].clone,
+      email_html: templates['email_html'].clone,
+      email_text: templates['email_text'].clone,
+      slack: templates['slack'].clone
+    }
+    results.each do |_, template|
+      data.each do |field_name, field_value|
+        string_value = case field_value
+          when Array
+            field_value.join(', ')
+          else
+            field_value.to_s
+          end
+        interpolate! template, field_name, string_value
+      end
+    end
+    Results.new results
+  end
+
+  private_class_method def self.interpolate! string, field_name, field_value
+    string.gsub! "{{#{field_name}}}", field_value
+  end
+
+  class Results < Hashie::Dash
+    property :title, required: true
+    property :on_hub, required: true
+    property :email_html, required: true
+    property :email_text, required: true
+    property :slack, required: true
+  end
+
+end

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
 
     resources :announcement_templates do
       get :form_field_types, on: :collection
+      post :preview, on: :collection
     end
 
     resources :announcements do

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -68,6 +68,10 @@ Rails.application.routes.draw do
       except: [ :create ],
       constraints: { id: ContactList::ID_REGEX }
 
+    resources :announcement_templates do
+      get :form_field_types, on: :collection
+    end
+
     resources :announcements do
       get :global, on: :collection
       post :mark_sticky, on: :member

--- a/platform-hub-api/db/migrate/20170712132824_create_announcement_templates.rb
+++ b/platform-hub-api/db/migrate/20170712132824_create_announcement_templates.rb
@@ -1,0 +1,15 @@
+class CreateAnnouncementTemplates < ActiveRecord::Migration[5.0]
+  def change
+    create_table :announcement_templates, id: :uuid do |t|
+      t.string :shortname, null: false
+      t.string :slug, null: false
+      t.text :description, null: false
+      t.json :spec, null: false
+
+      t.timestamps
+
+      t.index :shortname, unique: true
+      t.index :slug, unique: true
+    end
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 9.6.1
--- Dumped by pg_dump version 9.6.3
+-- Dumped by pg_dump version 9.6.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -61,6 +61,21 @@ SET search_path = public, pg_catalog;
 SET default_tablespace = '';
 
 SET default_with_oids = false;
+
+--
+-- Name: announcement_templates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE announcement_templates (
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    shortname character varying NOT NULL,
+    slug character varying NOT NULL,
+    description text NOT NULL,
+    spec json NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
 
 --
 -- Name: announcements; Type: TABLE; Schema: public; Owner: -
@@ -378,6 +393,14 @@ ALTER TABLE ONLY read_marks ALTER COLUMN id SET DEFAULT nextval('read_marks_id_s
 
 
 --
+-- Name: announcement_templates announcement_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY announcement_templates
+    ADD CONSTRAINT announcement_templates_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: announcements announcements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -502,6 +525,20 @@ ALTER TABLE ONLY users
 --
 
 CREATE INDEX delayed_jobs_priority ON delayed_jobs USING btree (priority, run_at);
+
+
+--
+-- Name: index_announcement_templates_on_shortname; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_announcement_templates_on_shortname ON announcement_templates USING btree (shortname);
+
+
+--
+-- Name: index_announcement_templates_on_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_announcement_templates_on_slug ON announcement_templates USING btree (slug);
 
 
 --
@@ -746,6 +783,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170619125933'),
 ('20170621140022'),
 ('20170626134741'),
-('20170628103710');
+('20170628103710'),
+('20170712132824');
 
 

--- a/platform-hub-api/spec/controllers/announcement_templates_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/announcement_templates_controller_spec.rb
@@ -1,0 +1,270 @@
+require 'rails_helper'
+
+RSpec.describe AnnouncementTemplatesController, type: :controller do
+
+  include_context 'time helpers'
+
+  describe 'GET #index' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        get :index
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          get :index
+        end
+      end
+
+      it_behaves_like 'an admin' do
+
+        before do
+          @announcement_templates = create_list :announcement_template, 3
+        end
+
+        let :total_announcement_templates do
+          @announcement_templates.length
+        end
+
+        let :announcement_template_ids do
+          @announcement_templates.sort_by(&:shortname).map(&:friendly_id)
+        end
+
+        it 'should return a list of all announcement templates' do
+          get :index
+          expect(response).to be_success
+          expect(json_response.length).to eq total_announcement_templates
+          expect(pluck_from_json_response('id')).to eq announcement_template_ids
+        end
+
+      end
+
+    end
+  end
+
+  describe 'GET #show' do
+    before do
+      @announcement_template = create :announcement_template
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        get :show, params: { id: @announcement_template.friendly_id }
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          get :show, params: { id: @announcement_template.friendly_id }
+        end
+      end
+
+      it_behaves_like 'an admin' do
+
+        context 'for a non-existent announcement template' do
+          it 'should return a 404' do
+            get :show, params: { id: 'unknown' }
+            expect(response).to have_http_status(404)
+          end
+        end
+
+        context 'for a announcement template that exists' do
+          it 'should return the specified announcement template resource' do
+            get :show, params: { id: @announcement_template.friendly_id }
+            expect(response).to be_success
+            expect(json_response).to eq({
+              'id' => @announcement_template.friendly_id,
+              'shortname' => @announcement_template.shortname,
+              'description' => @announcement_template.description,
+              'spec' => Hashie::Mash.new(@announcement_template.spec),
+              'created_at' => now_json_value,
+              'updated_at' => now_json_value,
+            })
+          end
+        end
+
+      end
+
+    end
+  end
+
+  describe 'POST #create' do
+    let :post_data do
+      source_data = build :announcement_template
+
+      {
+        announcement_template: {
+          shortname: source_data.shortname,
+          description: source_data.description,
+          spec: source_data.spec
+        }
+      }
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        post :create, params: post_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          post :create, params: post_data
+        end
+      end
+
+      it_behaves_like 'an admin' do
+
+        it 'creates a new announcement template as expected' do
+          expect(AnnouncementTemplate.count).to eq 0
+          expect(Audit.count).to eq 0
+          post :create, params: post_data
+          expect(response).to be_success
+          expect(AnnouncementTemplate.count).to eq 1
+          announcement_template = AnnouncementTemplate.first
+          announcement_template_external_id = announcement_template.friendly_id
+          announcement_template_internal_id = announcement_template.id
+          expect(json_response).to eq({
+            'id' => announcement_template_external_id,
+            'shortname' => post_data[:announcement_template][:shortname],
+            'description' => post_data[:announcement_template][:description],
+            'spec' => Hashie::Mash.new(post_data[:announcement_template][:spec]),
+            'created_at' => now_json_value,
+            'updated_at' => now_json_value
+          });
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'create'
+          expect(audit.auditable.id).to eq announcement_template_internal_id
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+  describe 'PUT #update' do
+    let :put_data do
+      {
+        id: @announcement_template.friendly_id,
+        announcement_template: {
+          shortname: 'foo'
+        }
+      }
+    end
+
+    before do
+      @announcement_template = create :announcement_template
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        put :update, params: put_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          put :update, params: put_data
+        end
+      end
+
+      it_behaves_like 'an admin' do
+
+        it 'updates the specified announcement template' do
+          expect(AnnouncementTemplate.count).to eq 1
+          expect(Audit.count).to eq 0
+          put :update, params: put_data
+          expect(response).to be_success
+          expect(AnnouncementTemplate.count).to eq 1
+          updated = AnnouncementTemplate.first
+          expect(updated.shortname).to eq put_data[:announcement_template][:shortname]
+          expect(updated.description).to eq @announcement_template.description
+          expect(updated.spec).to eq Hashie::Mash.new(@announcement_template.spec)
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'update'
+          expect(audit.auditable.id).to eq @announcement_template.id
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before do
+      @announcement_template = create :announcement_template
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        delete :destroy, params: { id: @announcement_template.id }
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          delete :destroy, params: { id: @announcement_template.id }
+        end
+      end
+
+      it_behaves_like 'an admin' do
+
+        it 'should delete the specified announcement template' do
+          expect(AnnouncementTemplate.exists?(@announcement_template.id)).to be true
+          expect(Audit.count).to eq 0
+          delete :destroy, params: { id: @announcement_template.id }
+          expect(response).to be_success
+          expect(AnnouncementTemplate.exists?(@announcement_template.id)).to be false
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'destroy'
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+  describe 'GET #form_field_types' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        get :form_field_types
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not an admin so forbidden'  do
+        before do
+          get :form_field_types
+        end
+      end
+
+      it_behaves_like 'an admin' do
+        it 'should return the available form field types' do
+          get :form_field_types
+          expect(response).to be_success
+          expect(json_response).to eq AnnouncementTemplate.form_field_types.to_a
+        end
+      end
+
+    end
+  end
+
+end

--- a/platform-hub-api/spec/factories/announcement_templates.rb
+++ b/platform-hub-api/spec/factories/announcement_templates.rb
@@ -1,0 +1,42 @@
+FactoryGirl.define do
+  factory :announcement_template do
+    id { SecureRandom.uuid }
+
+    sequence :shortname do |n|
+      "Announcement Type #{n}"
+    end
+
+    description 'This is a template for an announcement'
+
+    transient do
+      fields_count 1
+      templates do
+        {
+          'title': 'Title {{field1}}',
+          'on_hub': 'On hub {{field1}}',
+          'email_html': 'Email HTML <p>{{field1}}</p>',
+          'email_text': 'Email text {{field1}}',
+          'slack': 'Slack {{field1}}'
+        }
+      end
+    end
+
+    after :build do |at, evaluator|
+      fields = evaluator.fields_count.times.map do |ix|
+        {
+          id: "field#{ix}",
+          label: "Field #{ix}",
+          field_type: 'text',
+          required: true,
+          placeholder: 'Type some fancy text',
+          help_text: 'Try to keep this as short as possible'
+        }
+      end
+
+      at.spec = {
+        fields: fields,
+        templates: evaluator.templates
+      }
+    end
+  end
+end

--- a/platform-hub-api/spec/models/announcement_template_spec.rb
+++ b/platform-hub-api/spec/models/announcement_template_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe AnnouncementTemplate, type: :model do
+
+  it_behaves_like "validates hashes"
+
+end

--- a/platform-hub-api/spec/routing/announcement_templates_routing_spec.rb
+++ b/platform-hub-api/spec/routing/announcement_templates_routing_spec.rb
@@ -31,5 +31,9 @@ RSpec.describe AnnouncementTemplatesController, type: :routing do
       expect(:get => '/announcement_templates/form_field_types').to route_to('announcement_templates#form_field_types')
     end
 
+    it 'routes to #preview' do
+      expect(:post => '/announcement_templates/preview').to route_to('announcement_templates#preview')
+    end
+
   end
 end

--- a/platform-hub-api/spec/routing/announcement_templates_routing_spec.rb
+++ b/platform-hub-api/spec/routing/announcement_templates_routing_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe AnnouncementTemplatesController, type: :routing do
+  describe 'routing' do
+
+    it 'routes to #index' do
+      expect(:get => '/announcement_templates').to route_to('announcement_templates#index')
+    end
+
+    it 'routes to #show' do
+      expect(:get => '/announcement_templates/1').to route_to('announcement_templates#show', :id => '1')
+    end
+
+    it 'routes to #create' do
+      expect(:post => '/announcement_templates').to route_to('announcement_templates#create')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(:put => '/announcement_templates/1').to route_to('announcement_templates#update', :id => '1')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(:patch => '/announcement_templates/1').to route_to('announcement_templates#update', :id => '1')
+    end
+
+    it 'routes to #destroy' do
+      expect(:delete => '/announcement_templates/1').to route_to('announcement_templates#destroy', :id => '1')
+    end
+
+    it 'routes to #form_field_types' do
+      expect(:get => '/announcement_templates/form_field_types').to route_to('announcement_templates#form_field_types')
+    end
+
+  end
+end

--- a/platform-hub-api/spec/services/announcement_formatter_service_spec.rb
+++ b/platform-hub-api/spec/services/announcement_formatter_service_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+describe AnnouncementFormatterService, type: :service do
+
+  describe '.format' do
+
+    let :title_template do
+      'Hello {{user_name}}'
+    end
+
+    let :on_hub_template do
+      <<~TEXT
+        Today we release {{service_names}} on to the world
+
+        This your chance to be a pioneer, {{user_name}}!
+      TEXT
+    end
+
+    let :email_html_template do
+      <<~HTML
+        <div>
+          Today we release {{service_names}} on to the world
+        </div>
+        <br />
+        <div>This your chance to be a pioneer, {{user_name}}!</div>
+      HTML
+    end
+
+    let :email_text_template do
+      <<~TEXT
+        Today we release {{service_names}} on to the world
+
+        This your chance to be a pioneer, {{user_name}}!
+      TEXT
+    end
+
+    let :slack_template do
+      'NOTHING'
+    end
+
+    let :templates do
+      {
+        'title' => title_template,
+        'on_hub' => on_hub_template,
+        'email_html' => email_html_template,
+        'email_text' => email_text_template,
+        'slack' => slack_template
+      }
+    end
+
+    let :data do
+      {
+        user_name: 'foo',
+        service_names: [ 'bar', 'soap' ]
+      }
+    end
+
+    let :title_result do
+      'Hello foo'
+    end
+
+    let :on_hub_result do
+      <<~TEXT
+        Today we release bar, soap on to the world
+
+        This your chance to be a pioneer, foo!
+      TEXT
+    end
+
+    let :email_html_result do
+      <<~HTML
+        <div>
+          Today we release bar, soap on to the world
+        </div>
+        <br />
+        <div>This your chance to be a pioneer, foo!</div>
+      HTML
+    end
+
+    let :email_text_result do
+      <<~TEXT
+        Today we release bar, soap on to the world
+
+        This your chance to be a pioneer, foo!
+      TEXT
+    end
+
+    let :slack_result do
+      'NOTHING'
+    end
+
+    let :results do
+      AnnouncementFormatterService::Results.new(
+        title: title_result,
+        on_hub: on_hub_result,
+        email_html: email_html_result,
+        email_text: email_text_result,
+        slack: slack_result
+      )
+    end
+
+    it 'should apply the fields data to the templates and produce the expected output results' do
+      expect(AnnouncementFormatterService.format(templates, data)).to eq results
+    end
+  end
+
+end

--- a/platform-hub-web/src/app/announcements/announcements.module.js
+++ b/platform-hub-web/src/app/announcements/announcements.module.js
@@ -2,18 +2,27 @@ import angular from 'angular';
 
 import {AnnouncementsEditorFormComponent} from './editor/announcements-editor-form.component';
 import {AnnouncementsEditorListComponent} from './editor/announcements-editor-list.component';
+import {AnnouncementTemplatesDetailComponent} from './templates/announcement-templates-detail.component';
+import {AnnouncementTemplatesFormComponent} from './templates/announcement-templates-form.component';
+import {AnnouncementTemplatesListComponent} from './templates/announcement-templates-list.component';
 import {GlobalAnnouncementsComponent} from './global-announcements.component';
 import {StickyAnnouncementsComponent} from './sticky-announcements.component';
 
 // Main section component names
 export const AnnouncementsEditorForm = 'announcementsEditorForm';
 export const AnnouncementsEditorList = 'announcementsEditorList';
+export const AnnouncementTemplatesDetail = 'announcementTemplatesDetail';
+export const AnnouncementTemplatesForm = 'announcementTemplatesForm';
+export const AnnouncementTemplatesList = 'announcementTemplatesList';
 export const GlobalAnnouncements = 'globalAnnouncements';
 
 export const AnnouncementsModule = angular
   .module('app.announcements', [])
   .component(AnnouncementsEditorForm, AnnouncementsEditorFormComponent)
   .component(AnnouncementsEditorList, AnnouncementsEditorListComponent)
+  .component(AnnouncementTemplatesDetail, AnnouncementTemplatesDetailComponent)
+  .component(AnnouncementTemplatesForm, AnnouncementTemplatesFormComponent)
+  .component(AnnouncementTemplatesList, AnnouncementTemplatesListComponent)
   .component(GlobalAnnouncements, GlobalAnnouncementsComponent)
   .component('stickyAnnouncements', StickyAnnouncementsComponent)
   .name;

--- a/platform-hub-web/src/app/announcements/announcements.module.js
+++ b/platform-hub-web/src/app/announcements/announcements.module.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 
 import {AnnouncementsEditorFormComponent} from './editor/announcements-editor-form.component';
 import {AnnouncementsEditorListComponent} from './editor/announcements-editor-list.component';
+import {AnnouncementTemplatePreviewPopupController} from './templates/announcement-template-preview-popup.controller';
+import {announcementTemplatePreviewPopupService} from './templates/announcement-template-preview-popup.service';
 import {AnnouncementTemplatesDetailComponent} from './templates/announcement-templates-detail.component';
 import {AnnouncementTemplatesFormComponent} from './templates/announcement-templates-form.component';
 import {AnnouncementTemplatesListComponent} from './templates/announcement-templates-list.component';
@@ -20,6 +22,8 @@ export const AnnouncementsModule = angular
   .module('app.announcements', [])
   .component(AnnouncementsEditorForm, AnnouncementsEditorFormComponent)
   .component(AnnouncementsEditorList, AnnouncementsEditorListComponent)
+  .controller('AnnouncementTemplatePreviewPopupController', AnnouncementTemplatePreviewPopupController)
+  .service('announcementTemplatePreviewPopupService', announcementTemplatePreviewPopupService)
   .component(AnnouncementTemplatesDetail, AnnouncementTemplatesDetailComponent)
   .component(AnnouncementTemplatesForm, AnnouncementTemplatesFormComponent)
   .component(AnnouncementTemplatesList, AnnouncementTemplatesListComponent)

--- a/platform-hub-web/src/app/announcements/templates/announcement-template-preview-popup.controller.js
+++ b/platform-hub-web/src/app/announcements/templates/announcement-template-preview-popup.controller.js
@@ -1,0 +1,27 @@
+export const AnnouncementTemplatePreviewPopupController = function ($mdDialog, fields, templates, hubApiService) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.processing = false;
+  ctrl.fields = fields;
+  ctrl.data = {};
+  ctrl.results = null;
+
+  ctrl.finish = $mdDialog.hide;
+  ctrl.preview = preview;
+
+  function preview() {
+    ctrl.processing = true;
+    ctrl.results = null;
+
+    hubApiService
+      .previewAnnouncementTemplate(templates, ctrl.data)
+      .then(results => {
+        ctrl.results = results;
+      })
+      .finally(() => {
+        ctrl.processing = false;
+      });
+  }
+};

--- a/platform-hub-web/src/app/announcements/templates/announcement-template-preview-popup.html
+++ b/platform-hub-web/src/app/announcements/templates/announcement-template-preview-popup.html
@@ -1,0 +1,127 @@
+<md-dialog aria-label="Announcement template preview" flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50">
+  <md-toolbar class="md-toolbar-tools md-accent">
+    <h2>Preview an announcement template</h2>
+    <span flex></span>
+    <md-button
+      class="close-button md-icon-button"
+      ng-click="$ctrl.finish()"
+      aria-label="Close popup">
+      <md-icon>clear</md-icon>
+    </md-button>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.processing"></loading-indicator>
+
+  <md-dialog-content class="md-dialog-content" layout="column" layout-padding>
+
+    <div md-whiteframe="2" flex="100">
+      <form name="$ctrl.form">
+        <form-field
+          ng-repeat="field in $ctrl.fields track by field.id"
+          spec="field"
+          value="$ctrl.data[field.id]",
+          form="$ctrl.form">
+        </form-field>
+
+        <div layout="row" layout-align="center center">
+          <md-button
+            class="md-primary"
+            ng-disabled="$ctrl.processing || $ctrl.form.$invalid"
+            ng-class="{'md-raised': ($ctrl.form.$dirty && $ctrl.form.$valid) }"
+            aria-label="Preview the output results for this template"
+            ng-click="$ctrl.preview()">
+            Preview
+          </md-button>
+        </div>
+      </form>
+    </div>
+
+    <div ng-if="$ctrl.results">
+      <br />
+      <br />
+
+      <h4 class="md-subhead centred">Output</h4>
+
+      <div>
+        <p class="md-body-1" md-colors="{color: 'default-blue-grey-700'}">
+          Title:
+        </p>
+        <p
+          class="md-body-1"
+          md-colors="{background: 'default-blue-grey-50'}"
+          ng-bind-html='$ctrl.results.title | simpleFormat'
+          layout-padding>
+        </p>
+      </div>
+
+      <br />
+
+      <div>
+        <p class="md-body-1" md-colors="{color: 'default-blue-grey-700'}">
+          On hub:
+        </p>
+        <p
+          class="md-body-1"
+          md-colors="{background: 'default-blue-grey-50'}"
+          ng-bind-html='$ctrl.results.on_hub'
+          layout-padding>
+        </p>
+      </div>
+
+      <br />
+
+      <div>
+        <p class="md-body-1" md-colors="{color: 'default-blue-grey-700'}">
+          HTML email:
+        </p>
+        <p
+          class="md-body-1"
+          md-colors="{background: 'default-blue-grey-50'}"
+          ng-bind-html='$ctrl.results.email_html'
+          layout-padding>
+        </p>
+        <p class="md-body-2">
+          NOTE: actual HTML rendering will depend on email clients!
+        </p>
+      </div>
+
+      <br />
+
+      <div>
+        <p class="md-body-1" md-colors="{color: 'default-blue-grey-700'}">
+          Text email:
+        </p>
+        <p
+          class="md-body-1"
+          md-colors="{background: 'default-blue-grey-50'}"
+          ng-bind-html='$ctrl.results.email_text | simpleFormat'
+          layout-padding>
+        </p>
+      </div>
+
+      <br />
+
+      <div>
+        <p class="md-body-1" md-colors="{color: 'default-blue-grey-700'}">
+          Slack:
+        </p>
+        <p
+          class="md-body-1"
+          md-colors="{background: 'default-blue-grey-50'}"
+          ng-bind-html='$ctrl.results.slack | simpleFormat'
+          layout-padding>
+        </p>
+      </div>
+    </div>
+
+  </md-dialog-content>
+
+  <md-dialog-actions>
+    <md-button
+      class="md-primary"
+      ng-click="$ctrl.finish()"
+      aria-label="Finish">
+      Finish
+    </md-button>
+  </md-dialog-actions>
+</md-dialog>

--- a/platform-hub-web/src/app/announcements/templates/announcement-template-preview-popup.service.js
+++ b/platform-hub-web/src/app/announcements/templates/announcement-template-preview-popup.service.js
@@ -1,0 +1,25 @@
+export const announcementTemplatePreviewPopupService = function ($document, $mdDialog) {
+  'ngInject';
+
+  const service = {};
+
+  service.open = function (fields, templates, targetEvent) {
+    return $mdDialog.show({
+      template: require('./announcement-template-preview-popup.html'),
+      controller: 'AnnouncementTemplatePreviewPopupController',
+      controllerAs: '$ctrl',
+      bindToController: true,
+      parent: angular.element($document.body),
+      targetEvent: targetEvent,  // eslint-disable-line object-shorthand
+      clickOutsideToClose: false,
+      escapeToClose: false,
+      fullscreen: true,
+      locals: {
+        fields,
+        templates
+      }
+    });
+  };
+
+  return service;
+};

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-detail.component.js
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-detail.component.js
@@ -6,7 +6,7 @@ export const AnnouncementTemplatesDetailComponent = {
   controller: AnnouncementTemplatesDetailController
 };
 
-function AnnouncementTemplatesDetailController($mdDialog, $state, hubApiService, logger) {
+function AnnouncementTemplatesDetailController($mdDialog, $state, hubApiService, announcementTemplatePreviewPopupService, logger) {
   'ngInject';
 
   const ctrl = this;
@@ -17,6 +17,7 @@ function AnnouncementTemplatesDetailController($mdDialog, $state, hubApiService,
   ctrl.template = null;
 
   ctrl.deleteTemplate = deleteTemplate;
+  ctrl.triggerPreview = triggerPreview;
 
   init();
 
@@ -62,5 +63,13 @@ function AnnouncementTemplatesDetailController($mdDialog, $state, hubApiService,
             ctrl.loading = false;
           });
       });
+  }
+
+  function triggerPreview(targetEvent) {
+    announcementTemplatePreviewPopupService.open(
+      ctrl.template.spec.fields,
+      ctrl.template.spec.templates,
+      targetEvent
+    );
   }
 }

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-detail.component.js
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-detail.component.js
@@ -1,0 +1,66 @@
+export const AnnouncementTemplatesDetailComponent = {
+  bindings: {
+    transition: '<'
+  },
+  template: require('./announcement-templates-detail.html'),
+  controller: AnnouncementTemplatesDetailController
+};
+
+function AnnouncementTemplatesDetailController($mdDialog, $state, hubApiService, logger) {
+  'ngInject';
+
+  const ctrl = this;
+
+  const id = ctrl.transition.params().id;
+
+  ctrl.loading = true;
+  ctrl.template = null;
+
+  ctrl.deleteTemplate = deleteTemplate;
+
+  init();
+
+  function init() {
+    loadTemplate();
+  }
+
+  function loadTemplate() {
+    ctrl.loading = true;
+    ctrl.template = null;
+
+    hubApiService
+      .getAnnouncementTemplate(id)
+      .then(template => {
+        ctrl.template = template;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function deleteTemplate(targetEvent) {
+    const confirm = $mdDialog.confirm()
+      .title('Are you sure?')
+      .textContent('This will delete the announcement template permanently from the hub.')
+      .ariaLabel('Confirm deletion of announcement template')
+      .targetEvent(targetEvent)
+      .ok('Do it')
+      .cancel('Cancel');
+
+    $mdDialog
+      .show(confirm)
+      .then(() => {
+        ctrl.loading = true;
+
+        hubApiService
+          .deleteAnnouncementTemplate(ctrl.template.id)
+          .then(() => {
+            logger.success('Announcement template deleted');
+            $state.go('announcements.templates.list');
+          })
+          .finally(() => {
+            ctrl.loading = false;
+          });
+      });
+  }
+}

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-detail.html
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-detail.html
@@ -1,0 +1,129 @@
+<div class="announcement-templates-detail">
+  <md-toolbar md-scroll-shrink>
+    <div class="md-toolbar-tools">
+      <h3>
+        <span>Announcement Template: </span>
+        <span ng-cloak>{{$ctrl.template.shortname}}</span>
+      </h3>
+      <span flex></span>
+      <md-button
+        ng-if="$ctrl.template"
+        aria-label="Edit this announcement template"
+        ui-sref="announcements.templates.edit({id: $ctrl.template.id})">
+        <md-icon>edit</md-icon>
+        Edit
+      </md-button>
+      <md-button
+        ng-if="$ctrl.template"
+        aria-label="Delete this announcement template"
+        ng-click="$ctrl.deleteTemplate($event)">
+        <md-icon>delete</md-icon>
+        Delete
+      </md-button>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading"></loading-indicator>
+
+  <md-content layout-padding ng-if="!$ctrl.loading && $ctrl.template">
+
+    <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z2">
+      <md-content layout-padding>
+
+        <h3 class="md-title" layout="row">
+          {{$ctrl.template.shortname}}
+        </h3>
+
+        <p
+          class="md-body-1"
+          md-colors="{background: 'blue-grey-50'}"
+          ng-if="$ctrl.template.description"
+          ng-bind-html='$ctrl.template.description | simpleFormat'>
+        </p>
+
+        <br />
+
+        <md-divider></md-divider>
+
+        <div>
+          <fields-listings
+            title="Fields to fill in for the announcement"
+            fields="$ctrl.template.spec.fields">
+          </field-listings>
+        </div>
+
+        <br />
+        <md-divider></md-divider>
+
+        <div>
+          <h5 md-colors="{color: 'blue-grey-700'}">
+            Template definitions:
+          </h5>
+
+          <div>
+            <p class="md-body-1" md-colors="{color: 'blue-grey-700'}">
+              Title:
+            </p>
+            <p
+              class="md-body-1"
+              md-colors="{background: 'blue-grey-50'}"
+              ng-bind-html='$ctrl.template.spec.templates.title | simpleFormat'
+              layout-padding>
+            </p>
+          </div>
+
+          <div>
+            <p class="md-body-1" md-colors="{color: 'blue-grey-700'}">
+              On hub:
+            </p>
+            <p
+              class="md-body-1"
+              md-colors="{background: 'blue-grey-50'}"
+              ng-bind-html='$ctrl.template.spec.templates.on_hub | simpleFormat'
+              layout-padding>
+            </p>
+          </div>
+
+          <div>
+            <p class="md-body-1" md-colors="{color: 'blue-grey-700'}">
+              HTML email:
+            </p>
+            <p
+              class="md-body-1"
+              md-colors="{background: 'blue-grey-50'}"
+              ng-bind-html='$ctrl.template.spec.templates.email_html | simpleFormat'
+              layout-padding>
+            </p>
+          </div>
+
+          <div>
+            <p class="md-body-1" md-colors="{color: 'blue-grey-700'}">
+              Text email:
+            </p>
+            <p
+              class="md-body-1"
+              md-colors="{background: 'blue-grey-50'}"
+              ng-bind-html='$ctrl.template.spec.templates.email_text | simpleFormat'
+              layout-padding>
+            </p>
+          </div>
+
+          <div>
+            <p class="md-body-1" md-colors="{color: 'blue-grey-700'}">
+              Slack:
+            </p>
+            <p
+              class="md-body-1"
+              md-colors="{background: 'blue-grey-50'}"
+              ng-bind-html='$ctrl.template.spec.templates.slack | simpleFormat'
+              layout-padding>
+            </p>
+          </div>
+
+        </div>
+
+      </md-content>
+    </div>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-detail.html
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-detail.html
@@ -119,7 +119,15 @@
               layout-padding>
             </p>
           </div>
+        </div>
 
+        <div layout="row" layout-align="center center">
+          <md-button
+            class="md-accent md-raised"
+            aria-label="Preview the output results for this template"
+            ng-click="$ctrl.triggerPreview($event)">
+            Open Previewer
+          </md-button>
         </div>
 
       </md-content>

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-form.component.js
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-form.component.js
@@ -8,7 +8,7 @@ export const AnnouncementTemplatesFormComponent = {
   controller: AnnouncementTemplatesFormController
 };
 
-function AnnouncementTemplatesFormController($state, hubApiService, formFieldsValidator, logger) {
+function AnnouncementTemplatesFormController($state, hubApiService, formFieldsValidator, announcementTemplatePreviewPopupService, logger) {
   'ngInject';
 
   const ctrl = this;
@@ -23,6 +23,7 @@ function AnnouncementTemplatesFormController($state, hubApiService, formFieldsVa
   ctrl.template = null;
 
   ctrl.createOrUpdate = createOrUpdate;
+  ctrl.triggerPreview = triggerPreview;
 
   init();
 
@@ -109,6 +110,14 @@ function AnnouncementTemplatesFormController($state, hubApiService, formFieldsVa
           ctrl.saving = false;
         });
     }
+  }
+
+  function triggerPreview(targetEvent) {
+    announcementTemplatePreviewPopupService.open(
+      ctrl.template.spec.fields,
+      ctrl.template.spec.templates,
+      targetEvent
+    );
   }
 
   function validate(template) {

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-form.component.js
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-form.component.js
@@ -8,7 +8,7 @@ export const AnnouncementTemplatesFormComponent = {
   controller: AnnouncementTemplatesFormController
 };
 
-function AnnouncementTemplatesFormController($state, hubApiService, formFieldsValidator, announcementTemplatePreviewPopupService, logger) {
+function AnnouncementTemplatesFormController($state, hubApiService, announcementTemplateValidator, announcementTemplatePreviewPopupService, logger) {
   'ngInject';
 
   const ctrl = this;
@@ -81,7 +81,7 @@ function AnnouncementTemplatesFormController($state, hubApiService, formFieldsVa
       return;
     }
 
-    const errors = validate(ctrl.template);
+    const errors = announcementTemplateValidator.validator(ctrl.template);
     if (errors.length > 0) {
       logger.error(errors.join('<br />'));
       return;
@@ -118,9 +118,5 @@ function AnnouncementTemplatesFormController($state, hubApiService, formFieldsVa
       ctrl.template.spec.templates,
       targetEvent
     );
-  }
-
-  function validate(template) {
-    return formFieldsValidator.validate(template.spec.fields);
   }
 }

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-form.component.js
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-form.component.js
@@ -1,0 +1,117 @@
+/* eslint camelcase: 0 */
+
+export const AnnouncementTemplatesFormComponent = {
+  bindings: {
+    transition: '<'
+  },
+  template: require('./announcement-templates-form.html'),
+  controller: AnnouncementTemplatesFormController
+};
+
+function AnnouncementTemplatesFormController($state, hubApiService, formFieldsValidator, logger) {
+  'ngInject';
+
+  const ctrl = this;
+
+  const id = ctrl.transition && ctrl.transition.params().id;
+
+  ctrl.ready = false;
+  ctrl.loading = true;
+  ctrl.saving = false;
+  ctrl.isNew = true;
+  ctrl.formFieldTypes = null;
+  ctrl.template = null;
+
+  ctrl.createOrUpdate = createOrUpdate;
+
+  init();
+
+  function init() {
+    ctrl.isNew = !id;
+
+    loadFormFieldTypes();
+
+    if (ctrl.isNew) {
+      ctrl.template = initEmptyTemplate();
+      ctrl.loading = false;
+    } else {
+      loadTemplate();
+    }
+  }
+
+  function initEmptyTemplate() {
+    return {
+      spec: {
+        fields: [],
+        templates: {}
+      }
+    };
+  }
+
+  function loadFormFieldTypes() {
+    ctrl.ready = false;
+    ctrl.formFieldTypes = null;
+
+    hubApiService
+      .getAnnouncementTemplateFormFieldTypes()
+      .then(types => {
+        ctrl.formFieldTypes = types;
+        ctrl.ready = true;
+      });
+  }
+
+  function loadTemplate() {
+    ctrl.loading = true;
+    ctrl.template = null;
+
+    hubApiService
+      .getAnnouncementTemplate(id)
+      .then(template => {
+        ctrl.template = template;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function createOrUpdate() {
+    if (ctrl.templateForm.$invalid) {
+      logger.error('Check the form for issues before saving');
+      return;
+    }
+
+    const errors = validate(ctrl.template);
+    if (errors.length > 0) {
+      logger.error(errors.join('<br />'));
+      return;
+    }
+
+    ctrl.saving = true;
+
+    if (ctrl.isNew) {
+      hubApiService
+        .createAnnouncementTemplate(ctrl.template)
+        .then(template => {
+          logger.success('New annnouncement template created');
+          $state.go('announcements.templates.detail', {id: template.id});
+        })
+        .finally(() => {
+          ctrl.saving = false;
+        });
+    } else {
+      hubApiService
+        .updateAnnouncementTemplate(ctrl.template.id, ctrl.template)
+        .then(template => {
+          logger.success('Announcement template updated');
+          $state.go('announcements.templates.detail', {id: template.id});
+        })
+        .finally(() => {
+          ctrl.saving = false;
+        });
+    }
+  }
+
+  function validate(template) {
+    return formFieldsValidator.validate(template.spec.fields);
+  }
+}

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-form.html
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-form.html
@@ -126,7 +126,16 @@
             </md-input-container>
           </fieldset>
 
-          <br />
+          <div layout="row" layout-align="center center">
+            <md-button
+              class="md-accent md-raised"
+              aria-label="Preview the output results for this template"
+              ng-click="$ctrl.triggerPreview($event)"
+              ng-disabled="!$ctrl.template.spec.fields || $ctrl.template.spec.fields.length == 0">
+              Open Previewer
+            </md-button>
+          </div>
+
           <br />
 
           <div>

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-form.html
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-form.html
@@ -1,0 +1,150 @@
+<div class="announcement-templates-form">
+  <md-toolbar md-scroll-shrink>
+    <div class="md-toolbar-tools">
+      <h3>
+        <span ng-if="$ctrl.isNew">New Announcement Template</span>
+        <span ng-if="!$ctrl.isNew">Edit Announcement Template</span>
+      </h3>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading || $ctrl.saving"></loading-indicator>
+
+  <md-content layout-padding ng-if="$ctrl.ready && !$ctrl.loading">
+
+    <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z2" layout-padding>
+      <md-content>
+        <form name="$ctrl.templateForm" role="form" ng-submit="$ctrl.createOrUpdate()">
+
+          <md-input-container class="md-block">
+            <label for="shortname">Shortname:</label>
+            <input
+              name="shortname"
+              ng-model="$ctrl.template.shortname"
+              required
+              placeholder="A short and memorable name for this template, e.g. 'Service downtime'">
+            <div ng-messages="$ctrl.templateForm.shortname.$error">
+              <div ng-message="required">This is required.</div>
+            </div>
+          </md-input-container>
+
+          <md-input-container class="md-block">
+            <label for="description">Description:</label>
+            <textarea
+              name="description"
+              ng-model="$ctrl.template.description"
+              rows="4"
+              required
+              md-select-on-focus>
+            </textarea>
+            <div ng-messages="$ctrl.templateForm.description.$error">
+              <div ng-message="required">This is required.</div>
+            </div>
+          </md-input-container>
+
+          <fields-editor
+            title="Fields to fill in for the announcement"
+            field-types="$ctrl.formFieldTypes"
+            fields="$ctrl.template.spec.fields"
+            form="$ctrl.templateForm">
+          </fields-editor>
+
+          <br />
+          <br />
+
+          <fieldset>
+            <legend>Template definitions</legend>
+
+            <md-input-container class="md-block">
+              <label for="templates_title">For the title (same across all formats):</label>
+              <textarea
+                name="templates_title"
+                ng-model="$ctrl.template.spec.templates.title"
+                rows="2"
+                required
+                aria-label="Template definition for the title">
+              </textarea>
+              <div ng-messages="$ctrl.templateForm.templates_title.$error">
+                <div ng-message="required">This is required.</div>
+              </div>
+            </md-input-container>
+
+            <md-input-container class="md-block">
+              <label for="templates_on_hub">Displaying on the hub (HTML allowed):</label>
+              <textarea
+                name="templates_on_hub"
+                ng-model="$ctrl.template.spec.templates.on_hub"
+                rows="10"
+                required
+                aria-label="Template definition for displaying on the hub">
+              </textarea>
+              <div ng-messages="$ctrl.templateForm.templates_on_hub.$error">
+                <div ng-message="required">This is required.</div>
+              </div>
+            </md-input-container>
+
+            <md-input-container class="md-block">
+              <label for="templates_email_html">For email HTML:</label>
+              <textarea
+                name="templates_email_html"
+                ng-model="$ctrl.template.spec.templates.email_html"
+                rows="10"
+                required
+                aria-label="Template definition for email HTML">
+              </textarea>
+              <div ng-messages="$ctrl.templateForm.templates_email_html.$error">
+                <div ng-message="required">This is required.</div>
+              </div>
+            </md-input-container>
+
+            <md-input-container class="md-block">
+              <label for="templates_email_text">For email text only:</label>
+              <textarea
+                name="templates_email_text"
+                ng-model="$ctrl.template.spec.templates.email_text"
+                rows="10"
+                required
+                aria-label="Template definition for email text only">
+              </textarea>
+              <div ng-messages="$ctrl.templateForm.templates_email_text.$error">
+                <div ng-message="required">This is required.</div>
+              </div>
+            </md-input-container>
+
+            <md-input-container class="md-block">
+              <label for="templates_slack">For Slack:</label>
+              <textarea
+                name="templates_slack"
+                ng-model="$ctrl.template.spec.templates.slack"
+                rows="10"
+                required
+                aria-label="Template definition for Slack messages">
+              </textarea>
+              <div ng-messages="$ctrl.templateForm.templates_slack.$error">
+                <div ng-message="required">This is required.</div>
+              </div>
+            </md-input-container>
+          </fieldset>
+
+          <br />
+          <br />
+
+          <div>
+            <md-button
+              type="submit"
+              class="md-primary"
+              ng-disabled="$ctrl.saving || $ctrl.templateForm.$invalid"
+              ng-class="{'md-raised': ($ctrl.templateForm.$dirty && $ctrl.templateForm.$valid) }"
+              aria-label="Save announcement template">
+              <span ng-if="$ctrl.isNew">Create</span>
+              <span ng-if="!$ctrl.isNew">Update</span>
+            </md-button>
+            <md-button ui-sref="announcements.templates.list" ng-disabled="$ctrl.saving">Cancel</md-button>
+          </div>
+
+        </form>
+      </md-content>
+    </div>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-list.component.js
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-list.component.js
@@ -1,0 +1,34 @@
+export const AnnouncementTemplatesListComponent = {
+  template: require('./announcement-templates-list.html'),
+  controller: AnnouncementTemplatesListController
+};
+
+function AnnouncementTemplatesListController(hubApiService) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.loading = false;
+
+  ctrl.templates = [];
+
+  init();
+
+  function init() {
+    loadTemplates();
+  }
+
+  function loadTemplates() {
+    ctrl.loading = true;
+    ctrl.templates = [];
+
+    hubApiService
+      .getAnnouncementTemplates()
+      .then(templates => {
+        ctrl.templates = templates;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+}

--- a/platform-hub-web/src/app/announcements/templates/announcement-templates-list.html
+++ b/platform-hub-web/src/app/announcements/templates/announcement-templates-list.html
@@ -1,13 +1,13 @@
-<div class="support-request-templates-list">
+<div class="announcement-templates-list">
   <md-toolbar md-scroll-shrink>
     <div class="md-toolbar-tools">
       <h3>
-        <span>All Support Request Templates</span>
+        <span>All Announcement Templates</span>
       </h3>
       <span flex></span>
       <md-button
-        aria-label="Add new support request template"
-        ui-sref="help.support.request-templates.new">
+        aria-label="Add new announcement template"
+        ui-sref="announcements.templates.new">
         <md-icon>add_box</md-icon>
         New
       </md-button>
@@ -22,61 +22,53 @@
       <md-card-title>
         <md-card-title-text>
           <span class="md-headline">
-            {{t.title}}
+            {{t.shortname}}
           </span>
         </md-card-title-text>
       </md-card-title>
 
       <md-card-content>
-        <p class="md-body-1">
-          <span md-colors="{color: 'blue-grey-700'}">
-            Shortname (not shown to users):
-          </span>
-          {{t.shortname}}
-        </p>
-
-        <p class="md-body-1">
-          <span md-colors="{color: 'blue-grey-700'}">
-            Target GitHub repo:
-          </span>
-          {{t.git_hub_repo}}
-        </p>
-
-        <p class="md-body-1">
-          <span md-colors="{color: 'blue-grey-700'}">
-            User scope:
-          </span>
-          {{t.user_scope || '--'}}
+        <p
+          class="md-body-1"
+          md-colors="{background: 'blue-grey-50'}"
+          ng-if="t.description"
+          ng-bind-html='t.description | simpleFormat'
+          layout-padding>
         </p>
 
         <p class="md-body-1">
           <span md-colors="{color: 'blue-grey-700'}">
             <ng-pluralize
-              count="t.form_spec.fields.length"
+              count="t.spec.fields.length"
               when="{'0': 'No fields specified',
               '1': '1 field specified: ',
               'other': '{} fields specified: '}">
             </ng-pluralize>
           </span>
 
-          <span ng-repeat="f in t.form_spec.fields track by f.id">
+          <span ng-repeat="f in t.spec.fields track by f.id">
             <span>{{f.id}}</span><span ng-if="!$last">, </span>
           </span>
         </p>
 
-        <p class="md-body-1">
-          <span md-colors="{color: 'blue-grey-700'}">
-            GitHub issue title:
-          </span>
-          {{t.git_hub_issue_spec.title_text}}
-        </p>
+        <div>
+          <p class="md-body-1" md-colors="{color: 'blue-grey-700'}">
+            Title template:
+          </p>
+          <p
+            class="md-body-1"
+            md-colors="{background: 'blue-grey-50'}"
+            ng-bind-html='t.spec.templates.title | simpleFormat'
+            layout-padding>
+          </p>
+        </div>
       </md-card-content>
 
       <md-card-actions layout="row" layout-align="start center">
         <md-button
           class="md-primary"
-          aria-label="View details for this support request template"
-          ui-sref="help.support.request-templates.detail({id: t.id})">
+          aria-label="View details of this announcement template"
+          ui-sref="announcements.templates.detail({id: t.id})">
           Details
         </md-button>
       </md-card-actions>

--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -1,6 +1,9 @@
 import {
   AnnouncementsEditorForm,
   AnnouncementsEditorList,
+  AnnouncementTemplatesDetail,
+  AnnouncementTemplatesForm,
+  AnnouncementTemplatesList,
   GlobalAnnouncements
 } from './announcements/announcements.module';
 import {AppSettingsForm} from './app-settings/app-settings.module';
@@ -414,5 +417,48 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         data: {
           authenticate: true
         }
-      });
+      })
+      .state('announcements.templates', {
+        abstract: true,
+        url: '/templates',
+        template: '<ui-view></ui-view>'
+      })
+        .state('announcements.templates.list', {
+          url: '/list',
+          component: AnnouncementTemplatesList,
+          data: {
+            authenticate: true,
+            rolePermitted: 'admin'
+          }
+        })
+        .state('announcements.templates.detail', {
+          url: '/detail/:id',
+          component: AnnouncementTemplatesDetail,
+          resolve: {
+            transition: '$transition$'
+          },
+          data: {
+            authenticate: true,
+            rolePermitted: 'admin'
+          }
+        })
+        .state('announcements.templates.new', {
+          url: '/new',
+          component: AnnouncementTemplatesForm,
+          data: {
+            authenticate: true,
+            rolePermitted: 'admin'
+          }
+        })
+        .state('announcements.templates.edit', {
+          url: '/edit/:id',
+          component: AnnouncementTemplatesForm,
+          resolve: {
+            transition: '$transition$'
+          },
+          data: {
+            authenticate: true,
+            rolePermitted: 'admin'
+          }
+        });
 };

--- a/platform-hub-web/src/app/layout/shell.component.js
+++ b/platform-hub-web/src/app/layout/shell.component.js
@@ -92,6 +92,12 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
       icon: ctrl.announcementsIcon
     },
     {
+      title: 'Announcement Templates',
+      state: 'announcements.templates.list',
+      activeState: 'announcements.templates',
+      icon: ctrl.announcementsIcon
+    },
+    {
       title: 'Users',
       state: 'users',
       icon: icons.users

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -72,6 +72,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.updateAnnouncementTemplate = buildResourceUpdater('announcement_templates');
   service.deleteAnnouncementTemplate = buildResourceDeletor('announcement_templates');
   service.getAnnouncementTemplateFormFieldTypes = buildSimpleFetcher('announcement_templates/form_field_types', 'field types');
+  service.previewAnnouncementTemplate = previewAnnouncementTemplate;
 
   service.getKubernetesClusters = buildSimpleFetcher('kubernetes/clusters', 'kubernetes clusters');
   service.getKubernetesTokens = getKubernetesTokens;
@@ -367,6 +368,29 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       .post(`${apiEndpoint}/announcements/${announcementId}/unmark_sticky`)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to unmark announcement as sticky', response));
+        return $q.reject(response);
+      });
+  }
+
+  function previewAnnouncementTemplate(templates, data) {
+    if (_.isNull(templates) || _.isEmpty(templates)) {
+      throw new Error('"templates" argument not specified or empty');
+    }
+
+    if (_.isNull(data) || _.isEmpty(data)) {
+      throw new Error('"data" argument not specified or empty');
+    }
+
+    return $http
+      .post(`${apiEndpoint}/announcement_templates/preview`, {
+        templates: templates,
+        data: data
+      })
+      .then(response => {
+        return response.data;
+      })
+      .catch(response => {
+        logger.error(buildErrorMessageFromResponse('Failed to preview announcement template', response));
         return $q.reject(response);
       });
   }

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -66,6 +66,13 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.announcementMarkSticky = announcementMarkSticky;
   service.announcementUnmarkSticky = announcementUnmarkSticky;
 
+  service.getAnnouncementTemplates = buildCollectionFetcher('announcement_templates');
+  service.getAnnouncementTemplate = buildResourceFetcher('announcement_templates');
+  service.createAnnouncementTemplate = buildResourceCreator('announcement_templates');
+  service.updateAnnouncementTemplate = buildResourceUpdater('announcement_templates');
+  service.deleteAnnouncementTemplate = buildResourceDeletor('announcement_templates');
+  service.getAnnouncementTemplateFormFieldTypes = buildSimpleFetcher('announcement_templates/form_field_types', 'field types');
+
   service.getKubernetesClusters = buildSimpleFetcher('kubernetes/clusters', 'kubernetes clusters');
   service.getKubernetesTokens = getKubernetesTokens;
   service.deleteKubernetesToken = deleteKubernetesToken;

--- a/platform-hub-web/src/app/shared/model/model.module.js
+++ b/platform-hub-web/src/app/shared/model/model.module.js
@@ -13,6 +13,7 @@ import {PlatformThemes} from './platform-themes';
 import {PlatformThemesResourceKinds} from './platform-themes-resource-kinds';
 import {UserScopes} from './user-scopes';
 
+import {announcementTemplateValidator} from './validators/announcement-template-validator';
 import {formFieldsValidator} from './validators/form-fields-validator';
 
 export const ModelModule = angular
@@ -29,5 +30,6 @@ export const ModelModule = angular
   .service('PlatformThemes', PlatformThemes)
   .service('PlatformThemesResourceKinds', PlatformThemesResourceKinds)
   .service('UserScopes', UserScopes)
+  .service('announcementTemplateValidator', announcementTemplateValidator)
   .service('formFieldsValidator', formFieldsValidator)
   .name;

--- a/platform-hub-web/src/app/shared/model/validators/announcement-template-validator.js
+++ b/platform-hub-web/src/app/shared/model/validators/announcement-template-validator.js
@@ -1,0 +1,50 @@
+export const announcementTemplateValidator = function (formFieldsValidator, _) {
+  'ngInject';
+
+  const TEMPLATE_DEFINITION_KEYS = [
+    'title',
+    'on_hub',
+    'email_html',
+    'email_text',
+    'slack'
+  ];
+
+  const service = {};
+
+  service.validate = function (template) {
+    return _.concat(
+      formFieldsValidator.validate(template.spec.fields),
+      validateTemplateDefinitions(template.spec.templates, template.spec.fields)
+    );
+  };
+
+  return service;
+
+  function validateTemplateDefinitions(templates, fields) {
+    const fieldIds = _.map(fields, 'id');
+
+    const errors = [];
+
+    // Make sure the fields used in the template definitions actually correspond
+    // to fields that are defined.
+
+    TEMPLATE_DEFINITION_KEYS.forEach(d => {
+      const unused = findUnusedFieldsInTemplateDefinition(templates[d], fieldIds);
+      if (unused.length > 0) {
+        errors.push(`${d} template definition references field(s) that don't exist: ${unused.join(', ')}`);
+      }
+    });
+
+    return errors;
+  }
+
+  function findUnusedFieldsInTemplateDefinition(definition, allowedFieldIds) {
+    const regex = /{{(\w+?)}}/gm;
+    let matches = null;
+    const foundIds = [];
+    while ((matches = regex.exec(definition)) !== null) {
+      foundIds.push(matches[1]);
+    }
+    return _.difference(foundIds, allowedFieldIds);
+  }
+};

--- a/platform-hub-web/src/app/shared/model/validators/announcement-template-validator.spec.js
+++ b/platform-hub-web/src/app/shared/model/validators/announcement-template-validator.spec.js
@@ -1,0 +1,67 @@
+/* eslint camelcase: 0 */
+
+import angular from 'angular';
+
+import 'angular-mocks';
+
+import {ModelModule} from '../model.module';
+
+describe('announcementTemplateValidator', () => {
+  let validator = null;
+
+  beforeEach(() => {
+    const moduleName = `${ModelModule}.announcementTemplateValidator.spec`;
+    angular.module(moduleName, ['app']);
+    angular.mock.module(moduleName);
+  });
+
+  beforeEach(angular.mock.inject(announcementTemplateValidator => {
+    validator = announcementTemplateValidator;
+  }));
+
+  describe('.validate', () => {
+    describe('given a template with valid fields and template definitions', () => {
+      const template = {
+        spec: {
+          fields: [{id: 'foo'}, {id: 'bar'}, {id: 'baz'}],
+          templates: {
+            title: 'Hello {{foo}} and {{baz}}',
+            on_hub: 'Hello {{foo}} and \n{{baz}}\n',
+            email_html: 'Hello {{foo}} and \n{{baz}}\n',
+            email_text: 'Hello {{foo}} and \n{{baz}}\n',
+            slack: 'Hello {{foo}} and \n{{baz}}\n'
+          }
+        }
+      };
+
+      it('should return no errors', () => {
+        expect(validator.validate(template)).toEqual([]);
+      });
+    });
+
+    describe('given a template with invalid template definitions', () => {
+      const template = {
+        spec: {
+          fields: [{id: 'foo'}, {id: 'bar'}, {id: 'baz'}],
+          templates: {
+            title: 'Hello {{fooooo}} and {{baz}}',
+            on_hub: 'Hello {{foo}} and \n{{baz}}\n',
+            email_html: 'Hello {{foo}} and \n{{bar}}\n',
+            email_text: 'Hello {{foo}} and \n{{bazzzz}}\n',
+            slack: 'Hello {{foo}} and \n{{nothing}}\n and {{nope}}'
+          }
+        }
+      };
+
+      const errors = [
+        'title template definition references field(s) that don\'t exist: fooooo',
+        'email_text template definition references field(s) that don\'t exist: bazzzz',
+        'slack template definition references field(s) that don\'t exist: nothing, nope'
+      ];
+
+      it('should return the specified errors', () => {
+        expect(validator.validate(template)).toEqual(errors);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Please see individual commits. This covers: admins being able to manage announcement templates, plus formatting and previewing of these templates.

An upcoming PR will integrate these templates into the process of creating announcements.