### PR TITLE
Kube robot tokens should be restricted to allocated clusters only

### DIFF
--- a/platform-hub-api/app/controllers/kubernetes/clusters_controller.rb
+++ b/platform-hub-api/app/controllers/kubernetes/clusters_controller.rb
@@ -1,9 +1,8 @@
 class Kubernetes::ClustersController < ApiJsonController
 
-  before_action :find_cluster, only: [ :show, :update ]
+  before_action :find_cluster, only: [ :show, :update, :allocate, :allocations ]
 
-  skip_authorization_check only: [ :index, :show ]
-  authorize_resource class: KubernetesCluster, :except => [:index, :show]
+  authorize_resource class: KubernetesCluster
 
   # GET /kubernetes/clusters
   def index
@@ -45,6 +44,39 @@ class Kubernetes::ClustersController < ApiJsonController
     else
       render_model_errors @cluster.errors
     end
+  end
+
+  # POST /kubernetes/clusters/:id/allocate
+  def allocate
+    project = Project.friendly.find(params.require(:project_id))
+
+    allocation = Allocation.new(
+      allocatable: @cluster,
+      allocation_receivable: project
+    )
+
+    if allocation.save
+      AuditService.log(
+        context: audit_context,
+        action: 'create',
+        auditable: allocation,
+        data: {
+          allocatable_type: @cluster.class.name,
+          allocatable_id: @cluster.id,
+          allocatable_descriptor: @cluster.name
+        }
+      )
+
+      head :no_content
+    else
+      render_model_errors allocation.errors
+    end
+  end
+
+  # GET /kubernetes/clusters/:id/allocations
+  def allocations
+    allocations = Allocation.by_allocatable @cluster
+    render json: allocations
   end
 
   private

--- a/platform-hub-api/app/controllers/projects_controller.rb
+++ b/platform-hub-api/app/controllers/projects_controller.rb
@@ -12,6 +12,7 @@ class ProjectsController < ApiJsonController
     :set_role,
     :unset_role,
     :role_check,
+    :kubernetes_clusters,
     :kubernetes_groups
   ]
 
@@ -34,6 +35,7 @@ class ProjectsController < ApiJsonController
     :show,
     :memberships,
     :role_check,
+    :kubernetes_clusters,  # Will be checked separately
     :kubernetes_groups  # Will be checked separately
   ]
 
@@ -163,6 +165,13 @@ class ProjectsController < ApiJsonController
   # DELETE /projects/:id/memberships/:user_id/role/:role
   def unset_role
     handle_role_change role: nil
+  end
+
+  # GET /projects/:id/kubernetes_clusters
+  def kubernetes_clusters
+    authorize! :read_resources_in_project, @project
+
+    render json: @project.kubernetes_clusters.order(:name)
   end
 
   # GET /projects/:id/kubernetes_groups

--- a/platform-hub-api/app/models/project.rb
+++ b/platform-hub-api/app/models/project.rb
@@ -33,6 +33,11 @@ class Project < ApplicationRecord
   has_many :services,
     dependent: :delete_all
 
+  has_many :kubernetes_clusters,
+    through: :allocations,
+    source: :allocatable,
+    source_type: 'KubernetesCluster'
+
   has_many :kubernetes_groups,
     through: :allocations,
     source: :allocatable,

--- a/platform-hub-api/app/serializers/kubernetes_cluster_serializer.rb
+++ b/platform-hub-api/app/serializers/kubernetes_cluster_serializer.rb
@@ -1,3 +1,7 @@
 class KubernetesClusterSerializer < BaseSerializer
+
+  include WithFriendlyIdAttribute
+
   attributes :name, :description
+
 end

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
         delete '/memberships/:user_id/role/:role', to: 'projects#unset_role', on: :member
       end
 
+      get :kubernetes_clusters, on: :member
       get :kubernetes_groups, on: :member
 
       resources :services do
@@ -107,7 +108,10 @@ Rails.application.routes.draw do
           patch '/deescalate', to: 'tokens#deescalate', on: :member
         end
 
-        resources :clusters, except: :destroy
+        resources :clusters, except: :destroy do
+          post :allocate, on: :member
+          get :allocations, on: :member
+        end
 
         get '/changeset/:cluster', to: 'changeset#index'
 

--- a/platform-hub-api/spec/controllers/kubernetes/tokens_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/tokens_controller_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
               'uid' => @token.uid,
               'groups' => @token.groups,
               'cluster' => {
+                'id' => @token.cluster.friendly_id,
                 'name' => @token.cluster.name,
                 'description' => @token.cluster.description
               }
@@ -147,6 +148,7 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
               'uid' => @token.uid,
               'groups' => @token.groups,
               'cluster' => {
+                'id' => @token.cluster.friendly_id,
                 'name' => @token.cluster.name,
                 'description' => @token.cluster.description
               },

--- a/platform-hub-api/spec/controllers/services_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/services_controller_spec.rb
@@ -897,6 +897,7 @@ RSpec.describe ServicesController, type: :controller do
           'uid' => token.uid,
           'groups' => token.groups,
           'cluster' => {
+            'id' => token.cluster.friendly_id,
             'name' => token.cluster.name,
             'description' => token.cluster.description
           },
@@ -1202,6 +1203,7 @@ RSpec.describe ServicesController, type: :controller do
           'uid' => token.uid,
           'groups' => patch_data[:robot_token][:groups],
           'cluster' => {
+            'id' => token.cluster.friendly_id,
             'name' => token.cluster.name,
             'description' => token.cluster.description
           },

--- a/platform-hub-api/spec/factories/kubernetes_clusters.rb
+++ b/platform-hub-api/spec/factories/kubernetes_clusters.rb
@@ -1,14 +1,26 @@
 FactoryGirl.define do
 
   factory :kubernetes_cluster do
-    name { "dev_#{SecureRandom.uuid}" }
+    sequence :name do |n|
+      "dev_#{n}"
+    end
     description { 'Dev cluster' }
 
     s3_region { 'eu-west-2' }
     s3_bucket_name { 'some-bucket' }
     s3_access_key_id { ENCRYPTOR.encrypt('s3_access_key_id') }
-    s3_secret_access_key { ENCRYPTOR.encrypt('s3_secret_access_key') } 
+    s3_secret_access_key { ENCRYPTOR.encrypt('s3_secret_access_key') }
     s3_object_key { 's3/object/key.csv' }
