### PR TITLE
Backend: model validations for checking cluster and groups for kube robot tokens

### DIFF
--- a/platform-hub-api/spec/factories/kubernetes_clusters.rb
+++ b/platform-hub-api/spec/factories/kubernetes_clusters.rb
@@ -17,8 +17,10 @@ FactoryGirl.define do
     end
 
     after(:create) do |cluster, evaluator|
-      if evaluator.allocate_to
-        create :allocation, allocatable: cluster, allocation_receivable: evaluator.allocate_to
+      unless evaluator.allocate_to.blank?
+        Array(evaluator.allocate_to).each do |ar|
+          create :allocation, allocatable: cluster, allocation_receivable: ar
+        end
       end
     end
   end

--- a/platform-hub-api/spec/factories/kubernetes_groups.rb
+++ b/platform-hub-api/spec/factories/kubernetes_groups.rb
@@ -38,8 +38,10 @@ FactoryGirl.define do
     end
 
     after(:create) do |group, evaluator|
-      if evaluator.allocate_to
-        create :allocation, allocatable: group, allocation_receivable: evaluator.allocate_to
+      unless evaluator.allocate_to.blank?
+        Array(evaluator.allocate_to).each do |ar|
+          create :allocation, allocatable: group, allocation_receivable: ar
+        end
       end
     end
   end

--- a/platform-hub-api/spec/services/kubernetes/token_file_service_spec.rb
+++ b/platform-hub-api/spec/services/kubernetes/token_file_service_spec.rb
@@ -2,20 +2,26 @@ require 'rails_helper'
 
 describe Kubernetes::TokenFileService, type: :service do
 
+  let(:service) { create :service }
+
   before do
-    @cluster = create :kubernetes_cluster
+    @cluster = create :kubernetes_cluster, allocate_to: service
   end
 
   describe '.generate' do
+    let(:user_group_1) { create :kubernetes_group, :not_privileged, :for_user }
+    let(:user_group_2) { create :kubernetes_group, :not_privileged, :for_user }
+    let(:robot_group_1) { create :kubernetes_group, :not_privileged, :for_robot, allocate_to: service }
+
     before do
-      @u1 = create :user_kubernetes_token, cluster: @cluster, groups: "g1,g2"
+      @u1 = create :user_kubernetes_token, cluster: @cluster, groups: "#{user_group_1.name},#{user_group_2.name}"
       @u2 = create :user_kubernetes_token, cluster: @cluster, groups: []
-      @r1 = create :robot_kubernetes_token, cluster: @cluster, groups: "g3"
+      @r1 = create :robot_kubernetes_token, tokenable: service, cluster: @cluster, groups: [ robot_group_1.name ]
     end
 
     it 'generates csv tokens file for given cluster name' do
       tokens_csv = subject.generate(@cluster.name)
-      
+
       parsed = CSV.parse(tokens_csv)
       expect(parsed.size).to eq 3
 
@@ -24,7 +30,7 @@ describe Kubernetes::TokenFileService, type: :service do
           expect(i.first).to eq @u1.decrypted_token
           expect(i.second).to eq @u1.name
           expect(i.third).to eq @u1.uid
-          expect(i.fourth).to eq @u1.groups.join(',')
+          expect(i.fourth).to eq "#{user_group_1.name},#{user_group_2.name}"
 
         elsif i.first == @u2.decrypted_token
           expect(i.first).to eq @u2.decrypted_token
@@ -36,11 +42,10 @@ describe Kubernetes::TokenFileService, type: :service do
           expect(i.first).to eq @r1.decrypted_token
           expect(i.second).to eq @r1.name
           expect(i.third).to eq @r1.uid
-          expect(i.fourth).to eq @r1.groups.join(',')
+          expect(i.fourth).to eq robot_group_1.name
         end
       end
     end
   end
 
 end
-


### PR DESCRIPTION
This ensures that only allocated clusters and RBAC groups can be used when creating kubernetes tokens of kind `robot`.

---

**Note:** I've gone for a slightly less performant implementation in order to (hopefully) provide a more readable and better structured solution to the different validations. Given that a) tokens won't be created/updated that often, and b) we assume that at most there only be a few groups assigned to a token, this implementation should be "okay" (until proven otherwise :)).