### PR TITLE
Interim solution for robot tokens - associate with users

### DIFF
--- a/platform-hub-api/README.md
+++ b/platform-hub-api/README.md
@@ -178,14 +178,15 @@ bin/rails console
 
 Kubernetes::StaticTokenService.create_or_update(<cluster-id>, :robot, <robot-name>)
 
-# Or with optional groups
+# Or with optional groups and description
 
-Kubernetes::StaticTokenService.create_or_update(<cluster-id>, :robot, <robot-name>, '<groups>')
+Kubernetes::StaticTokenService.create_or_update(<cluster-id>, :robot, <robot-name>, <groups>, <description>)
 ```
 where
 - `<cluster-id>` is the id of cluster for which we want to create a robot account eg. 'development'
 - `<robot-name>` is a name of the robot. This can be any meaningful string which identifies the robot.
 - `<groups>` is a semicolon separated list of group names for the robot eg. `group1;group2`.
+- `<description>` is a string describing this token.
 
 #### Delete robot account
 
@@ -195,7 +196,7 @@ _**NOTE: this can now be done directly in the Hub UI. The instructions below hav
 bin/rails console
 
 # By robot name
-Kubernetes::StaticTokenService.delete_by_user_name(<cluster-id>, :robot, <robot-name>)
+Kubernetes::StaticTokenService.delete_by_name(<cluster-id>, :robot, <robot-name>)
 
 # By robot token
 Kubernetes::StaticTokenService.delete_by_token(<cluster-id>, :robot, <token>)

--- a/platform-hub-api/app/controllers/kubernetes/robot_tokens_controller.rb
+++ b/platform-hub-api/app/controllers/kubernetes/robot_tokens_controller.rb
@@ -3,7 +3,7 @@ class Kubernetes::RobotTokensController < ApiJsonController
   # GET /kubernetes/robot_tokens/:cluster
   def index
     authorize! :read, :kubernetes_robot_tokens
-    tokens = Kubernetes::RobotTokenService.get params[:cluster]
+    tokens = Kubernetes::RobotTokenService.get_by_cluster params[:cluster]
     render json: tokens
   end
 
@@ -15,13 +15,15 @@ class Kubernetes::RobotTokensController < ApiJsonController
     cluster = params[:cluster]
     name = params[:name]
     groups = params[:groups] || []
+    description = params[:description]
+    user_id = params[:user_id]
 
-    Kubernetes::RobotTokenService.create_or_update cluster, name, groups
+    Kubernetes::RobotTokenService.create_or_update cluster, name, groups, description, user_id
 
     AuditService.log(
       context: audit_context,
       action: 'update_kubernetes_robot_token',
-      data: { cluster: cluster, name: name },
+      data: { cluster: cluster, name: name, user_id: user_id },
       comment: "Kubernetes `#{cluster}` robot token '#{name}' created or updated"
     )
 

--- a/platform-hub-api/app/models/kubernetes_robot_token.rb
+++ b/platform-hub-api/app/models/kubernetes_robot_token.rb
@@ -1,12 +1,14 @@
 class KubernetesRobotToken < KubernetesTokenBase
-  attr_accessor :name
+  attr_accessor :name, :description, :user_id
 
   validates_presence_of :name
+
+  belongs_to :user
 
   def self.from_data(cluster, attributes)
     attributes = attributes.with_indifferent_access
     params = attributes
-      .extract!(:uid, :groups)
+      .extract!(:uid, :groups, :description, :user_id)
       .merge!(
         cluster: cluster,
         name: attributes[:user],

--- a/platform-hub-api/app/serializers/identity_serializer.rb
+++ b/platform-hub-api/app/serializers/identity_serializer.rb
@@ -14,4 +14,10 @@ class IdentitySerializer < BaseSerializer
       Kubernetes::TokenService.tokens_from_identity_data(object.data)
     )
   end
+
+  attribute :kubernetes_robot_tokens, if: -> { object.kubernetes? && FeatureFlagService.is_enabled?(:kubernetes_tokens) } do
+    ActiveModel::Serializer::CollectionSerializer.new(
+      Kubernetes::RobotTokenService.get_by_user_id(object.user_id)
+    )
+  end
 end