+
+    transient do
+      allocate_to nil
+    end
+
+    after(:create) do |cluster, evaluator|
+      if evaluator.allocate_to
+        create :allocation, allocatable: cluster, allocation_receivable: evaluator.allocate_to
+      end
+    end
   end
 
 end

--- a/platform-hub-api/spec/routing/kubernetes_clusters_routing_spec.rb
+++ b/platform-hub-api/spec/routing/kubernetes_clusters_routing_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Kubernetes::ClustersController, type: :routing do
   describe 'routing' do
 
     context 'with kubernetes_tokens feature flag enabled' do
+
       before do
         FeatureFlagService.create_or_update(:kubernetes_tokens, true)
       end
@@ -27,9 +28,23 @@ RSpec.describe Kubernetes::ClustersController, type: :routing do
       it 'routes to #update via PUT' do
         expect(:put => '/kubernetes/clusters/foo').to route_to('kubernetes/clusters#update', :id => 'foo')
       end
+
+      it 'routes to #allocate' do
+        expect(:post => '/kubernetes/clusters/foo/allocate').to route_to('kubernetes/clusters#allocate', :id => 'foo')
+      end
+
+      it 'routes to #allocations' do
+        expect(:get => '/kubernetes/groups/foo/allocations').to route_to('kubernetes/groups#allocations', :id => 'foo')
+      end
+
     end
 
     context 'with kubernetes_tokens feature flag disabled' do
+
+      before do
+        FeatureFlagService.create_or_update(:kubernetes_tokens, false)
+      end
+
       it 'route to #index is not routable' do
         expect(:get => '/kubernetes/clusters').to_not be_routable
       end
@@ -49,6 +64,15 @@ RSpec.describe Kubernetes::ClustersController, type: :routing do
       it 'route to #update is not routable via PUT' do
         expect(:put => '/kubernetes/clusters/foo').to_not be_routable
       end
+
+      it 'route to #allocate is not routable' do
+        expect(:post => '/kubernetes/clusters/foo/allocate').to_not be_routable
+      end
+
+      it 'route to #allocations is not routable' do
+        expect(:get => '/kubernetes/clusters/foo/allocations').to_not be_routable
+      end
+
     end
 
   end

--- a/platform-hub-api/spec/routing/projects_routing_spec.rb
+++ b/platform-hub-api/spec/routing/projects_routing_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe ProjectsController, type: :routing do
         expect(:put => '/projects/1/memberships/25/role/unknown_role').not_to be_routable
       end
 
+      it 'routes to #kubernetes_clusters' do
+        expect(:get => '/projects/1/kubernetes_clusters').to route_to('projects#kubernetes_clusters', :id => '1')
+      end
+
       it 'routes to #kubernetes_groups' do
         expect(:get => '/projects/1/kubernetes_groups').to route_to('projects#kubernetes_groups', :id => '1')
       end
@@ -119,6 +123,10 @@ RSpec.describe ProjectsController, type: :routing do
 
       it 'route to #unset_role is not routable' do
         expect(:delete => '/projects/1/memberships/25/role/manager').to_not be_routable
+      end
+
+      it 'route to #kubernetes_clusters is not routable' do
+        expect(:get => '/projects/1/kubernetes_clusters').to_not be_routable
       end
 
       it 'route to #kubernetes_groups is not routable' do

--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -26,6 +26,7 @@ import {
 } from './home/home.module';
 import {IdentitiesManager} from './identities/identities.module';
 import {
+  KubernetesClustersDetail,
   KubernetesClustersForm,
   KubernetesClustersList,
   KubernetesGroupsDetail,
@@ -141,6 +142,18 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
             rolePermitted: 'admin'
           }
         })
