### PR TITLE
Admins can now resend an existing published announcement

### DIFF
--- a/platform-hub-api/app/controllers/announcements_controller.rb
+++ b/platform-hub-api/app/controllers/announcements_controller.rb
@@ -1,6 +1,6 @@
 class AnnouncementsController < ApiJsonController
 
-  before_action :find_announcement, only: [ :show, :update, :destroy, :mark_sticky, :unmark_sticky ]
+  before_action :find_announcement, only: [ :show, :update, :destroy, :mark_sticky, :unmark_sticky, :resend ]
 
   skip_authorization_check :only => [ :global ]
   authorize_resource except: [ :global ]
@@ -99,6 +99,19 @@ class AnnouncementsController < ApiJsonController
       action: 'unmark_sticky',
       auditable: @announcement
     )
+
+    head :no_content
+  end
+
+  # POST /announcements/:id/resend
+  def resend
+    if @announcement.mark_for_resend!
+      AuditService.log(
+        context: audit_context,
+        action: 'resend',
+        auditable: @announcement
+      )
+    end
 
     head :no_content
   end

--- a/platform-hub-api/app/mailers/announcement_mailer.rb
+++ b/platform-hub-api/app/mailers/announcement_mailer.rb
@@ -2,7 +2,7 @@ class AnnouncementMailer < ApplicationMailer
 
   include ActionView::Helpers::TextHelper
 
-  def announcement_email announcement, recipients
+  def announcement_email announcement, recipients, is_reminder = false
     if announcement.template_data.present?
       output = AnnouncementTemplateFormatterService.format announcement.template_definitions, announcement.template_data
       @announcement_title = output.title
@@ -15,6 +15,10 @@ class AnnouncementMailer < ApplicationMailer
     end
 
     subject = "[#{announcement.level}] #{@announcement_title}"
