### PR TITLE
Refactor the way we do project manager checks

### DIFF
--- a/platform-hub-api/app/controllers/projects_controller.rb
+++ b/platform-hub-api/app/controllers/projects_controller.rb
@@ -1,10 +1,10 @@
 class ProjectsController < ApiJsonController
 
-  before_action :find_project, only: [ :show, :update, :destroy, :memberships, :add_membership, :remove_membership, :set_role, :unset_role ]
+  before_action :find_project, only: [ :show, :update, :destroy, :memberships, :add_membership, :remove_membership, :set_role, :unset_role, :role_check ]
   before_action :find_user, only: [ :add_membership, :remove_membership, :set_role, :unset_role ]
 
-  skip_authorization_check only: [ :index, :show, :memberships ]
-  authorize_resource except: [ :index, :show, :memberships ]
+  skip_authorization_check only: [ :index, :show, :memberships, :role_check ]
+  authorize_resource except: [ :index, :show, :memberships, :role_check ]
 
   # GET /projects
   def index
@@ -110,6 +110,17 @@ class ProjectsController < ApiJsonController
     )
 
     head :no_content
+  end
+
+  # GET /projects/:id/memberships/role_check/:role
+  def role_check
+    case params[:role]
+    when 'manager'
+      is_manager = ProjectMembershipsService.is_user_a_manager_of_project?(@project.id, current_user.id)
+      render json: { result: is_manager }
+    else
+      not_found_error
+    end
   end
 
   # PUT /projects/:id/memberships/:user_id/role/:role

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -50,11 +50,12 @@ Rails.application.routes.draw do
     end
 
     resources :projects, constraints: lambda { |request| FeatureFlagService.is_enabled?(:projects) } do
-      get '/memberships', to: 'projects#memberships', on: :member
+      get :memberships, on: :member
       put '/memberships/:user_id', to: 'projects#add_membership', on: :member
       delete '/memberships/:user_id', to: 'projects#remove_membership', on: :member
 
       constraints lambda { |request| ProjectMembership.roles.keys.include?(request.params[:role]) } do
+        get '/memberships/role_check/:role', to: 'projects#role_check', on: :member
         put '/memberships/:user_id/role/:role', to: 'projects#set_role', on: :member
         delete '/memberships/:user_id/role/:role', to: 'projects#unset_role', on: :member
       end

--- a/platform-hub-api/spec/routing/projects_routing_spec.rb
+++ b/platform-hub-api/spec/routing/projects_routing_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe ProjectsController, type: :routing do
         expect(:delete => '/projects/1/memberships/25').to route_to('projects#remove_membership', :id => '1', :user_id => '25')
       end
 
+      it 'routes to #role_check' do
+        expect(:get => '/projects/1/memberships/role_check/manager').to route_to('projects#role_check', :id => '1', :role => 'manager')
+      end
+
       it 'routes to #set_role' do
         expect(:put => '/projects/1/memberships/25/role/manager').to route_to('projects#set_role', :id => '1', :user_id => '25', :role => 'manager')
       end
@@ -99,6 +103,10 @@ RSpec.describe ProjectsController, type: :routing do
 
       it 'route to #remove_membership is not routable' do
         expect(:delete => '/projects/1/memberships/25').to_not be_routable
+      end
+
+      it 'route to #role_check is not routable' do
+        expect(:get => '/projects/1/memberships/role_check/manager').to_not be_routable
       end
 
       it 'route to #set_role is not routable' do

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -30,6 +30,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.getProjectMemberships = buildSubCollectionFetcher('projects', 'memberships');
   service.addProjectMembership = addProjectMembership;
   service.removeProjectMembership = removeProjectMembership;
+  service.projectMembershipRoleCheck = projectMembershipRoleCheck;
   service.projectSetMembershipRole = projectSetMembershipRole;
   service.projectUnsetMembershipRole = projectUnsetMembershipRole;
   service.getProjectServices = buildSubCollectionFetcher('projects', 'services');
@@ -310,6 +311,25 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       .delete(`${apiEndpoint}/projects/${projectId}/memberships/${userId}`)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to remove team member from project', response));
+        return $q.reject(response);
+      });
+  }
+
+  function projectMembershipRoleCheck(projectId, role) {
+    if (_.isNull(projectId) || _.isEmpty(projectId)) {
+      throw new Error('"projectId" argument not specified or empty');
+    }
+    if (_.isNull(role) || _.isEmpty(role)) {
+      throw new Error('"role" argument not specified or empty');
+    }
+
+    return $http
+      .get(`${apiEndpoint}/projects/${projectId}/memberships/role_check/${role}`)
+      .then(response => {
+        return response.data;
+      })
+      .catch(response => {
+        logger.error(buildErrorMessageFromResponse('Failed to check if user if a manager for the specific project', response));
         return $q.reject(response);
       });
   }

--- a/platform-hub-web/src/app/shared/model/projects.js
+++ b/platform-hub-web/src/app/shared/model/projects.js
@@ -18,6 +18,7 @@ export const Projects = function ($window, $q, apiBackoffTimeMs, hubApiService, 
   model.getMemberships = hubApiService.getProjectMemberships;
   model.addMembership = hubApiService.addProjectMembership;
   model.removeMembership = hubApiService.removeProjectMembership;
+  model.membershipRoleCheck = hubApiService.projectMembershipRoleCheck;
   model.setMembershipRole = hubApiService.projectSetMembershipRole;
   model.unsetMembershipRole = hubApiService.projectUnsetMembershipRole;
 


### PR DESCRIPTION
- Added a new endpoint for checking whether the logged in user has a specified role in a project
- Used this in the project detail page to determine whether to set the `isProjectManager` flag on that page
- Also changed the flow around in the projct detail page to first check admin status and then only continue if that was successful (this way if the API is down, or something is not quite right, we fail early)