+        .state('kubernetes.clusters.detail', {
+          url: '/detail/:id',
+          component: KubernetesClustersDetail,
+          resolve: {
+            transition: '$transition$'
+          },
+          data: {
+            authenticate: true,
+            featureFlag: featureFlagKeys.projects,
+            rolePermitted: 'admin'
+          }
+        })
         .state('kubernetes.clusters.new', {
           url: '/new',
           component: KubernetesClustersForm,
@@ -151,7 +164,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           }
         })
         .state('kubernetes.clusters.edit', {
-          url: '/edit/:name',
+          url: '/edit/:id',
           component: KubernetesClustersForm,
           resolve: {
             transition: '$transition$'

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-detail.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-detail.component.js
@@ -1,0 +1,68 @@
+export const KubernetesClustersDetailComponent = {
+  bindings: {
+    transition: '<'
+  },
+  template: require('./kubernetes-clusters-detail.html'),
+  controller: KubernetesClustersDetailController
+};
+
+function KubernetesClustersDetailController(KubernetesClusters, projectServiceSelectorPopupService, logger) {
+  'ngInject';
+
+  const ctrl = this;
+
+  const id = ctrl.transition.params().id;
+
+  ctrl.loading = true;
+  ctrl.cluster = null;
+  ctrl.allocations = [];
+  ctrl.loadingAllocations = [];
+
+  ctrl.allocate = allocate;
+  ctrl.loadAllocations = loadAllocations;
+
+  init();
+
+  function init() {
+    loadCluster();
+  }
+
+  function loadCluster() {
+    ctrl.loading = true;
+    ctrl.cluster = null;
+
+    KubernetesClusters
+      .get(id)
+      .then(cluster => {
+        ctrl.cluster = cluster;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function allocate(targetEvent) {
+    return projectServiceSelectorPopupService
+      .openForProjectOnly(targetEvent)
+      .then(result => {
+        return KubernetesClusters.allocate(ctrl.cluster.id, result.project.id);
+      })
+      .then(() => {
+        logger.success('Successfully allocated this cluster to a project');
+        loadAllocations();
+      });
+  }
+
+  function loadAllocations() {
+    ctrl.loadingAllocations = true;
+
+    return KubernetesClusters
+      .getAllocations(ctrl.cluster.id)
+      .then(allocations => {
+        angular.copy(allocations, ctrl.allocations);
+      })
+      .finally(() => {
+        ctrl.loadingAllocations = false;
+      });
+  }
+}

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-detail.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-detail.html
@@ -1,0 +1,74 @@
+<div class="kubernetes-clusters-detail">
+  <md-toolbar md-scroll-shrink>
+    <div class="md-toolbar-tools">
+      <h3 ng-if="$ctrl.cluster">
+        <span>Kubernetes Cluster: </span>
+        <span>{{$ctrl.cluster.name}}</span>
+      </h3>
+      <span flex></span>
+      <md-button
+        ng-if="$ctrl.cluster"
+        aria-label="Edit this cluster"
+        ui-sref="kubernetes.clusters.edit({id: $ctrl.cluster.id})">
+        <md-icon>edit</md-icon>
+        Edit
+      </md-button>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading"></loading-indicator>
+
+  <md-content>
+    <md-tabs
+      ng-if="!$ctrl.loading && $ctrl.cluster"
+      md-dynamic-height
+      md-border-bottom>
+
+      <md-tab id="overview-tab">
+        <md-tab-label>Overview</md-tab-label>
+        <md-tab-body>
+          <div layout-padding>
+            <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z2">
+              <md-content layout-padding>
+
+                <h3 class="md-title">
+                  {{$ctrl.cluster.name}}
+                </h3>
+
+                <p
+                  class="md-body-1"
+                  md-colors="{background: 'blue-grey-50'}"
+                  ng-if="$ctrl.cluster.description"
+                  ng-bind-html='$ctrl.cluster.description | simpleFormat'>
+                </p>
+
+              </md-content>
+            </div>
+          </div>
+        </md-tab-body>
+      </md-tab>
+
+      <md-tab id="allocations-tab" md-on-select="$ctrl.loadAllocations()">
+        <md-tab-label>Allocations</md-tab-label>
+        <md-tab-body>
+          <loading-indicator loading="$ctrl.loadingAllocations"></loading-indicator>
+
+          <div layout="row" layout-align="center center">
+            <md-button
+              class="md-primary md-raised"
+              ng-click="$ctrl.allocate($event)">
+              Allocate this cluster to a project
+            </md-button>
+          </div>
+
+          <allocations-listing
+            busy="$ctrl.loadingAllocations"
+            items="$ctrl.allocations"
+            allocatable-noun="cluster"
+            after-delete="$ctrl.loadAllocations()">
+          </allocations-listing>
+        </md-tab-body>
+      </md-tab>
+    </md-tabs>
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.component.js
@@ -6,12 +6,12 @@ export const KubernetesClustersFormComponent = {
   controller: KubernetesClustersFormController
 };
 
-function KubernetesClustersFormController($state, hubApiService, KubernetesClusters, logger) {
+function KubernetesClustersFormController($state, KubernetesClusters, logger) {
   'ngInject';
 
   const ctrl = this;
 
-  const name = ctrl.transition && ctrl.transition.params().name;
+  const id = ctrl.transition && ctrl.transition.params().id;
 
   ctrl.loading = true;
   ctrl.saving = false;
@@ -23,7 +23,7 @@ function KubernetesClustersFormController($state, hubApiService, KubernetesClust
   init();
 
   function init() {
-    ctrl.isNew = !name;
+    ctrl.isNew = !id;
 
     if (ctrl.isNew) {
       ctrl.cluster = {};
@@ -38,7 +38,7 @@ function KubernetesClustersFormController($state, hubApiService, KubernetesClust
     ctrl.cluster = {};
 
     KubernetesClusters
-      .get(name)
+      .get(id)
       .then(cluster => {
         // Make sure to store a copy as we may be mutating this!
         angular.copy(cluster, ctrl.cluster);
@@ -57,8 +57,8 @@ function KubernetesClustersFormController($state, hubApiService, KubernetesClust
     ctrl.saving = true;
 
     if (ctrl.isNew) {
-      hubApiService
-        .createKubernetesCluster(ctrl.cluster)
+      KubernetesClusters
+        .create(ctrl.cluster)
         .then(() => {
           logger.success('New cluster created');
           $state.go('kubernetes.clusters.list');
@@ -67,8 +67,8 @@ function KubernetesClustersFormController($state, hubApiService, KubernetesClust
           ctrl.saving = false;
         });
     } else {
-      hubApiService
-        .updateKubernetesCluster(ctrl.cluster.name, ctrl.cluster)
+      KubernetesClusters
+        .update(ctrl.cluster.id, ctrl.cluster)
         .then(() => {
           logger.success('Cluster updated');
           $state.go('kubernetes.clusters.list');

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
@@ -125,7 +125,18 @@
               <span ng-if="$ctrl.isNew">Create</span>
               <span ng-if="!$ctrl.isNew">Update</span>
             </md-button>
-            <md-button ui-sref="kubernetes.clusters.list" ng-disabled="$ctrl.saving">Cancel</md-button>
+            <md-button
+              ng-if="$ctrl.isNew"
+              ui-sref="kubernetes.clusters.list"
+              ng-disabled="$ctrl.saving">
+              Cancel
+            </md-button>
+            <md-button
+              ng-if="!$ctrl.isNew"
+              ui-sref="kubernetes.clusters.detail({id: $ctrl.cluster.id})"
+              ng-disabled="$ctrl.saving">
+              Cancel
+            </md-button>
           </div>
 
         </form>

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-list.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-list.html
@@ -2,7 +2,7 @@
   <md-toolbar md-scroll-shrink>
     <div class="md-toolbar-tools">
       <h3>
-        <span>All Kubernetes Cluster Configs</span>
+        <span>All Kubernetes Clusters</span>
       </h3>
       <span flex></span>
       <md-button
@@ -29,13 +29,14 @@
           {{c.description}}
         </p>
       </md-card-content>
-      <md-card-actions layout="row">
+      <md-card-actions layout="row" layout-align="start center">
         <md-button
           class="md-primary"
-          aria-label="Edit cluster config"
-          ui-sref="kubernetes.clusters.edit({name: c.name})">
-          Edit
+          aria-label="View details of this kubernetes cluster"
+          ui-sref="kubernetes.clusters.detail({id: c.id})">
+          Details
         </md-button>
+      </md-card-actions>
       </md-card-actions>
     </md-card>
 

--- a/platform-hub-web/src/app/kubernetes/kubernetes-groups-detail.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-groups-detail.component.js
@@ -6,7 +6,7 @@ export const KubernetesGroupsDetailComponent = {
   controller: KubernetesGroupsDetailController
 };
 
-function KubernetesGroupsDetailController($mdDialog, $state, KubernetesGroups, projectServiceSelectorPopupService, hubApiService, logger) {
+function KubernetesGroupsDetailController($mdDialog, $state, KubernetesGroups, projectServiceSelectorPopupService, logger) {
   'ngInject';
 
   const ctrl = this;
@@ -21,7 +21,6 @@ function KubernetesGroupsDetailController($mdDialog, $state, KubernetesGroups, p
   ctrl.deleteGroup = deleteGroup;
   ctrl.allocate = allocate;
   ctrl.loadAllocations = loadAllocations;
-  ctrl.deleteAllocation = deleteAllocation;
 
   init();
 
@@ -70,8 +69,8 @@ function KubernetesGroupsDetailController($mdDialog, $state, KubernetesGroups, p
   }
 
   function allocate(targetEvent) {
-    projectServiceSelectorPopupService
-      .open(true, targetEvent)
+    return projectServiceSelectorPopupService
+      .openForProjectOrService(targetEvent)
       .then(result => {
         if (result.service) {
           return KubernetesGroups.allocateToService(
@@ -102,32 +101,6 @@ function KubernetesGroupsDetailController($mdDialog, $state, KubernetesGroups, p
       })
       .finally(() => {
         ctrl.loadingAllocations = false;
-      });
-  }
-
-  function deleteAllocation(allocation, targetEvent) {
-    const confirm = $mdDialog.confirm()
-      .title('Are you sure?')
-      .textContent('This will delete the allocation selected')
-      .ariaLabel('Confirm deletion of allocation of RBAC group')
-      .targetEvent(targetEvent)
-      .ok('Do it')
-      .cancel('Cancel');
-
-    $mdDialog
-      .show(confirm)
-      .then(() => {
-        ctrl.loadingAllocations = true;
-
-        return hubApiService
-          .deleteAllocation(allocation.id)
-          .then(() => {
-            logger.success('Allocation deleted');
-            return loadAllocations();
-          })
-          .finally(() => {
-            ctrl.loadingAllocations = false;
-          });
       });
   }
 }

--- a/platform-hub-web/src/app/kubernetes/kubernetes-groups-detail.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-groups-detail.html
@@ -95,46 +95,16 @@
             <md-button
               class="md-primary md-raised"
               ng-click="$ctrl.allocate($event)">
-              Allocate this to a project or a project's service
+              Allocate this group to a project OR a project's service
             </md-button>
           </div>
 
-          <div ng-if="$ctrl.allocations.length == 0" layout-padding>
-            <p class="md-body-1 none-text text-center">
-              This group has not been allocated to anything yet
-            </p>
-          </div>
-
-          <md-card
-            ng-repeat="a in $ctrl.allocations track by a.id"
-            ng-init="ar_type = a.allocation_receivable.type; ar = a.allocation_receivable[ar_type]">
-            <md-card-title>
-              <span class="md-headline" ng-switch="ar_type">
-                <span ng-switch-when="project">
-                  Project: {{ar.name}} ({{ar.shortname}})
-                </span>
-                <span ng-switch-when="service">
-                  Service: {{ar.name}}
-                  <br />
-                  <span class="md-subhead">
-                    Project: {{ar.project.name}} ({{ar.project.shortname}})
-                  </span>
-                </span>
-                <span ng-switch-default>
-                  <span>{{ar_type}}: </span>
-                  <span>{{ar.name || ar.shortname || ar.title}}</span>
-                </span>
-              </span>
-            </md-card-title>
-            <md-card-actions layout="row" layout-align="start center">
-              <md-button
-                class="md-primary"
-                aria-label="Delete this allocation"
-                ng-click="$ctrl.deleteAllocation(a, $event)">
-                Delete
-              </md-button>
-            </md-card-actions>
-          </md-card>
+          <allocations-listing
+            busy="$ctrl.loadingAllocations"
+            items="$ctrl.allocations"
+            allocatable-noun="group"
+            after-delete="$ctrl.loadAllocations()">
+          </allocations-listing>
         </md-tab-body>
       </md-tab>
     </md-tabs>

--- a/platform-hub-web/src/app/kubernetes/kubernetes-groups-list.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-groups-list.component.js
@@ -9,12 +9,11 @@ function KubernetesGroupsListController(KubernetesGroups) {
   const ctrl = this;
 
   ctrl.KubernetesGroups = KubernetesGroups;
+  ctrl.loading = true;
 
   init();
 
   function init() {
-    ctrl.loading = true;
-
     KubernetesGroups
       .refresh()
       .finally(() => {

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.spec.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.spec.js
@@ -30,7 +30,6 @@ describe('kubernetes robot tokens form', () => {
   let $state = null;
   let roleCheckerService = null;
   let Projects = null;
-  let KubernetesClusters = null;
 
   beforeEach(() => {
     const moduleName = `${KubernetesModule}.KubernetesRobotTokensFormComponent.spec`;
@@ -38,7 +37,7 @@ describe('kubernetes robot tokens form', () => {
     angular.mock.module(moduleName);
   });
 
-  beforeEach(angular.mock.inject((_$compile_, _$rootScope_, _$q_, _$httpBackend_, _$state_, _roleCheckerService_, _Projects_, _KubernetesClusters_) => {
+  beforeEach(angular.mock.inject((_$compile_, _$rootScope_, _$q_, _$httpBackend_, _$state_, _roleCheckerService_, _Projects_) => {
     sandbox = sinon.sandbox.create();
 
     $compile = _$compile_;
@@ -48,7 +47,6 @@ describe('kubernetes robot tokens form', () => {
     $state = _$state_;
     roleCheckerService = _roleCheckerService_;
     Projects = _Projects_;
-    KubernetesClusters = _KubernetesClusters_;
 
     $httpBackend
       .whenGET(/.+/)
@@ -99,7 +97,6 @@ describe('kubernetes robot tokens form', () => {
 
   beforeEach(() => {
     sandbox.spy($state, 'go');
-    sandbox.spy(KubernetesClusters, 'refresh');
   });
 
   describe('for an admin user', () => {
@@ -118,7 +115,6 @@ describe('kubernetes robot tokens form', () => {
 
         it('should boot the user out', () => {
           $state.go.should.have.been.calledWith('home');
-          KubernetesClusters.refresh.should.have.callCount(0);
         });
       });
 
@@ -129,7 +125,6 @@ describe('kubernetes robot tokens form', () => {
 
         it('should load the form as expected', () => {
           $state.go.should.have.callCount(0);
-          KubernetesClusters.refresh.should.have.callCount(1);
           expect(element).toContainElement('div.kubernetes-robot-tokens-form');
         });
       });
@@ -146,7 +141,6 @@ describe('kubernetes robot tokens form', () => {
 
         it('should load the form as expected', () => {
           $state.go.should.have.callCount(0);
-          KubernetesClusters.refresh.should.have.callCount(1);
           expect(element).toContainElement('div.kubernetes-robot-tokens-form');
         });
       });
@@ -165,7 +159,6 @@ describe('kubernetes robot tokens form', () => {
 
         it('should load the form as expected', () => {
           $state.go.should.have.callCount(0);
-          KubernetesClusters.refresh.should.have.callCount(1);
           expect(element).toContainElement('div.kubernetes-robot-tokens-form');
         });
       });
@@ -182,7 +175,6 @@ describe('kubernetes robot tokens form', () => {
 
         it('should load the form as expected', () => {
           $state.go.should.have.callCount(0);
-          KubernetesClusters.refresh.should.have.callCount(1);
           expect(element).toContainElement('div.kubernetes-robot-tokens-form');
         });
       });
@@ -205,7 +197,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
 
@@ -222,7 +213,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should load the form as expected', () => {
             $state.go.should.have.callCount(0);
-            KubernetesClusters.refresh.should.have.callCount(1);
             expect(element).toContainElement('div.kubernetes-robot-tokens-form');
           });
         });
@@ -239,7 +229,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
       });
@@ -259,7 +248,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
 
@@ -276,7 +264,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should load the form as expected', () => {
             $state.go.should.have.callCount(0);
-            KubernetesClusters.refresh.should.have.callCount(1);
             expect(element).toContainElement('div.kubernetes-robot-tokens-form');
           });
         });
@@ -293,7 +280,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
       });
@@ -315,7 +301,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
 
@@ -329,7 +314,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
 
@@ -343,7 +327,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
       });
@@ -361,7 +344,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
 
@@ -375,7 +357,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
 
@@ -389,7 +370,6 @@ describe('kubernetes robot tokens form', () => {
 
           it('should boot the user out', () => {
             $state.go.should.have.been.calledWith('home');
-            KubernetesClusters.refresh.should.have.callCount(0);
           });
         });
       });

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.html
@@ -29,7 +29,7 @@
               <input
                 name="service"
                 ng-value="$ctrl.service.name"
-                ng-class="{'pointer': $ctrl.isAdmin}"
+                ng-class="{'pointer': $ctrl.isAdmin && !$ctrl.fromService}"
                 disabled="true"
                 required>
               <div ng-messages="$ctrl.kubernetesTokenForm.service.$error">
@@ -63,6 +63,16 @@
             </md-button>
           </div>
 
+          <p
+            ng-if="!$ctrl.processing && $ctrl.service && $ctrl.allowedClusters.length == 0"
+            class="md-body-2"
+            md-colors="{background: 'accent-50'}"
+            layout-padding>
+            No Kubernetes clusters have been allocated yet to this project.
+            <br />
+            Please contact the {{$ctrl.AppSettings.getPlatformName()}} team to allocate a cluster to use in the project.
+          </p>
+
           <md-input-container class="md-block">
             <label for="cluster">Cluster:</label>
             <md-select
@@ -71,9 +81,9 @@
               ng-change="$ctrl.handleClusterChange()"
               required
               placeholder="Select the cluster"
-              ng-disabled="!$ctrl.service || (!$ctrl.isNew && $ctrl.token.cluster)">
+              ng-disabled="!$ctrl.service || (!$ctrl.isNew && $ctrl.token.cluster) || $ctrl.allowedClusters.length == 0">
               <md-option
-                ng-repeat="c in $ctrl.KubernetesClusters.all track by c.name"
+                ng-repeat="c in $ctrl.allowedClusters track by c.name"
                 ng-value="c.name">
                 {{c.name}} ({{c.description}})
               </md-option>

--- a/platform-hub-web/src/app/kubernetes/kubernetes.module.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes.module.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 
+import {KubernetesClustersDetailComponent} from './kubernetes-clusters-detail.component';
 import {KubernetesClustersFormComponent} from './kubernetes-clusters-form.component';
 import {KubernetesClustersListComponent} from './kubernetes-clusters-list.component';
 import {KubernetesGroupsDetailComponent} from './kubernetes-groups-detail.component';
@@ -14,6 +15,7 @@ import {KubernetesUserTokensFormComponent} from './kubernetes-user-tokens-form.c
 import {KubernetesUserTokensListComponent} from './kubernetes-user-tokens-list.component';
 
 // Main section component names
+export const KubernetesClustersDetail = 'kubernetesClustersDetail';
 export const KubernetesClustersForm = 'kubernetesClustersForm';
 export const KubernetesClustersList = 'kubernetesClustersList';
 export const KubernetesGroupsDetail = 'kubernetesGroupsDetail';
@@ -27,6 +29,7 @@ export const KubernetesUserTokensList = 'kubernetesUserTokensList';
 
 export const KubernetesModule = angular
   .module('app.kubernetes', [])
+  .component(KubernetesClustersDetail, KubernetesClustersDetailComponent)
   .component(KubernetesClustersForm, KubernetesClustersFormComponent)
   .component(KubernetesClustersList, KubernetesClustersListComponent)
   .component(KubernetesGroupsDetail, KubernetesGroupsDetailComponent)

--- a/platform-hub-web/src/app/projects/services/project-service-selector-popup.controller.js
+++ b/platform-hub-web/src/app/projects/services/project-service-selector-popup.controller.js
@@ -1,10 +1,10 @@
-export const ProjectServiceSelectorPopupController = function ($mdDialog, Projects, serviceIsOptional) {
+export const ProjectServiceSelectorPopupController = function ($mdDialog, Projects, mode) {
   'ngInject';
 
   const ctrl = this;
 
   ctrl.Projects = Projects;
-  ctrl.serviceIsOptional = serviceIsOptional;
+  ctrl.mode = mode;
 
   ctrl.loading = true;
   ctrl.selectedProject = null;
@@ -27,6 +27,10 @@ export const ProjectServiceSelectorPopupController = function ($mdDialog, Projec
   }
 
   function handleProjectChanged() {
+    if (ctrl.mode === 'project-only') {
+      return;
+    }
+
     ctrl.loading = true;
     ctrl.services = [];
     ctrl.selectedService = null;

--- a/platform-hub-web/src/app/projects/services/project-service-selector-popup.html
+++ b/platform-hub-web/src/app/projects/services/project-service-selector-popup.html
@@ -1,10 +1,13 @@
 <md-dialog aria-label="Choose a project service">
   <md-toolbar class="md-toolbar-tools md-accent">
-    <h2 ng-if="$ctrl.serviceIsOptional">
-      Choose a project or a service from a project
+    <h2 ng-if="$ctrl.mode == 'project-only'">
+      Choose a project
     </h2>
-    <h2 ng-if="!$ctrl.serviceIsOptional">
+    <h2 ng-if="$ctrl.mode == 'service-only'">
       Choose a service from a project
+    </h2>
+    <h2 ng-if="$ctrl.mode == 'project-or-service'">
+      Choose a project or a service from a project
     </h2>
     <span flex></span>
     <md-button
@@ -37,13 +40,13 @@
         </md-select>
       </md-input-container>
 
-      <md-input-container class="md-block">
+      <md-input-container class="md-block" ng-if="$ctrl.mode != 'project-only'">
         <label for="service">Service:</label>
         <md-select
           name="service"
           ng-model="$ctrl.selectedService"
           ng-disabled="!$ctrl.services.length"
-          ng-required="!$ctrl.serviceIsOptional">
+          ng-required="$ctrl.mode == 'service-only'">
           <md-option
             ng-repeat="s in $ctrl.services"
             ng-value="s">
@@ -63,8 +66,8 @@
       Cancel
     </md-button>
     <md-button
-      ng-if="$ctrl.serviceIsOptional"
       class="md-primary md-raised"
+      ng-if="$ctrl.mode == 'project-only' || $ctrl.mode == 'project-or-service'"
       ng-click="$ctrl.chooseProject()"
       ng-disabled="$ctrl.loading || !$ctrl.selectedProject"
       aria-label="Choose the selected project">
@@ -72,6 +75,7 @@
     </md-button>
     <md-button
       class="md-primary md-raised"
+      ng-if="$ctrl.mode != 'project-only'"
       ng-click="$ctrl.chooseService()"
       ng-disabled="$ctrl.loading || !$ctrl.selectedService"
       aria-label="Choose the selected service">

--- a/platform-hub-web/src/app/projects/services/project-service-selector-popup.service.js
+++ b/platform-hub-web/src/app/projects/services/project-service-selector-popup.service.js
@@ -3,11 +3,21 @@ export const projectServiceSelectorPopupService = function ($document, $mdDialog
 
   const service = {};
 
-  service.open = open;
+  service.openForProjectOnly = function targetEvent() {
+    return _open('project-only', targetEvent);
+  };
+
+  service.openForServiceOnly = function (targetEvent) {
+    return _open('service-only', targetEvent);
+  };
+
+  service.openForProjectOrService = function (targetEvent) {
+    return _open('project-or-service', targetEvent);
+  };
 
   return service;
 
-  function open(serviceIsOptional, targetEvent) {
+  function _open(mode, targetEvent) {
     return $mdDialog.show({
       template: require('./project-service-selector-popup.html'),
       controller: 'ProjectServiceSelectorPopupController',
@@ -18,7 +28,7 @@ export const projectServiceSelectorPopupService = function ($document, $mdDialog
       clickOutsideToClose: false,
       escapeToClose: false,
       locals: {
-        serviceIsOptional
+        mode
       }
     });
   }

--- a/platform-hub-web/src/app/shared/allocations-listing.component.js
+++ b/platform-hub-web/src/app/shared/allocations-listing.component.js
@@ -1,0 +1,44 @@
+export const AllocationsListingComponent = {
+  bindings: {
+    busy: '=',
+    items: '<',
+    allocatableNoun: '@',
+    afterDelete: '&'
+  },
+  template: require('./allocations-listing.html'),
+  controller: AllocationsListingController
+};
+
+function AllocationsListingController($mdDialog, hubApiService, logger) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.deleteAllocation = deleteAllocation;
+
+  function deleteAllocation(allocation, targetEvent) {
+    const confirm = $mdDialog.confirm()
+      .title('Are you sure?')
+      .textContent('This will delete the allocation selected')
+      .ariaLabel(`Confirm deletion of allocation for ${ctrl.allocatableNoun}`)
+      .targetEvent(targetEvent)
+      .ok('Do it')
+      .cancel('Cancel');
+
+    $mdDialog
+      .show(confirm)
+      .then(() => {
+        ctrl.busy = true;
+
+        return hubApiService
+          .deleteAllocation(allocation.id)
+          .then(() => {
+            logger.success('Allocation deleted');
+            return ctrl.afterDelete();
+          })
+          .finally(() => {
+            ctrl.busy = false;
+          });
+      });
+  }
+}

--- a/platform-hub-web/src/app/shared/allocations-listing.html
+++ b/platform-hub-web/src/app/shared/allocations-listing.html
@@ -1,0 +1,36 @@
+<div ng-if="$ctrl.items.length == 0" layout-padding>
+  <p class="md-body-1 none-text text-center">
+    This {{$ctrl.allocatableNoun}} has not been allocated to anything yet
+  </p>
+</div>
+
+<md-card
+  ng-repeat="a in $ctrl.items track by a.id"
+  ng-init="ar_type = a.allocation_receivable.type; ar = a.allocation_receivable[ar_type]">
+  <md-card-title>
+    <span class="md-headline" ng-switch="ar_type">
+      <span ng-switch-when="project">
+        Project: {{ar.name}} ({{ar.shortname}})
+      </span>
+      <span ng-switch-when="service">
+        Service: {{ar.name}}
+        <br />
+        <span class="md-subhead">
+          Project: {{ar.project.name}} ({{ar.project.shortname}})
+        </span>
+      </span>
+      <span ng-switch-default>
+        <span>{{ar_type}}: </span>
+        <span>{{ar.name || ar.shortname || ar.title}}</span>
+      </span>
+    </span>
+  </md-card-title>
+  <md-card-actions layout="row" layout-align="start center">
+    <md-button
+      class="md-primary"
+      aria-label="Delete this allocation"
+      ng-click="$ctrl.deleteAllocation(a, $event)">
+      Delete
+    </md-button>
+  </md-card-actions>
+</md-card>

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -261,12 +261,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .post(`${apiEndpoint}/users/${userId}/activate`)
-      .then(response => {
-        // handle 4xx errors which are not picked up by `catch`.
-        if (response.data.error && response.status.toString().match(/4../)) {
-          return $q.reject(response);
-        }
-      })
+      .then(handle4xxError)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to activate user', response));
         return $q.reject(response);
@@ -922,11 +917,8 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         project_id: projectId,
         service_id: serviceId
       })
+      .then(handle4xxError)
       .then(response => {
-        // handle 4xx errors which are not handled by $http
-        if (response.status.toString().match(/4../)) {
-          return $q.reject(response);
-        }
         return response.data;
       })
       .catch(response => {
@@ -963,12 +955,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .delete(`${apiEndpoint}/kubernetes/tokens/${tokenId}`)
-      .then(response => {
-        // handle 4xx errors which are not picked up by `catch`.
-        if (response.data.error && response.status.toString().match(/4../)) {
-          return $q.reject(response);
-        }
-      })
+      .then(handle4xxError)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to delete kubernetes token', response));
         return $q.reject(response);
@@ -990,12 +977,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         cluster_name: data.cluster.name,
         groups: data.groups
       })
-      .then(response => {
-        // handle 4xx errors which are not picked up by `catch`.
-        if (response.data.error && response.status.toString().match(/4../)) {
-          return $q.reject(response);
-        }
-      })
+      .then(handle4xxError)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse(`Failed to create kubernetes token`, response));
         return $q.reject(response);
@@ -1015,12 +997,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         kind: 'user',
         groups: data.groups
       })
-      .then(response => {
-        // handle 4xx errors which are not picked up by `catch`.
-        if (response.data.error && response.status.toString().match(/4../)) {
-          return $q.reject(response);
-        }
-      })
+      .then(handle4xxError)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse(`Failed to update a "${data.cluster}" kubernetes token`, response));
         return $q.reject(response);
@@ -1065,12 +1042,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         name: data.name,
         description: data.description
       })
-      .then(response => {
-        // handle 4xx errors which are not picked up by `catch`.
-        if (response.data.error && response.status.toString().match(/4../)) {
-          return $q.reject(response);
-        }
-      })
+      .then(handle4xxError)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse(`Failed to create a kubernetes robot token`, response));
         return $q.reject(response);
@@ -1091,12 +1063,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         groups: data.groups,
         description: data.description
       })
-      .then(response => {
-        // handle 4xx errors which are not picked up by `catch`.
-        if (response.data.error && response.status.toString().match(/4../)) {
-          return $q.reject(response);
-        }
-      })
+      .then(handle4xxError)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse(`Failed to update a "${data.name}" kubernetes robot token`, response));
         return $q.reject(response);
@@ -1142,12 +1109,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .post(`${apiEndpoint}/kubernetes/revoke`, data)
-      .then(response => {
-        // handle 4xx errors which are not picked up by `catch`.
-        if (response.data.error && response.status.toString().match(/4../)) {
-          return $q.reject(response);
-        }
-      })
+      .then(handle4xxError)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Revocation error', response));
         return $q.reject(response);
@@ -1170,12 +1132,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         privileged_group: group,
         expires_in_secs: expiresInSecs
       })
-      .then(response => {
-        // handle 4xx errors which are not picked up by `catch`.
-        if (response.data.error && response.status.toString().match(/4../)) {
-          return $q.reject(response);
-        }
-      })
+      .then(handle4xxError)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to escalate privilege on Kube token', response));
         return $q.reject(response);

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -130,9 +130,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   function getMe() {
     return $http
       .get(`${apiEndpoint}/me`)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error('Failed to fetch profile data – the API might be down. Try again later.');
         return $q.reject(response);
@@ -164,9 +162,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
     return $http
       .post(`${apiEndpoint}/me/complete_hub_onboarding`, data)
       .then(handle4xxError)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to complete hub onboarding', response));
         return $q.reject(response);
@@ -177,9 +173,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
     return $http
       .post(`${apiEndpoint}/me/complete_services_onboarding`)
       .then(handle4xxError)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to complete services onboarding', response));
         return $q.reject(response);
@@ -189,9 +183,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   function agreeTermsOfService() {
     return $http
       .post(`${apiEndpoint}/me/agree_terms_of_service`)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Error occurred whilst agreeing to terms of service', response));
         return $q.reject(response);
@@ -202,9 +194,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
     return $http
       .post(`${apiEndpoint}/me/global_announcements/mark_all_read`)
       .then(handle4xxError)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to mark all global announcements as read', response));
         return $q.reject(response);
@@ -218,9 +208,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .get(`${apiEndpoint}/users/search/${query}?include_deactivated=${include_deactivated}`)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to search for users', response));
         return $q.reject(response);
@@ -276,9 +264,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
     return $http
       .post(`${apiEndpoint}/users/${userId}/deactivate`)
       .then(handle4xxError)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to deactivate user', response));
         return $q.reject(response);
@@ -295,9 +281,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .put(`${apiEndpoint}/projects/${projectId}/memberships/${userId}`)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to add team member to project', response));
         return $q.reject(response);
@@ -330,9 +314,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .get(`${apiEndpoint}/projects/${projectId}/memberships/role_check/${role}`)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to check if user if a manager for the specific project', response));
         return $q.reject(response);
@@ -352,9 +334,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .put(`${apiEndpoint}/projects/${projectId}/memberships/${userId}/role/${role}`)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to set project team role', response));
         return $q.reject(response);
@@ -374,9 +354,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .delete(`${apiEndpoint}/projects/${projectId}/memberships/${userId}/role/${role}`)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to unset project team role', response));
         return $q.reject(response);
@@ -394,9 +372,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
           target
         }
       })
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to fetch kubernetes groups for project', response));
         return $q.reject(response);
@@ -417,9 +393,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
           target
         }
       })
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to fetch kubernetes groups for service', response));
         return $q.reject(response);
@@ -448,9 +422,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         }
       })
       .then(handle4xxError)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to create new token for project service', response));
         return $q.reject(response);
@@ -479,9 +451,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         }
       })
       .then(handle4xxError)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to update token for project service', response));
         return $q.reject(response);
@@ -501,9 +471,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .delete(`${apiEndpoint}/projects/${projectId}/services/${serviceId}/kubernetes_robot_tokens/${tokenId}`)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to delete token', response));
         return $q.reject(response);
@@ -545,9 +513,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         data: data
       })
       .then(handle4xxError)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to create support request', response));
         return $q.reject(response);
@@ -611,9 +577,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         data: data
       })
       .then(handle4xxError)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to preview announcement template', response));
         return $q.reject(response);
@@ -918,9 +882,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
         service_id: serviceId
       })
       .then(handle4xxError)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse(`Failed to allocate Kubernetes RBAC group to a project or service`, response));
         return $q.reject(response);
@@ -939,9 +901,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
           user_id: userId
         }
       })
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error('Failed to fetch user kubernetes tokens – the API might be down. Try again later.');
         return $q.reject(response);
