### PR TITLE
Hub admins can now allocate Kubernetes groups to projects or project services

### DIFF
--- a/platform-hub-api/app/models/allocation.rb
+++ b/platform-hub-api/app/models/allocation.rb
@@ -1,0 +1,15 @@
+class Allocation < ApplicationRecord
+
+  include Audited
+
+  audited associated_field: :allocation_receivable
+
+  belongs_to :allocatable, polymorphic: true
+  validates :allocatable_type, presence: true
+  validates :allocatable_id, presence: true
+
+  belongs_to :allocation_receivable, polymorphic: true
+  validates :allocation_receivable_type, presence: true
+  validates :allocation_receivable_id, presence: true
+
+end

--- a/platform-hub-api/app/models/concerns/allocatable.rb
+++ b/platform-hub-api/app/models/concerns/allocatable.rb
@@ -1,0 +1,12 @@
+module Allocatable
+  extend ActiveSupport::Concern
+
+  class_methods do
+
+    def allocatable
+      has_many :allocations, as: :allocatable
+    end
+
+  end
+
+end

--- a/platform-hub-api/app/models/concerns/allocation_receivable.rb
+++ b/platform-hub-api/app/models/concerns/allocation_receivable.rb
@@ -1,0 +1,12 @@
+module AllocationReceivable
+  extend ActiveSupport::Concern
+
+  class_methods do
+
+    def allocation_receivable
+      has_many :allocations, as: :allocation_receivable
+    end
+
+  end
+
+end

--- a/platform-hub-api/app/models/kubernetes_group.rb
+++ b/platform-hub-api/app/models/kubernetes_group.rb
@@ -4,10 +4,13 @@ class KubernetesGroup < ApplicationRecord
 
   include Audited
   include FriendlyId
+  include Allocatable
 
   audited descriptor_field: :name
 
   friendly_id :name
+
+  allocatable
 
   validates :name,
     presence: true,
@@ -24,11 +27,13 @@ class KubernetesGroup < ApplicationRecord
     clusterwide: 'clusterwide',
     namespace: 'namespace'
   }
+  validates :kind, presence: true
 
   enum target: {
     user: 'user',
     robot: 'robot'
   }
+  validates :target, presence: true
 
   scope :privileged, -> { where(is_privileged: true) }
   scope :not_privileged, -> { where.not(is_privileged: true) }

--- a/platform-hub-api/app/models/project.rb
+++ b/platform-hub-api/app/models/project.rb
@@ -2,11 +2,14 @@ class Project < ApplicationRecord
 
   include FriendlyId
   include Audited
+  include AllocationReceivable
 
   audited descriptor_field: :shortname
   has_associated_audits
 
   friendly_id :shortname, :use => :slugged
+
+  allocation_receivable
 
   def should_generate_new_friendly_id?
     shortname_changed? || super

--- a/platform-hub-api/app/models/service.rb
+++ b/platform-hub-api/app/models/service.rb
@@ -1,8 +1,11 @@
 class Service < ApplicationRecord
 
   include Audited
+  include AllocationReceivable
 
   audited descriptor_field: :name, associated_field: :project
+
+  allocation_receivable
 
   validates :name,
     presence: true

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
 
         resources :groups do
           get :privileged, on: :collection
+          post :allocate, on: :member
         end
       end
     end