+
+    if is_reminder
+      subject = "Reminder: #{subject}"
+    end
 
     mail(
       to: Rails.application.config.email_from_address,

--- a/platform-hub-api/app/services/announcement_template_formatter_service.rb
+++ b/platform-hub-api/app/services/announcement_template_formatter_service.rb
@@ -1,7 +1,7 @@
 module AnnouncementTemplateFormatterService
 
   def self.format templates, data
-    templates = HashWithIndifferentAccess.new(templates)
+    templates = templates.with_indifferent_access
 
     results = AnnouncementTemplate::TEMPLATE_DEFINITION_TYPES.map do |t|
       [ t, templates[t].clone ]

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
       get :global, on: :collection
       post :mark_sticky, on: :member
       post :unmark_sticky, on: :member
+      post :resend, on: :member
     end
 
     constraints lambda { |request| FeatureFlagService.is_enabled?(:kubernetes_tokens) } do

--- a/platform-hub-api/spec/factories/announcements.rb
+++ b/platform-hub-api/spec/factories/announcements.rb
@@ -14,6 +14,10 @@ FactoryGirl.define do
       status :delivering
     end
 
+    factory :published_announcement do
+      publish_at { 1.hour.ago }
+    end
+
     factory :announcement_from_template do
       title nil
       text nil
@@ -30,10 +34,15 @@ FactoryGirl.define do
       end
 
       after :build do |a, evaluator|
-        if evaluator.original_template
-          evaluator.original_template.save!
-          a.original_template = evaluator.original_template
+        t = evaluator.original_template
+        if t
+          t.save! if t.new_record?
+          a.original_template = t
         end
+      end
+
+      factory :published_announcement_from_template do
+        publish_at { 1.hour.ago }
       end
     end
   end

--- a/platform-hub-api/spec/models/announcement_spec.rb
+++ b/platform-hub-api/spec/models/announcement_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Announcement, type: :model do
   include_context 'time helpers'
 
   describe 'update protections' do
-    it 'should not allow updates after the initial status has changed, except for status field' do
+    it 'should not allow updates after the initial status (\'awaiting_delivery\') has changed, except for status field' do
       a = create :announcement, title: 'foo'
       expect(a.title).to eq 'foo'
 
@@ -24,7 +24,7 @@ RSpec.describe Announcement, type: :model do
       expect(a2.status).to eq 'delivered'
     end
 
-    it 'should not allow updates after publish_at has been reached, except for status field' do
+    it 'should not allow updates for a published announcement, except for status field' do
       a = create :announcement, title: 'foo', publish_at: now + 1.hour
       expect(a.title).to eq 'foo'
 
@@ -40,6 +40,28 @@ RSpec.describe Announcement, type: :model do
       a2 = Announcement.find(a.id)
       a2.update! status: :delivered
       expect(a2.status).to eq 'delivered'
+    end
+
+    it 'should allow status change from the initial status (\'awaiting_delivery\') to \'delivering\'' do
+      a = create :published_announcement
+
+      a.update! status: :delivering
+      expect(a.status).to eq 'delivering'
+    end
+
+    it 'should allow status change from \'awaiting_resend\' to another status' do
+      a = create :published_announcement
+
+      a.mark_for_resend!
+      expect(a.status).to eq 'awaiting_resend'
+
+      expect {
+        a.update! title: 'baz'
+      }.to raise_error(ActiveRecord::ReadOnlyRecord)
+
+      a2 = Announcement.find(a.id)
+      a2.update! status: :delivering
+      expect(a2.status).to eq 'delivering'
     end
 
     it 'should still allow direct column update' do
@@ -158,6 +180,142 @@ RSpec.describe Announcement, type: :model do
         expect(@a.errors[:base]).to match_array ['either a template can be specified or content directly, not both']
       end
     end
+  end
+
+  describe 'using a template' do
+
+    context 'when creating an announcement' do
+      let(:template) { create :announcement_template }
+
+      it 'should set cache the template_definitions from the specified template' do
+        a = create :announcement_from_template, original_template: template
+        expect(a.original_template_id).to eq template.id
+        expect(a.template_definitions).to eq template.spec['templates'].with_indifferent_access
+      end
+    end
+
+    context 'when updating an announcement' do
+
+      let :initial_template_definitions do
+        {
+          'title': 'Title {{field0}}',
+          'on_hub': 'On hub {{field0}}',
+          'email_html': 'Email HTML <p>{{field0}}</p>',
+          'email_text': 'Email text {{field0}}',
+          'slack': 'Slack {{field0}}'
+        }
+      end
+
+      let :updated_template_definitions do
+        {
+          'title': 'NEW Title {{field0}}',
+          'on_hub': 'NEW On hub {{field0}}',
+          'email_html': 'NEW Email HTML <p>{{field0}}</p>',
+          'email_text': 'NEW Email text {{field0}}',
+          'slack': 'NEW Slack {{field0}}'
+        }
+      end
+
+      let :initial_template do
+        create :announcement_template, templates: initial_template_definitions
+      end
+
+      let :new_template do
+        create :announcement_template, templates: updated_template_definitions
+      end
+
+      let :updated_spec do
+        s = initial_template.spec.dup
+        s['templates'] = updated_template_definitions
+        s
+      end
+
+      context 'for an unpublished announcement' do
+
+        before do
+          @announcement = create :announcement_from_template, original_template: initial_template
+        end
+
+        context 'when the original template\'s definitions are updated' do
+          it 'should sync the definitions on update' do
+            initial_template.update! spec: updated_spec
+
+            expect(@announcement.template_data).not_to eq updated_template_definitions.with_indifferent_access
+
+            @announcement.update! is_sticky: !@announcement.is_sticky
+            expect(@announcement.template_definitions).to eq updated_template_definitions.with_indifferent_access
+          end
+        end
+
+        context 'when a whole new template is assigned' do
+          it 'should use the new template\'s definitions' do
+            @announcement.update! original_template_id: new_template.id
+
+            expect(@announcement.template_definitions).to eq new_template.spec['templates'].with_indifferent_access
+          end
+        end
+
+      end
+
+      context 'for a new published announcement' do
+        before do
+          @announcement = create :published_announcement_from_template, original_template: initial_template
+        end
+
+        context 'when the original template\'s definitions are updated' do
+          it 'should not sync the definitions on updates' do
+            initial_template.update! spec: updated_spec
+
+            expect(@announcement.template_data).not_to eq updated_template_definitions.with_indifferent_access
+
+            @announcement.update! status: :delivering
+            expect(@announcement.template_definitions).to eq initial_template_definitions.with_indifferent_access
+          end
+        end
+
+        context 'when a whole new template is assigned' do
+          it 'should not allow the original_template_id to be changed and it should not mutate template_definitions' do
+            expect {
+              @announcement.update! original_template_id: new_template.id
+            }.to raise_error(ActiveRecord::ReadOnlyRecord)
+
+            expect(@announcement.template_definitions).to eq initial_template.spec['templates']
+            expect(Announcement.find(@announcement.id).template_definitions).to eq initial_template.spec['templates'].with_indifferent_access
+          end
+        end
+      end
+
+      context 'for an announcement that becomes published' do
+        before do
+          @announcement = create :announcement_from_template, original_template_id: initial_template
+          @announcement.update! publish_at: now
+        end
+
+        context 'when the original template\'s definitions are updated' do
+          it 'should not sync the definitions on updates' do
+            initial_template.update! spec: updated_spec
+
+            expect(@announcement.template_data).not_to eq updated_template_definitions.with_indifferent_access
+
+            @announcement.update! status: :delivering
+            expect(@announcement.template_definitions).to eq initial_template_definitions.with_indifferent_access
+          end
+        end
+
+        context 'when a whole new template is assigned' do
+          it 'should not allow the original_template_id to be changed and it should not mutate template_definitions' do
+            expect {
+              @announcement.update! original_template_id: new_template.id
+            }.to raise_error(ActiveRecord::ReadOnlyRecord)
+
+            expect(@announcement.template_definitions).to eq initial_template.spec['templates'].with_indifferent_access
+            expect(Announcement.find(@announcement.id).template_definitions).to eq initial_template.spec['templates'].with_indifferent_access
+          end
+        end
+      end
+
+    end
+
   end
 
 end

--- a/platform-hub-api/spec/routing/announcements_routing_spec.rb
+++ b/platform-hub-api/spec/routing/announcements_routing_spec.rb
@@ -39,5 +39,9 @@ RSpec.describe AnnouncementsController, type: :routing do
       expect(:post => '/announcements/1/unmark_sticky').to route_to('announcements#unmark_sticky', :id => '1')
     end
 
+    it 'routes to #resend' do
+      expect(:post => '/announcements/1/resend').to route_to('announcements#resend', :id => '1')
+    end
+
   end
 end

--- a/platform-hub-web/src/app/announcements/editor/announcements-editor-list.component.js
+++ b/platform-hub-web/src/app/announcements/editor/announcements-editor-list.component.js
@@ -16,13 +16,14 @@ function AnnouncementsEditorListController($q, $mdDialog, icons, AnnouncementTem
   ctrl.announcementIcon = icons.announcements;
 
   ctrl.loading = true;
-  ctrl.saving = false;
+  ctrl.processing = false;
   ctrl.templates = {};
 
   ctrl.preview = preview;
   ctrl.publish = publish;
   ctrl.markSticky = markSticky;
   ctrl.unmarkSticky = unmarkSticky;
+  ctrl.resend = resend;
   ctrl.deleteAnnouncement = deleteAnnouncement;
 
   init();
@@ -61,7 +62,7 @@ function AnnouncementsEditorListController($q, $mdDialog, icons, AnnouncementTem
     $mdDialog
       .show(confirm)
       .then(() => {
-        ctrl.saving = true;
+        ctrl.processing = true;
 
         Announcements
           .publishNow(announcement)
@@ -69,13 +70,13 @@ function AnnouncementsEditorListController($q, $mdDialog, icons, AnnouncementTem
             logger.success('Announcement published');
           })
           .finally(() => {
-            ctrl.saving = false;
+            ctrl.processing = false;
           });
       });
   }
 
   function markSticky(announcement) {
-    ctrl.saving = true;
+    ctrl.processing = true;
 
     Announcements
       .markSticky(announcement)
@@ -84,12 +85,12 @@ function AnnouncementsEditorListController($q, $mdDialog, icons, AnnouncementTem
         announcement.is_sticky = true;
       })
       .finally(() => {
-        ctrl.saving = false;
+        ctrl.processing = false;
       });
   }
 
   function unmarkSticky(announcement) {
-    ctrl.saving = true;
+    ctrl.processing = true;
 
     Announcements
       .unmarkSticky(announcement)
@@ -98,7 +99,33 @@ function AnnouncementsEditorListController($q, $mdDialog, icons, AnnouncementTem
         announcement.is_sticky = false;
       })
       .finally(() => {
-        ctrl.saving = false;
+        ctrl.processing = false;
+      });
+  }
+
+  function resend(announcement, targetEvent) {
+    const confirm = $mdDialog.confirm()
+      .title('Are you sure?')
+      .textContent('This will mark the announcement for resending, which will send out new reminder messages to the specified delivery targets.')
+      .ariaLabel('Confirm resending of announcement')
+      .targetEvent(targetEvent)
+      .ok('Do it')
+      .cancel('Cancel');
+
+    $mdDialog
+      .show(confirm)
+      .then(() => {
+        ctrl.processing = true;
+
+        Announcements
+          .resend(announcement)
+          .then(() => {
+            logger.success('Announcement has been marked for resending – it will be sent out soon');
+            reload();
+          })
+          .finally(() => {
+            ctrl.processing = false;
+          });
       });
   }
 