@@ -1016,9 +976,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
           cluster_name: cluster
         }
       })
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error('Failed to fetch robot kubernetes tokens – the API might be down. Try again later.');
         return $q.reject(response);
@@ -1077,9 +1035,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .get(`${apiEndpoint}/kubernetes/changeset/${cluster}`)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(`Failed to fetch kubernetes tokens changeset for "${cluster}" cluster – the API might be down. Try again later.`);
         return $q.reject(response);
@@ -1093,9 +1049,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
 
     return $http
       .post(`${apiEndpoint}/kubernetes/sync`, data)
-      .then(response => {
-        return response.data;
-      })
+      .then(response => response.data)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Sync error', response));
         return $q.reject(response);

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -33,6 +33,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.projectMembershipRoleCheck = projectMembershipRoleCheck;
   service.projectSetMembershipRole = projectSetMembershipRole;
   service.projectUnsetMembershipRole = projectUnsetMembershipRole;
+  service.getProjectKubernetesClusters = buildSubCollectionFetcher('projects', 'kubernetes_clusters');
   service.getProjectKubernetesGroups = getProjectKubernetesGroups;
   service.getProjectServices = buildSubCollectionFetcher('projects', 'services');
   service.getProjectService = buildSubResourceFetcher('projects', 'services');
@@ -95,6 +96,8 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.getKubernetesCluster = buildResourceFetcher('kubernetes/clusters');
   service.createKubernetesCluster = buildResourceCreator('kubernetes/clusters');
   service.updateKubernetesCluster = buildResourceUpdater('kubernetes/clusters');