--- a/platform-hub-api/db/migrate/20171010111440_create_allocations.rb
+++ b/platform-hub-api/db/migrate/20171010111440_create_allocations.rb
@@ -1,0 +1,23 @@
+class CreateAllocations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :allocations, id: :uuid do |t|
+      t.references :allocatable,
+        type: :uuid,
+        polymorphic: true,
+        null: false,
+        index: {
+          name: 'index_allocations_on_al_type_and_al_id'
+        }
+
+      t.references :allocation_receivable,
+        type: :uuid,
+        polymorphic: true,
+        null: false,
+        index: {
+          name: 'index_allocations_on_al_rec_type_and_al_rec_id'
+        }
+
+      t.timestamps
+    end
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -63,6 +63,21 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
+-- Name: allocations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE allocations (
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    allocatable_type character varying NOT NULL,
+    allocatable_id uuid NOT NULL,
+    allocation_receivable_type character varying NOT NULL,
+    allocation_receivable_id uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
 -- Name: announcement_templates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -446,6 +461,14 @@ ALTER TABLE ONLY read_marks ALTER COLUMN id SET DEFAULT nextval('read_marks_id_s
 
 
 --
+-- Name: allocations allocations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY allocations
+    ADD CONSTRAINT allocations_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: announcement_templates announcement_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -602,6 +625,20 @@ ALTER TABLE ONLY users
 --
 
 CREATE INDEX delayed_jobs_priority ON delayed_jobs USING btree (priority, run_at);
+
+
+--
+-- Name: index_allocations_on_al_rec_type_and_al_rec_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_allocations_on_al_rec_type_and_al_rec_id ON allocations USING btree (allocation_receivable_type, allocation_receivable_id);
+
+
+--
+-- Name: index_allocations_on_al_type_and_al_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_allocations_on_al_type_and_al_id ON allocations USING btree (allocatable_type, allocatable_id);
 
 
 --
@@ -931,6 +968,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170727103721'),
 ('20170920154859'),
 ('20171001181648'),
-('20171005115420');
+('20171005115420'),
+('20171010111440');
 
 

--- a/platform-hub-api/spec/factories/allocations.rb
+++ b/platform-hub-api/spec/factories/allocations.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :allocation do
+    
+  end
+end

--- a/platform-hub-api/spec/routing/kubernetes_groups_routing_spec.rb
+++ b/platform-hub-api/spec/routing/kubernetes_groups_routing_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Kubernetes::GroupsController, type: :routing do
         expect(:get => '/kubernetes/groups/privileged').to route_to('kubernetes/groups#privileged')
       end
 
+      it 'routes to #allocate' do
+        expect(:post => '/kubernetes/groups/1/allocate').to route_to('kubernetes/groups#allocate', :id => '1')
+      end
+
     end
 
     context 'with kubernetes_tokens feature flag disabled' do
@@ -71,6 +75,10 @@ RSpec.describe Kubernetes::GroupsController, type: :routing do
 
       it 'route to #privileged is not routable' do
         expect(:get => '/kubernetes/groups/privileged').to_not be_routable
+      end
+
+      it 'route to #allocate is not routable' do
+        expect(:post => '/kubernetes/groups/1/allocate').to_not be_routable
       end
 
     end

--- a/platform-hub-web/src/app/kubernetes/kubernetes-groups-detail.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-groups-detail.component.js
@@ -6,7 +6,7 @@ export const KubernetesGroupsDetailComponent = {
   controller: KubernetesGroupsDetailController
 };
 
-function KubernetesGroupsDetailController($mdDialog, $state, KubernetesGroups, logger) {
+function KubernetesGroupsDetailController($mdDialog, $state, KubernetesGroups, projectServiceSelectorPopupService, logger) {
   'ngInject';
 
   const ctrl = this;
@@ -17,6 +17,7 @@ function KubernetesGroupsDetailController($mdDialog, $state, KubernetesGroups, l
   ctrl.group = null;
 
   ctrl.deleteGroup = deleteGroup;
+  ctrl.allocate = allocate;
 
   init();
 
@@ -61,6 +62,28 @@ function KubernetesGroupsDetailController($mdDialog, $state, KubernetesGroups, l
           .finally(() => {
             ctrl.loading = false;
           });
+      });
+  }
+
+  function allocate(targetEvent) {
+    projectServiceSelectorPopupService
+      .open(true, targetEvent)
+      .then(result => {
+        if (result.service) {
+          return KubernetesGroups.allocateToService(
+            ctrl.group.id,
+            result.project.id,
+            result.service.id
+          );
+        }
+
+        return KubernetesGroups.allocateToProject(
+          ctrl.group.id,
+          result.project.id
+        );
+      })
+      .then(() => {
+        logger.success('Successfully allocated this Kubernetes RBAC group');
       });
   }
 }

--- a/platform-hub-web/src/app/kubernetes/kubernetes-groups-detail.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-groups-detail.html
@@ -72,6 +72,14 @@
           </span>
         </p>
 
+        <div layout="row" layout-align="center center">
+          <md-button
+            class="md-primary md-raised"
+            ng-click="$ctrl.allocate($event)">
+            Allocate this to a project or a project's service
+          </md-button>
+        </div>
+
       </md-content>
     </div>
 

--- a/platform-hub-web/src/app/projects/projects.module.js
+++ b/platform-hub-web/src/app/projects/projects.module.js
@@ -5,6 +5,8 @@ import {ProjectsDetailComponent} from './projects-detail.component';
 import {ProjectsListComponent} from './projects-list.component';
 import {ProjectServicesDetailComponent} from './services/project-services-detail.component';
 import {ProjectServicesFormComponent} from './services/project-services-form.component';
+import {ProjectServiceSelectorPopupController} from './services/project-service-selector-popup.controller';
+import {projectServiceSelectorPopupService} from './services/project-service-selector-popup.service';
 
 // Main section component names
 export const ProjectsForm = 'projectsForm';
@@ -20,4 +22,6 @@ export const ProjectsModule = angular
   .component(ProjectsList, ProjectsListComponent)
   .component(ProjectServicesDetail, ProjectServicesDetailComponent)
   .component(ProjectServicesForm, ProjectServicesFormComponent)
+  .controller('ProjectServiceSelectorPopupController', ProjectServiceSelectorPopupController)
+  .service('projectServiceSelectorPopupService', projectServiceSelectorPopupService)
   .name;

--- a/platform-hub-web/src/app/projects/services/project-service-selector-popup.controller.js
+++ b/platform-hub-web/src/app/projects/services/project-service-selector-popup.controller.js
@@ -1,0 +1,57 @@
+export const ProjectServiceSelectorPopupController = function ($mdDialog, Projects, serviceIsOptional) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.Projects = Projects;
+  ctrl.serviceIsOptional = serviceIsOptional;
+
+  ctrl.loading = true;
+  ctrl.selectedProject = null;
+  ctrl.services = [];
+  ctrl.selectedService = null;
+
+  ctrl.handleProjectChanged = handleProjectChanged;
+  ctrl.cancel = $mdDialog.cancel;
+  ctrl.chooseProject = chooseProject;
+  ctrl.chooseService = chooseService;
+
+  init();
+
+  function init() {
+    Projects
+      .refresh()
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function handleProjectChanged() {
+    ctrl.loading = true;
+    ctrl.services = [];
+    ctrl.selectedService = null;
+
+    Projects
+      .getServices(ctrl.selectedProject.id)
+      .then(services => {
+        ctrl.services = services;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function chooseProject() {
+    $mdDialog.hide({
+      project: ctrl.selectedProject,
+      service: null
+    });
+  }
+
+  function chooseService() {
+    $mdDialog.hide({
+      project: ctrl.selectedProject,
+      service: ctrl.selectedService
+    });
+  }
+};

--- a/platform-hub-web/src/app/projects/services/project-service-selector-popup.html
+++ b/platform-hub-web/src/app/projects/services/project-service-selector-popup.html
@@ -1,0 +1,81 @@
+<md-dialog aria-label="Choose a project service">
+  <md-toolbar class="md-toolbar-tools md-accent">
+    <h2 ng-if="$ctrl.serviceIsOptional">
+      Choose a project or a service from a project
+    </h2>
+    <h2 ng-if="!$ctrl.serviceIsOptional">
+      Choose a service from a project
+    </h2>
+    <span flex></span>
+    <md-button
+      class="close-button md-icon-button"
+      ng-click="$ctrl.cancel()"
+      aria-label="Close dialog">
+      <md-icon>clear</md-icon>
+    </md-button>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading"></loading-indicator>
+
+  <md-dialog-content class="md-dialog-content" layout="column" layout-padding>
+
+    <form name="$ctrl.form">
+      <md-input-container class="md-block">
+        <label for="project">Project:</label>
+        <md-select
+          name="project"
+          ng-model="$ctrl.selectedProject"
+          ng-disabled="!$ctrl.Projects.all.length"
+          ng-change="$ctrl.handleProjectChanged()"
+          required>
+          <md-option
+            ng-repeat="p in $ctrl.Projects.all"
+            ng-value="p">
+            {{p.shortname}}
+            ({{p.name}})
+          </md-option>
+        </md-select>
+      </md-input-container>
+
+      <md-input-container class="md-block">
+        <label for="service">Service:</label>
+        <md-select
+          name="service"
+          ng-model="$ctrl.selectedService"
+          ng-disabled="!$ctrl.services.length"
+          ng-required="!$ctrl.serviceIsOptional">
+          <md-option
+            ng-repeat="s in $ctrl.services"
+            ng-value="s">
+            {{s.name}}
+            ({{s.description}})
+          </md-option>
+        </md-select>
+      </md-input-container>
+    </form>
+
+  </md-dialog-content>
+
+  <md-dialog-actions>
+    <md-button
+      ng-click="$ctrl.cancel()"
+      aria-label="Cancel">
+      Cancel
+    </md-button>
+    <md-button
+      ng-if="$ctrl.serviceIsOptional"
+      class="md-primary md-raised"
+      ng-click="$ctrl.chooseProject()"
+      ng-disabled="$ctrl.loading || !$ctrl.selectedProject"
+      aria-label="Choose the selected project">
+      Choose project
+    </md-button>
+    <md-button
+      class="md-primary md-raised"
+      ng-click="$ctrl.chooseService()"
+      ng-disabled="$ctrl.loading || !$ctrl.selectedService"
+      aria-label="Choose the selected service">
+      Choose service
+    </md-button>
+  </md-dialog-actions>
+</md-dialog>

--- a/platform-hub-web/src/app/projects/services/project-service-selector-popup.service.js
+++ b/platform-hub-web/src/app/projects/services/project-service-selector-popup.service.js
@@ -1,0 +1,25 @@
+export const projectServiceSelectorPopupService = function ($document, $mdDialog) {
+  'ngInject';
+
+  const service = {};
+
+  service.open = open;
+
+  return service;
+
+  function open(serviceIsOptional, targetEvent) {
+    return $mdDialog.show({
+      template: require('./project-service-selector-popup.html'),
+      controller: 'ProjectServiceSelectorPopupController',
+      controllerAs: '$ctrl',
+      bindToController: true,
+      parent: angular.element($document.body),
+      targetEvent: targetEvent,  // eslint-disable-line object-shorthand
+      clickOutsideToClose: false,
+      escapeToClose: false,
+      locals: {
+        serviceIsOptional
+      }
+    });
+  }
+};

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -92,6 +92,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.createKubernetesGroup = buildResourceCreator('kubernetes/groups');
   service.updateKubernetesGroup = buildResourceUpdater('kubernetes/groups');
   service.deleteKubernetesGroup = buildResourceDeletor('kubernetes/groups');
+  service.allocateKubernetesGroup = allocateKubernetesGroup;
   service.getKubernetesTokens = getKubernetesTokens;
   service.deleteKubernetesToken = deleteKubernetesToken;
   service.createOrUpdateKubernetesToken = createOrUpdateKubernetesToken;
@@ -680,6 +681,28 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       msg += `: ${errorDetails}`;
     }
     return msg;
+  }
+
+  function allocateKubernetesGroup(groupId, projectId, serviceId) {
+    if (_.isNull(groupId) || _.isEmpty(groupId)) {
+      throw new Error('"groupId" argument not specified or empty');
+    }
+    if (_.isNull(projectId) || _.isEmpty(projectId)) {
+      throw new Error('"projectId" argument not specified or empty');
+    }
+
+    return $http
+      .post(`${apiEndpoint}/kubernetes/groups/${groupId}/allocate`, {
+        project_id: projectId,
+        service_id: serviceId
+      })
+      .then(response => {
+        return response.data;
+      })
+      .catch(response => {
+        logger.error(buildErrorMessageFromResponse(`Failed to allocate Kubernetes RBAC group to a project or service`, response));
+        return $q.reject(response);
+      });
   }
 
   function getKubernetesTokens(userId) {

--- a/platform-hub-web/src/app/shared/model/kubernetes-groups.js
+++ b/platform-hub-web/src/app/shared/model/kubernetes-groups.js
@@ -24,6 +24,8 @@ export const KubernetesGroups = function ($window, hubApiService, apiBackoffTime
   model.create = hubApiService.createKubernetesGroup;
   model.update = hubApiService.updateKubernetesGroup;
   model.delete = hubApiService.deleteKubernetesGroup;
+  model.allocateToProject = allocateToProject;
+  model.allocateToService = allocateToService;
 
   return model;
 
@@ -43,5 +45,13 @@ export const KubernetesGroups = function ($window, hubApiService, apiBackoffTime
         });
     }
     return fetcherPromise;
+  }
+
+  function allocateToProject(groupId, projectId) {
+    return hubApiService.allocateKubernetesGroup(groupId, projectId);
+  }
+
+  function allocateToService(groupId, projectId, serviceId) {
+    return hubApiService.allocateKubernetesGroup(groupId, projectId, serviceId);
   }
 };


### PR DESCRIPTION
Note: this doesn't yet include a way to list and modify these allocations. Coming soon!