### PR TITLE
Web: unpublished announcements are now clearer in the announcements editor

### DIFF
--- a/platform-hub-web/src/app/announcements/editor/announcements-editor-list.html
+++ b/platform-hub-web/src/app/announcements/editor/announcements-editor-list.html
@@ -68,6 +68,13 @@
 
       <md-card-content>
         <p
+          class="md-body-2"
+          md-colors="{color: 'accent'}"
+          ng-if="!$ctrl.Announcements.isPublished(a)">
+          Not yet published
+        </p>
+
+        <p
           ng-if="template"
           class="md-body-1">
           <span md-colors="{color: 'blue-grey-700'}">


### PR DESCRIPTION
Before, it was not immediately obvious to an admin why an announcement was not visible in the "Global Announcements" section of the hub. With this change, hopefully the unpublished nature makes things clearer.