+  service.allocateKubernetesCluster = allocateKubernetesCluster;
+  service.getKubernetesClusterAllocations = buildSubCollectionFetcher('kubernetes/clusters', 'allocations');
 
   service.getKubernetesGroups = buildCollectionFetcher('kubernetes/groups');
   service.getKubernetesGroup = buildResourceFetcher('kubernetes/groups');
@@ -866,6 +869,26 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       return $q.reject(response);
     }
     return response;
+  }
+
+  function allocateKubernetesCluster(clusterId, projectId) {
+    if (_.isNull(clusterId) || _.isEmpty(clusterId)) {
+      throw new Error('"clusterId" argument not specified or empty');
+    }
+    if (_.isNull(projectId) || _.isEmpty(projectId)) {
+      throw new Error('"projectId" argument not specified or empty');
+    }
+
+    return $http
+      .post(`${apiEndpoint}/kubernetes/clusters/${clusterId}/allocate`, {
+        project_id: projectId
+      })
+      .then(handle4xxError)
+      .then(response => response.data)
+      .catch(response => {
+        logger.error(buildErrorMessageFromResponse(`Failed to allocate Kubernetes cluster to a project`, response));
+        return $q.reject(response);
+      });
   }
 
   function allocateKubernetesGroup(groupId, projectId, serviceId) {

--- a/platform-hub-web/src/app/shared/model/kubernetes-clusters.js
+++ b/platform-hub-web/src/app/shared/model/kubernetes-clusters.js
@@ -10,7 +10,11 @@ export const KubernetesClusters = function ($window, hubApiService, apiBackoffTi
   model.all = [];
 
   model.refresh = refresh;
-  model.get = get;
+  model.get = hubApiService.getKubernetesCluster;
+  model.create = hubApiService.createKubernetesCluster;
+  model.update = hubApiService.updateKubernetesCluster;
+  model.allocate = hubApiService.allocateKubernetesCluster;
+  model.getAllocations = hubApiService.getKubernetesClusterAllocations;
 
   return model;
 
@@ -30,12 +34,5 @@ export const KubernetesClusters = function ($window, hubApiService, apiBackoffTi
         });
     }
     return fetcherPromise;