--- a/platform-hub-api/app/serializers/kubernetes_robot_token_serializer.rb
+++ b/platform-hub-api/app/serializers/kubernetes_robot_token_serializer.rb
@@ -1,3 +1,11 @@
 class KubernetesRobotTokenSerializer < KubernetesTokenBaseSerializer
-  attributes :name
+  attributes :name, :description
+
+  attribute :user, if: -> { object.user.present? } do
+    {
+      id: object.user.id,
+      name: object.user.name,
+      email: object.user.email
+    }
+  end
 end

--- a/platform-hub-api/app/services/kubernetes/robot_token_service.rb
+++ b/platform-hub-api/app/services/kubernetes/robot_token_service.rb
@@ -4,18 +4,26 @@ module Kubernetes
 
     KIND = :robot
 
-    def get cluster
+    def get_by_cluster cluster
       Kubernetes::StaticTokenService.get_static_tokens_hash_record(cluster, KIND).data.map do |t|
         KubernetesRobotToken.from_data cluster, t
       end.sort_by!(&:name)
     end
 
-    def create_or_update cluster, name, groups
-      Kubernetes::StaticTokenService.create_or_update cluster, KIND, name, groups
+    def get_by_user_id user_id
+      Kubernetes::StaticTokenService.get_by_user_id(user_id, KIND).map do |(cluster, tokens)|
+        tokens.map do |t|
+          KubernetesRobotToken.from_data cluster, t
+        end
+      end.flatten.sort_by!(&:name)
+    end
+
+    def create_or_update cluster, name, groups, description, user_id
+      Kubernetes::StaticTokenService.create_or_update cluster, KIND, name, groups, description, user_id
     end
 
     def delete cluster, name
-      Kubernetes::StaticTokenService.delete_by_user_name cluster, KIND, name
+      Kubernetes::StaticTokenService.delete_by_name cluster, KIND, name
     end
 
   end

--- a/platform-hub-api/spec/services/kubernetes/robot_token_service_spec.rb
+++ b/platform-hub-api/spec/services/kubernetes/robot_token_service_spec.rb
@@ -4,7 +4,7 @@ describe Kubernetes::RobotTokenService, type: :service do
 
   let(:cluster) { 'foo' }
 
-  describe '.get' do
+  describe '.get_by_cluster' do
 
     before do
       expect(Kubernetes::StaticTokenService).to receive(:get_static_tokens_hash_record)
@@ -22,7 +22,7 @@ describe Kubernetes::RobotTokenService, type: :service do
       it 'should return an empty list' do
         expect(KubernetesRobotToken).to receive(:from_data).never
 
-        expect(Kubernetes::RobotTokenService.get(cluster)).to be_empty
+        expect(Kubernetes::RobotTokenService.get_by_cluster(cluster)).to be_empty
       end
     end
 
@@ -56,7 +56,7 @@ describe Kubernetes::RobotTokenService, type: :service do
         expect(KubernetesRobotToken).to receive(:from_data).with(cluster, token1).and_call_original
         expect(KubernetesRobotToken).to receive(:from_data).with(cluster, token2).and_call_original
 
-        tokens = Kubernetes::RobotTokenService.get(cluster)
+        tokens = Kubernetes::RobotTokenService.get_by_cluster(cluster)
         expect(tokens.length).to eq 2
         expect(tokens.map(&:name)).to eq ['user1', 'user2']
         expect(tokens.map(&:decrypted_token)).to eq ['token1', 'token2']
@@ -68,15 +68,15 @@ describe Kubernetes::RobotTokenService, type: :service do
   describe '.create_or_update' do
     it 'should call the Kubernetes::StaticTokenService appropriately' do
       expect(Kubernetes::StaticTokenService).to receive(:create_or_update)
-        .with(cluster, :robot, 'foo', [])
+        .with(cluster, :robot, 'foo', [], 'desc', 'user_id')
 
-      Kubernetes::RobotTokenService.create_or_update(cluster, 'foo', [])
+      Kubernetes::RobotTokenService.create_or_update(cluster, 'foo', [], 'desc', 'user_id')
     end
   end
 
   describe '.delete' do
     it 'should call the Kubernetes::StaticTokenService appropriately' do