@@ -114,7 +141,7 @@ function AnnouncementsEditorListController($q, $mdDialog, icons, AnnouncementTem
     $mdDialog
       .show(confirm)
       .then(() => {
-        ctrl.saving = true;
+        ctrl.processing = true;
 
         Announcements
           .deleteAnnouncement(announcement)
@@ -123,7 +150,7 @@ function AnnouncementsEditorListController($q, $mdDialog, icons, AnnouncementTem
             reload();
           })
           .finally(() => {
-            ctrl.saving = false;
+            ctrl.processing = false;
           });
       });
   }

--- a/platform-hub-web/src/app/announcements/editor/announcements-editor-list.html
+++ b/platform-hub-web/src/app/announcements/editor/announcements-editor-list.html
@@ -14,7 +14,7 @@
     </div>
   </md-toolbar>
 
-  <loading-indicator loading="$ctrl.loading || $ctrl.saving"></loading-indicator>
+  <loading-indicator loading="$ctrl.loading || $ctrl.processing"></loading-indicator>
 
   <md-content layout-padding ng-if="!ctrl.loading && $ctrl.Announcements.all.length == 0">
     <p class="md-body-2 none-text text-center">
@@ -169,28 +169,35 @@
           Full Preview
         </md-button>
         <md-button
-          ng-disabled="$ctrl.saving"
+          ng-disabled="$ctrl.processing"
           ng-if="!$ctrl.Announcements.isPublished(a)"
           aria-label="Publish this announcement now"
           ng-click="$ctrl.publish(a, $event)">
           Publish
         </md-button>
         <md-button