-  }
-
-  function get(name) {
-    return refresh()
-      .then(clusters => {
-        return _.find(clusters, ['name', name]);
-      });
   }
 };

--- a/platform-hub-web/src/app/shared/model/projects.js
+++ b/platform-hub-web/src/app/shared/model/projects.js
@@ -22,6 +22,7 @@ export const Projects = function ($window, $q, apiBackoffTimeMs, hubApiService, 
   model.setMembershipRole = hubApiService.projectSetMembershipRole;
   model.unsetMembershipRole = hubApiService.projectUnsetMembershipRole;
 
+  model.getKubernetesClusters = hubApiService.getProjectKubernetesClusters;
   model.getKubernetesGroups = hubApiService.getProjectKubernetesGroups;
 
   model.getServices = hubApiService.getProjectServices;

--- a/platform-hub-web/src/app/shared/shared.module.js
+++ b/platform-hub-web/src/app/shared/shared.module.js
@@ -7,12 +7,13 @@ import {ModelModule} from './model/model.module';
 import {UiModule} from './ui/ui.module';
 import {UtilModule} from './util/util.module';
 
+import {AllocationsListingComponent} from './allocations-listing.component';
+import {apiInterceptorService} from './api-interceptor.service';
 import {events} from './events.factory';
 import {homeEndpoints} from './home-endpoints.factory';
 import {icons} from './icons.factory';
 import {onboardingTrigger} from './onboarding-trigger.factory';
 import {roleCheckerService} from './role-checker.service';
-import {apiInterceptorService} from './api-interceptor.service';
 
 export const SharedModule = angular
   .module('app.shared', [
@@ -23,10 +24,11 @@ export const SharedModule = angular
     UiModule,
     UtilModule
   ])
+  .component('allocationsListing', AllocationsListingComponent)
+  .service('apiInterceptorService', apiInterceptorService)
   .factory('events', events)
   .factory('homeEndpoints', homeEndpoints)
   .factory('icons', icons)
   .factory('onboardingTrigger', onboardingTrigger)
   .service('roleCheckerService', roleCheckerService)
-  .service('apiInterceptorService', apiInterceptorService)
   .name;


### PR DESCRIPTION
This introduces the capability for hub admins to allocate clusters to projects, and only then can they be used when creating robot tokens.