-      expect(Kubernetes::StaticTokenService).to receive(:delete_by_user_name)
+      expect(Kubernetes::StaticTokenService).to receive(:delete_by_name)
         .with(cluster, :robot, 'foo')
 
       Kubernetes::RobotTokenService.delete(cluster, 'foo')

--- a/platform-hub-api/spec/services/kubernetes/static_token_service_spec.rb
+++ b/platform-hub-api/spec/services/kubernetes/static_token_service_spec.rb
@@ -60,10 +60,10 @@ describe Kubernetes::StaticTokenService, type: :service do
     end
   end
 
-  describe '.delete_by_user_name' do
+  describe '.delete_by_name' do
     it 'removes static account from the list by user name' do
       expect {
-        subject.delete_by_user_name(cluster, kind, user)
+        subject.delete_by_name(cluster, kind, user)
       }.to change { @static_tokens.reload.data.size }.by(-1)
 
       expect(@static_tokens.data.size).to eq 1

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.js
@@ -20,7 +20,10 @@ function KubernetesRobotTokensFormController($state, hubApiService, KubernetesCl
   ctrl.saving = false;
   ctrl.isNew = true;
   ctrl.tokenData = null;
+  ctrl.searchText = '';
+  ctrl.user = null;
 
+  ctrl.searchUsers = searchUsers;
   ctrl.createOrUpdate = createOrUpdate;
 
   init();
@@ -49,15 +52,20 @@ function KubernetesRobotTokensFormController($state, hubApiService, KubernetesCl
         .getKubernetesRobotTokens(cluster)
         .then(tokens => {
           ctrl.tokenData = _.find(tokens, ['name', name]);
+          ctrl.user = ctrl.tokenData.user;
         });
     }
+  }
+
+  function searchUsers(query) {
+    return hubApiService.searchUsers(query, true);
   }
 
   function createOrUpdate() {
     ctrl.saving = true;
 
     hubApiService
-      .createOrUpdateKubernetesRobotToken(ctrl.tokenData.cluster, ctrl.tokenData.name, ctrl.tokenData.groups)
+      .createOrUpdateKubernetesRobotToken(ctrl.tokenData.cluster, ctrl.tokenData.name, ctrl.tokenData.groups, ctrl.tokenData.description, ctrl.user && ctrl.user.id)
       .then(() => {
         logger.success('Token successfully created or updated');
         $state.go('kubernetes.robot-tokens.list', {cluster: ctrl.tokenData.cluster});

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.html
@@ -86,6 +86,42 @@
               placeholder="Comma separated list of groups.">
           </md-input-container>
 
+          <md-input-container class="md-block">
+            <label for="description">Description (optional):</label>
+            <textarea
+              name="description"
+              ng-model="$ctrl.tokenData.description"
+              rows="2"
+              aria-label="Set a description for this robot token"
+              md-select-on-focus>
+            </textarea>
+          </md-input-container>
+
+          <md-autocomplete
+            md-input-name="user"
+            md-no-cache="true"
+            md-selected-item="$ctrl.user"
+            md-search-text="$ctrl.searchText"
+            md-items="user in $ctrl.searchUsers($ctrl.searchText)"
+            md-item-text="user.name + ' (' + user.email + ')'"
+            md-min-length="1"
+            ng-model-options="{ debounce: 500 }"
+            placeholder="Search for a user…"
+            md-require-match
+            md-floating-label="Associate this token with a user (so they can see it):"
+            flex>
+            <md-item-template>
+              <span md-highlight-text="$ctrl.searchText" md-highlight-flags="^i">
+                {{user.name}}
+                ({{user.email}})
+              </span>
+              <small class="badge" ng-if="!user.is_active" md-colors="{background: 'blue-grey'}">Deactivated</small>
+            </md-item-template>
+            <md-not-found>
+              No users matching "{{$ctrl.searchText}}" were found.
+            </md-not-found>
+          </md-autocomplete>
+
           <div>
             <md-button
               type="submit"

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-list.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-list.html
@@ -56,6 +56,13 @@
       </md-card-title>
 
       <md-card-content>
+        <p
+          class="md-body-1"
+          md-colors="{background: 'blue-grey-50'}"
+          ng-if="t.description"
+          ng-bind-html='t.description | simpleFormat'
+          layout-padding>
+        </p>
         <p class="md-body-1">
           <strong>Token:</strong> {{t.token}}
         </p>
@@ -64,6 +71,10 @@
         </p>
         <p class="md-body-1" ng-if="t.groups && t.groups.length > 0">
           <strong>Groups:</strong> {{t.groups.join(', ')}}
+        </p>
+        <p class="md-body-1" ng-if="t.user">
+          <strong>Associated with user:</strong>
+          {{t.user.name}} ({{t.user.email}})
         </p>
       </md-card-content>
 

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -662,7 +662,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       });
   }
 