+          ng-disabled="$ctrl.processing"
+          ng-if="$ctrl.Announcements.isPublished(a)"
+          aria-label="Resend this announcement now"
+          ng-click="$ctrl.resend(a, $event)">
+          Resend reminder
+        </md-button>
+        <md-button
           ng-if="a.is_global && !a.is_sticky"
-          ng-disabled="$ctrl.saving"
+          ng-disabled="$ctrl.processing"
           aria-label="Mark this announcement as sticky"
           ng-click="$ctrl.markSticky(a)">
           Mark sticky
         </md-button>
         <md-button
           ng-if="a.is_global && a.is_sticky"
-          ng-disabled="$ctrl.saving"
+          ng-disabled="$ctrl.processing"
           aria-label="Unmark this announcement as sticky"
           ng-click="$ctrl.unmarkSticky(a)">
           Unmark sticky
         </md-button>
         <md-button
-          ng-disabled="$ctrl.saving"
+          ng-disabled="$ctrl.processing"
           aria-label="Delete this announcement"
           ng-click="$ctrl.deleteAnnouncement(a, $event)">
           Delete

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -67,6 +67,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.deleteAnnouncement = buildResourceDeletor('announcements');
   service.announcementMarkSticky = announcementMarkSticky;
   service.announcementUnmarkSticky = announcementUnmarkSticky;
+  service.announcementResend = announcementResend;
 
   service.getAnnouncementTemplates = buildCollectionFetcher('announcement_templates');
   service.getAnnouncementTemplate = buildResourceFetcher('announcement_templates');
@@ -409,6 +410,19 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       .post(`${apiEndpoint}/announcements/${announcementId}/unmark_sticky`)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to unmark announcement as sticky', response));
+        return $q.reject(response);
+      });
+  }
+
+  function announcementResend(announcementId) {
+    if (_.isNull(announcementId) || _.isEmpty(announcementId)) {
+      throw new Error('"announcementId" argument not specified or empty');
+    }
+
+    return $http
+      .post(`${apiEndpoint}/announcements/${announcementId}/resend`)
+      .catch(response => {
+        logger.error(buildErrorMessageFromResponse('Failed to mark announcement for resending', response));
         return $q.reject(response);
       });
   }

--- a/platform-hub-web/src/app/shared/model/announcements.js
+++ b/platform-hub-web/src/app/shared/model/announcements.js
@@ -33,6 +33,7 @@ export const Announcements = function ($window, moment, apiBackoffTimeMs, hubApi
   model.publishNow = publishNow;
   model.markSticky = markSticky;
   model.unmarkSticky = unmarkSticky;
+  model.resend = resend;
   model.hasDeliveryTargets = hasDeliveryTargets;
   model.createAnnouncement = createAnnouncement;
   model.updateAnnouncement = updateAnnouncement;
@@ -113,6 +114,14 @@ export const Announcements = function ($window, moment, apiBackoffTimeMs, hubApi
   function unmarkSticky(announcement) {
     return hubApiService
       .announcementUnmarkSticky(announcement.id)
+      .then(() => {
+        return refreshGlobal(true);
+      });
+  }
+
+  function resend(announcement) {
+    return hubApiService
+      .announcementResend(announcement.id)
       .then(() => {
         return refreshGlobal(true);
       });


### PR DESCRIPTION
This change also includes (to address some side effects of allowing redelivery):
- better specs for the `AnnouncementsProcessorService`
- better logic for when to update the template definitions for an announcement (i.e. now it only updates them for non-published announcements)
- better specs for the `Announcement` model, for the abovementioned change