-  function createOrUpdateKubernetesRobotToken(cluster, name, groups) {
+  function createOrUpdateKubernetesRobotToken(cluster, name, groups, description, user_id) {
     if (_.isNull(cluster) || _.isEmpty(cluster)) {
       throw new Error('"cluster" argument not specified or empty');
     }
@@ -673,7 +673,9 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .put(`${apiEndpoint}/kubernetes/robot_tokens/${cluster}/${name}`, {
-        groups: groups
+        groups: groups,
+        description: description,
+        user_id: user_id
       })
       .catch(response => {
         logger.error(buildErrorMessageFromResponse(`Failed to create or update robot token '${name}' for cluster '${cluster}'`, response));

--- a/platform-hub-web/src/app/shared/identities/identities-list.html
+++ b/platform-hub-web/src/app/shared/identities/identities-list.html
@@ -62,30 +62,60 @@
         </p>
 
         <div ng-if="$ctrl.showKubeTokens">
-          <ul class="md-body-1">
-            <li ng-repeat="t in i.kubernetes_tokens">
-              <p>
-                {{t.cluster}}: <strong>{{t.token}}</strong>
-              </p>
+          <br />
 
-              <ul ng-if="t.groups.length > 0 || t.expire_privileged_at">
-                <li ng-if="t.groups.length > 0">
-                  <p>
-                    Groups: {{t.groups.join(', ')}}
-                  </p>
-                </li>
-                <li ng-if="t.expire_privileged_at">
-                  <p
-                    md-colors="{color: 'accent'}">
-                    <strong>Escalated privilege ends at:</strong>
-                    <br />
-                    {{t.expire_privileged_at | date:'EEE MMM d y HH:mm UTC':'UTC'}}
-                    (<span am-time-ago="t.expire_privileged_at"></span>)
-                  </p>
-                </li>
-              </ul>
-            </li>
-          </ul>
+          <div ng-if="i.kubernetes_tokens.length > 0">
+            <h5>User tokens</h5>
+            <ul class="md-body-1">
+              <li ng-repeat="t in i.kubernetes_tokens">
+                <p>
+                  {{t.cluster}}: <strong>{{t.token}}</strong>
+                </p>
+
+                <ul ng-if="t.groups.length > 0 || t.expire_privileged_at">
+                  <li ng-if="t.groups.length > 0">
+                    <p>
+                      Groups: {{t.groups.join(', ')}}
+                    </p>
+                  </li>
+                  <li ng-if="t.expire_privileged_at">
+                    <p
+                      md-colors="{color: 'accent'}">
+                      <strong>Escalated privilege ends at:</strong>
+                      <br />
+                      {{t.expire_privileged_at | date:'EEE MMM d y HH:mm UTC':'UTC'}}
+                      (<span am-time-ago="t.expire_privileged_at"></span>)
+                    </p>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+
+          <div ng-if="i.kubernetes_robot_tokens.length > 0">
+            <h5>Robot tokens</h5>
+            <ul class="md-body-1">
+              <li ng-repeat="t in i.kubernetes_robot_tokens">
+                <p>
+                  {{t.cluster}}: <strong>{{t.token}}</strong>
+                </p>
+
+                <ul ng-if="t.description || t.groups.length > 0">
+                  <li ng-if="t.description">
+                    <p>
+                      <em>{{t.description}}</em>
+                    </p>
+                  </li>
+                  <li ng-if="t.groups.length > 0">
+                    <p>
+                      Groups: {{t.groups.join(', ')}}
+                    </p>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+
         </div>
 
         <md-button class="md-secondary md-raised"


### PR DESCRIPTION
This provides the ability for admins to associate robot tokens with users, and then for these tokens to be shown on the user's Connected Identities page.

This is an interim solution, until we have the new project and services self-serve tokens feature ready.