### PR TITLE
New feature flags for tokens sync + tokens escalation of privileges

### DIFF
--- a/platform-hub-api/app/jobs/tokens_sync_job.rb
+++ b/platform-hub-api/app/jobs/tokens_sync_job.rb
@@ -6,7 +6,10 @@ class TokensSyncJob < ApplicationJob
   end
 
   def perform
-    return unless FeatureFlagService.is_enabled?(:kubernetes_tokens)
+    return unless FeatureFlagService.all_enabled?([
+      :kubernetes_tokens_sync,
+      :kubernetes_tokens
+    ])
 
     KubernetesCluster.names.each do |cluster_name|
       begin

--- a/platform-hub-api/app/services/feature_flag_service.rb
+++ b/platform-hub-api/app/services/feature_flag_service.rb
@@ -33,6 +33,10 @@ module FeatureFlagService
     feature_flags.data.with_indifferent_access[flag] || false
   end
 
+  def all_enabled?(flags)
+    return flags.all?(&method(:is_enabled?))
+  end
+
   private
 
   def feature_flags

--- a/platform-hub-api/lib/tasks/kubernetes.rake
+++ b/platform-hub-api/lib/tasks/kubernetes.rake
@@ -2,8 +2,11 @@ namespace :kubernetes do
 
   desc "Trigger the Kubernetes sync tokens job if it's not already in the queue"
   task trigger_tokens_sync: :environment do
-    if !FeatureFlagService.is_enabled?(:kubernetes_tokens)
-      puts 'Kubernetes tokens feature flag is turned off... will not trigger tokens sync job'
+    if !FeatureFlagService.all_enabled?([
+      :kubernetes_tokens_sync,
+      :kubernetes_tokens
+    ])
+      puts 'Kubernetes tokens and/or tokens sync feature flags are turned off... will not trigger tokens sync job'
     elsif TokensSyncJob.is_already_queued
       puts 'Tokens sync job already in queue... will not trigger another one'
     else

--- a/platform-hub-api/spec/routing/kubernetes_sync_routing_spec.rb
+++ b/platform-hub-api/spec/routing/kubernetes_sync_routing_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe Kubernetes::SyncController, type: :routing do
   describe 'routing' do
 
-    context 'with kubernetes_tokens feature flag enabled' do
+    context 'with kubernetes_tokens_sync and kubernetes_tokens feature flags enabled' do
       before do
+        FeatureFlagService.create_or_update(:kubernetes_tokens_sync, true)
         FeatureFlagService.create_or_update(:kubernetes_tokens, true)
       end
 
@@ -13,7 +14,23 @@ RSpec.describe Kubernetes::SyncController, type: :routing do
       end
     end
 
+    context 'with kubernetes_tokens_sync feature flag disabled' do
+      before do
+        FeatureFlagService.create_or_update(:kubernetes_tokens_sync, false)
+        FeatureFlagService.create_or_update(:kubernetes_tokens, true)
+      end
+
+      it 'route to #sync is not routable' do
+        expect(:post => '/kubernetes/sync').to_not be_routable
+      end
+    end
+
     context 'with kubernetes_tokens feature flag disabled' do
+      before do
+        FeatureFlagService.create_or_update(:kubernetes_tokens_sync, true)
+        FeatureFlagService.create_or_update(:kubernetes_tokens, false)
+      end
+
       it 'route to #sync is not routable' do
         expect(:post => '/kubernetes/sync').to_not be_routable
       end

--- a/platform-hub-api/spec/routing/kubernetes_tokens_routing_spec.rb
+++ b/platform-hub-api/spec/routing/kubernetes_tokens_routing_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe Kubernetes::TokensController, type: :routing do
       it 'routes to #destroy' do
         expect(:delete => '/kubernetes/tokens/1').to route_to('kubernetes/tokens#destroy', :id => '1')
       end
-
-      it 'routes to #escalate' do
-        expect(:patch => '/kubernetes/tokens/1/escalate').to route_to('kubernetes/tokens#escalate', :id => '1')
-      end
-
-      it 'routes to #deescalate' do
-        expect(:patch => '/kubernetes/tokens/1/deescalate').to route_to('kubernetes/tokens#deescalate', :id => '1')
-      end
     end
 
     context 'with kubernetes_tokens feature flag disabled' do
@@ -56,6 +48,43 @@ RSpec.describe Kubernetes::TokensController, type: :routing do
 
       it 'route to #destroy is not routable' do
         expect(:delete => '/kubernetes/tokens/1').to_not be_routable
+      end
+    end
+
+    context 'with kubernetes_tokens_escalate_privilege and kubernetes_tokens feature flags enabled' do
+      before do
+        FeatureFlagService.create_or_update(:kubernetes_tokens_escalate_privilege, true)
+        FeatureFlagService.create_or_update(:kubernetes_tokens, true)
+      end
+
+      it 'routes to #escalate' do
+        expect(:patch => '/kubernetes/tokens/1/escalate').to route_to('kubernetes/tokens#escalate', :id => '1')
+      end
+
+      it 'routes to #deescalate' do
+        expect(:patch => '/kubernetes/tokens/1/deescalate').to route_to('kubernetes/tokens#deescalate', :id => '1')
+      end
+    end
+
+    context 'with kubernetes_tokens_escalate_privilege feature flag disabled' do
+      before do
+        FeatureFlagService.create_or_update(:kubernetes_tokens_escalate_privilege, false)
+        FeatureFlagService.create_or_update(:kubernetes_tokens, true)
+      end
+
+      it 'route to #escalate is not routable' do
+        expect(:post => '/kubernetes/tokens/1/escalate').to_not be_routable
+      end
+
+      it 'route to #deescalate is not routable' do
+        expect(:post => '/kubernetes/tokens/1/deescalate').to_not be_routable
+      end
+    end
+
+    context 'with kubernetes_tokens_sync feature flag disabled' do
+      before do
+        FeatureFlagService.create_or_update(:kubernetes_tokens_escalate_privilege, true)
+        FeatureFlagService.create_or_update(:kubernetes_tokens, false)
       end
 
       it 'route to #escalate is not routable' do

--- a/platform-hub-api/spec/services/feature_flag_service_spec.rb
+++ b/platform-hub-api/spec/services/feature_flag_service_spec.rb
@@ -72,6 +72,24 @@ describe FeatureFlagService, type: :service do
     end
   end
 
+  describe '.all_enabled?' do
+    it 'returns false for known features' do
+      expect(subject.all_enabled?([@flag1, @flag2])).to be false
+    end
+
+    it 'returns true for the enabled feature' do
+      expect(subject.all_enabled?([@flag1])).to be true
+    end
+
+    it 'returns false for the disabled feature' do
+      expect(subject.all_enabled?([@flag2])).to be false
+    end
+
+    it 'returns false when there is an unknown feature flag' do
+      expect(subject.all_enabled?([@flag1, :unknown_feature])).to be false
+    end
+  end
+
   describe 'private methods' do
     describe '.feature_flags' do
       it 'finds or creates general hash record by id' do

--- a/platform-hub-web/src/app/app.module.js
+++ b/platform-hub-web/src/app/app.module.js
@@ -107,6 +107,8 @@ angular
   .constant('apiBackoffTimeMs', 2000)
   .constant('featureFlagKeys', {
     kubernetesTokens: 'kubernetes_tokens',
+    kubernetesTokensEscalatePrivilege: 'kubernetes_tokens_escalate_privilege',
+    kubernetesTokensSync: 'kubernetes_tokens_sync',
     projects: 'projects'
   });
 

--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -124,7 +124,10 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         },
         data: {
           authenticate: true,
-          featureFlag: featureFlagKeys.kubernetesTokens,
+          featureFlags: [
+            featureFlagKeys.kubernetesTokensSync,
+            featureFlagKeys.kubernetesTokens
+          ],
           rolePermitted: 'admin'
         }
       })
@@ -138,7 +141,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           component: KubernetesClustersList,
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
             rolePermitted: 'admin'
           }
         })
@@ -150,7 +153,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.projects,
+            featureFlags: [featureFlagKeys.projects],
             rolePermitted: 'admin'
           }
         })
@@ -159,7 +162,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           component: KubernetesClustersForm,
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
             rolePermitted: 'admin'
           }
         })
@@ -171,7 +174,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
             rolePermitted: 'admin'
           }
         })
@@ -185,7 +188,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           component: KubernetesGroupsList,
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
             rolePermitted: 'admin'
           }
         })
@@ -197,7 +200,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.projects,
+            featureFlags: [featureFlagKeys.projects],
             rolePermitted: 'admin'
           }
         })
@@ -206,7 +209,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           component: KubernetesGroupsForm,
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
             rolePermitted: 'admin'
           }
         })
@@ -218,7 +221,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
             rolePermitted: 'admin'
           }
         })
@@ -232,7 +235,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           component: KubernetesUserTokensList,
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
             rolePermitted: 'admin'
           },
           resolve: {
@@ -250,7 +253,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens
+            featureFlags: [featureFlagKeys.kubernetesTokens]
           },
           params: {
             userId: '',
@@ -265,7 +268,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens
+            featureFlags: [featureFlagKeys.kubernetesTokens]
           },
           params: {
             fromProject: null
@@ -281,7 +284,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           component: KubernetesRobotTokensList,
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
             rolePermitted: 'admin'
           },
           resolve: {
@@ -299,7 +302,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens
+            featureFlags: [featureFlagKeys.kubernetesTokens]
           },
           params: {
             cluster: '',
@@ -315,7 +318,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.kubernetesTokens
+            featureFlags: [featureFlagKeys.kubernetesTokens]
           },
           params: {
             fromProject: null,
@@ -332,7 +335,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         component: ProjectsList,
         data: {
           authenticate: true,
-          featureFlag: featureFlagKeys.projects
+          featureFlags: [featureFlagKeys.projects]
         }
       })
       .state('projects.detail', {
@@ -343,7 +346,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         },
         data: {
           authenticate: true,
-          featureFlag: featureFlagKeys.projects
+          featureFlags: [featureFlagKeys.projects]
         }
       })
       .state('projects.new', {
@@ -351,7 +354,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         component: ProjectsForm,
         data: {
           authenticate: true,
-          featureFlag: featureFlagKeys.projects,
+          featureFlags: [featureFlagKeys.projects],
           rolePermitted: 'admin'
         }
       })
@@ -363,7 +366,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         },
         data: {
           authenticate: true,
-          featureFlag: featureFlagKeys.projects,
+          featureFlags: [featureFlagKeys.projects],
           rolePermitted: 'admin'
         }
       })
@@ -380,7 +383,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.projects
+            featureFlags: [featureFlagKeys.projects]
           }
         })
         .state('projects.services.new', {
@@ -391,7 +394,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.projects
+            featureFlags: [featureFlagKeys.projects]
           }
         })
         .state('projects.services.edit', {
@@ -402,7 +405,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           },
           data: {
             authenticate: true,
-            featureFlag: featureFlagKeys.projects
+            featureFlags: [featureFlagKeys.projects]
           }
         })
     .state('users', {

--- a/platform-hub-web/src/app/app.routes.spec.js
+++ b/platform-hub-web/src/app/app.routes.spec.js
@@ -15,7 +15,7 @@ describe('routes', () => {
   const ALLOWED_DATA_CONFIG_FIELDS = [
     'authenticate',
     'rolePermitted',
-    'featureFlag'
+    'featureFlags'
   ];
 
   const abstractStates = {};
@@ -85,7 +85,7 @@ describe('routes', () => {
 
         sandbox.stub(loginDialogService, 'run').usingPromise($q).rejects();
 
-        sandbox.spy(FeatureFlags, 'isEnabled');
+        sandbox.spy(FeatureFlags, 'allEnabled');
 
         sandbox.spy(roleCheckerService, 'hasHubRole');
       }
@@ -94,13 +94,13 @@ describe('routes', () => {
         if (state.data.authenticate) {
           authService.isAuthenticated.should.have.callCount(1);
           loginDialogService.run.should.have.callCount(1);
-          FeatureFlags.isEnabled.should.have.callCount(0);
+          FeatureFlags.allEnabled.should.have.callCount(0);
           roleCheckerService.hasHubRole.should.have.callCount(0);
           expect($state.current.name).toBe('home');
         } else {
           authService.isAuthenticated.should.have.callCount(0);
           loginDialogService.run.should.have.callCount(0);
-          FeatureFlags.isEnabled.should.have.callCount(0);
+          FeatureFlags.allEnabled.should.have.callCount(0);
           roleCheckerService.hasHubRole.should.have.callCount(0);
           expect($state.current.name).toBe(state.name);
         }
@@ -130,7 +130,7 @@ describe('routes', () => {
             sandbox.stub(loginDialogService, 'run').usingPromise($q).resolves();
 
             sandbox.stub(FeatureFlags, 'refresh').usingPromise($q).resolves({});
-            sandbox.stub(FeatureFlags, 'isEnabled').returns(true);
+            sandbox.stub(FeatureFlags, 'allEnabled').returns(true);
 
             sandbox.spy(roleCheckerService, 'hasHubRole');
 
@@ -141,8 +141,8 @@ describe('routes', () => {
             if (state.data.authenticate) {
               loginDialogService.run.should.have.callCount(1);
 
-              if (hasFeatureFlag(state)) {
-                FeatureFlags.isEnabled.should.have.callCount(1);
+              if (hasFeatureFlags(state)) {
+                FeatureFlags.allEnabled.should.have.callCount(1);
               }
 
               if (requiresAdmin(state)) {
@@ -157,7 +157,7 @@ describe('routes', () => {
             } else {
               authService.isAuthenticated.should.have.callCount(0);
               loginDialogService.run.should.have.callCount(0);
-              FeatureFlags.isEnabled.should.have.callCount(0);
+              FeatureFlags.allEnabled.should.have.callCount(0);
               roleCheckerService.hasHubRole.should.have.callCount(0);
               expect($state.current.name).toBe(state.name);
             }
@@ -179,7 +179,7 @@ describe('routes', () => {
             sandbox.stub(loginDialogService, 'run').usingPromise($q).resolves();
 
             sandbox.stub(FeatureFlags, 'refresh').usingPromise($q).resolves({});
-            sandbox.stub(FeatureFlags, 'isEnabled').returns(true);
+            sandbox.stub(FeatureFlags, 'allEnabled').returns(true);
 
             sandbox.spy(roleCheckerService, 'hasHubRole');
 
@@ -190,8 +190,8 @@ describe('routes', () => {
             if (state.data.authenticate) {
               loginDialogService.run.should.have.callCount(1);
 
-              if (hasFeatureFlag(state)) {
-                FeatureFlags.isEnabled.should.have.callCount(1);
+              if (hasFeatureFlags(state)) {
+                FeatureFlags.allEnabled.should.have.callCount(1);
               }
 
               if (requiresAdmin(state)) {
@@ -206,7 +206,7 @@ describe('routes', () => {
             } else {
               authService.isAuthenticated.should.have.callCount(0);
               loginDialogService.run.should.have.callCount(0);
-              FeatureFlags.isEnabled.should.have.callCount(0);
+              FeatureFlags.allEnabled.should.have.callCount(0);
               roleCheckerService.hasHubRole.should.have.callCount(0);
               expect($state.current.name).toBe(state.name);
             }
@@ -227,14 +227,14 @@ describe('routes', () => {
           function stubs(state) {
             const stub = sandbox.stub(authService, 'isAuthenticated');
             stub.onFirstCall().returns(false);
-            if (!hasFeatureFlag(state)) {
+            if (!hasFeatureFlags(state)) {
               stub.onSecondCall().returns(true);
             }
 
             sandbox.stub(loginDialogService, 'run').usingPromise($q).resolves();
 
             sandbox.stub(FeatureFlags, 'refresh').usingPromise($q).resolves({});
-            sandbox.stub(FeatureFlags, 'isEnabled').returns(false);
+            sandbox.stub(FeatureFlags, 'allEnabled').returns(false);
 
             sandbox.spy(roleCheckerService, 'hasHubRole');
 
@@ -245,26 +245,26 @@ describe('routes', () => {
             if (state.data.authenticate) {
               loginDialogService.run.should.have.callCount(1);
 
-              if (hasFeatureFlag(state)) {
+              if (hasFeatureFlags(state)) {
                 authService.isAuthenticated.should.have.callCount(1);
-                FeatureFlags.isEnabled.should.have.callCount(1);
+                FeatureFlags.allEnabled.should.have.callCount(1);
                 roleCheckerService.hasHubRole.should.have.callCount(0);
                 expect($state.current.name).toBe('home');
               } else if (requiresAdmin(state)) {
                 authService.isAuthenticated.should.have.callCount(2);
-                FeatureFlags.isEnabled.should.have.callCount(0);
+                FeatureFlags.allEnabled.should.have.callCount(0);
                 roleCheckerService.hasHubRole.should.have.callCount(1);
                 expect($state.current.name).toBe('home');
               } else {
                 authService.isAuthenticated.should.have.callCount(1);
-                FeatureFlags.isEnabled.should.have.callCount(0);
+                FeatureFlags.allEnabled.should.have.callCount(0);
                 roleCheckerService.hasHubRole.should.have.callCount(0);
                 expect($state.current.name).toBe(state.name);
               }
             } else {
               authService.isAuthenticated.should.have.callCount(0);
               loginDialogService.run.should.have.callCount(0);
-              FeatureFlags.isEnabled.should.have.callCount(0);
+              FeatureFlags.allEnabled.should.have.callCount(0);
               roleCheckerService.hasHubRole.should.have.callCount(0);
               expect($state.current.name).toBe(state.name);
             }
@@ -281,14 +281,14 @@ describe('routes', () => {
           function stubs(state) {
             const stub = sandbox.stub(authService, 'isAuthenticated');
             stub.onFirstCall().returns(false);
-            if (!hasFeatureFlag(state)) {
+            if (!hasFeatureFlags(state)) {
               stub.onSecondCall().returns(true);
             }
 
             sandbox.stub(loginDialogService, 'run').usingPromise($q).resolves();
 
             sandbox.stub(FeatureFlags, 'refresh').usingPromise($q).resolves({});
-            sandbox.stub(FeatureFlags, 'isEnabled').returns(false);
+            sandbox.stub(FeatureFlags, 'allEnabled').returns(false);
 
             sandbox.spy(roleCheckerService, 'hasHubRole');
 
@@ -299,26 +299,26 @@ describe('routes', () => {
             if (state.data.authenticate) {
               loginDialogService.run.should.have.callCount(1);
 
-              if (hasFeatureFlag(state)) {
+              if (hasFeatureFlags(state)) {
                 authService.isAuthenticated.should.have.callCount(1);
-                FeatureFlags.isEnabled.should.have.callCount(1);
+                FeatureFlags.allEnabled.should.have.callCount(1);
                 roleCheckerService.hasHubRole.should.have.callCount(0);
                 expect($state.current.name).toBe('home');
               } else if (requiresAdmin(state)) {
                 authService.isAuthenticated.should.have.callCount(2);
-                FeatureFlags.isEnabled.should.have.callCount(0);
+                FeatureFlags.allEnabled.should.have.callCount(0);
                 roleCheckerService.hasHubRole.should.have.callCount(1);
                 expect($state.current.name).toBe(state.name);
               } else {
                 authService.isAuthenticated.should.have.callCount(1);
-                FeatureFlags.isEnabled.should.have.callCount(0);
+                FeatureFlags.allEnabled.should.have.callCount(0);
                 roleCheckerService.hasHubRole.should.have.callCount(0);
                 expect($state.current.name).toBe(state.name);
               }
             } else {
               authService.isAuthenticated.should.have.callCount(0);
               loginDialogService.run.should.have.callCount(0);
-              FeatureFlags.isEnabled.should.have.callCount(0);
+              FeatureFlags.allEnabled.should.have.callCount(0);
               roleCheckerService.hasHubRole.should.have.callCount(0);
               expect($state.current.name).toBe(state.name);
             }
@@ -383,8 +383,8 @@ describe('routes', () => {
     });
   }
 
-  function hasFeatureFlag(state) {
-    return lodash.has(state.data, 'featureFlag');
+  function hasFeatureFlags(state) {
+    return lodash.has(state.data, 'featureFlags');
   }
 
   function requiresAdmin(state) {

--- a/platform-hub-web/src/app/app.run.js
+++ b/platform-hub-web/src/app/app.run.js
@@ -80,11 +80,11 @@ export const appRun = function ($q, $rootScope, $transitions, $state, authServic
       .catch(reject);
   }
 
-  function featureFlagChecker(flag) {
+  function featureFlagsChecker(flags) {
     return FeatureFlags
       .refresh()
       .then(() => {
-        if (FeatureFlags.isEnabled(flag)) {
+        if (FeatureFlags.allEnabled(flags)) {
           return $q.resolve(true);
         }
         return reject();
@@ -109,8 +109,8 @@ export const appRun = function ($q, $rootScope, $transitions, $state, authServic
 
     const shouldAuthenticate = Boolean(config.authenticate);
 
-    const shouldCheckFeatureFlag = _.has(config, 'featureFlag');
-    const featureFlag = config.featureFlag;
+    const shouldCheckFeatureFlags = _.has(config, 'featureFlags');
+    const featureFlags = config.featureFlags;
 
     const shouldCheckRole = _.has(config, 'rolePermitted');
     const rolePermitted = config.rolePermitted;
@@ -121,8 +121,8 @@ export const appRun = function ($q, $rootScope, $transitions, $state, authServic
     if (shouldAuthenticate) {
       return authenticationChecker()
         .then(() => {
-          if (shouldCheckFeatureFlag) {
-            return featureFlagChecker(featureFlag);
+          if (shouldCheckFeatureFlags) {
+            return featureFlagsChecker(featureFlags);
           }
           return true;
         })

--- a/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-list.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-list.component.js
@@ -6,13 +6,16 @@ export const KubernetesUserTokensListComponent = {
   controller: KubernetesUserTokensListController
 };
 
-function KubernetesUserTokensListController($state, roleCheckerService, hubApiService, logger, $mdDialog, _, Identities, KubernetesClusters, KubernetesTokens, icons, kubernetesTokenEscalatePrivilegePopupService) {
+function KubernetesUserTokensListController($state, roleCheckerService, hubApiService, logger, $mdDialog, _, featureFlagKeys, FeatureFlags, Identities, KubernetesClusters, KubernetesTokens, icons, kubernetesTokenEscalatePrivilegePopupService) {
   'ngInject';
 
   const ctrl = this;
   const userId = ctrl.transition && ctrl.transition.params().userId;
 
+  ctrl.featureFlagKeys = featureFlagKeys;
+  ctrl.FeatureFlags = FeatureFlags;
   ctrl.KubernetesClusters = KubernetesClusters;
+
   ctrl.searchSelectedUser = null;
   ctrl.loading = true;
   ctrl.busy = false;

--- a/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-list.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-list.html
@@ -140,7 +140,7 @@
           View and edit
         </md-button>
         <md-button
-          ng-if="$ctrl.user.is_active"
+          ng-if="$ctrl.user.is_active && $ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetes_tokens_escalate_privilege)"
           aria-label="Escalate privilege for this particular token. Opens up a popup where you can choose details for the escalation."
           ng-click="$ctrl.escalatePrivilege(t.id, $event)">
           Escalate privilege

--- a/platform-hub-web/src/app/layout/shell.component.js
+++ b/platform-hub-web/src/app/layout/shell.component.js
@@ -67,7 +67,7 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
       state: 'projects.list',
       activeState: 'projects',
       icon: icons.projects,
-      featureFlag: featureFlagKeys.projects
+      featureFlags: [featureFlagKeys.projects]
     }
   ];
 
@@ -124,31 +124,34 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
       title: 'Kubernetes Tokens Sync',
       state: 'kubernetes.tokens-sync',
       icon: icons.syncTokens,
-      featureFlag: featureFlagKeys.kubernetesTokens
+      featureFlags: [
+        featureFlagKeys.kubernetesTokensSync,
+        featureFlagKeys.kubernetesTokens
+      ]
     },
     {
       title: 'Kubernetes Clusters',
       state: 'kubernetes.clusters.list',
       icon: icons.kubernetesClusters,
-      featureFlag: featureFlagKeys.kubernetesTokens
+      featureFlags: [featureFlagKeys.kubernetesTokens]
     },
     {
       title: 'Kubernetes RBAC Groups',
       state: 'kubernetes.groups.list',
       icon: icons.kubernetesGroups,
-      featureFlag: featureFlagKeys.kubernetesTokens
+      featureFlags: [featureFlagKeys.kubernetesTokens]
     },
     {
       title: 'Kubernetes User Tokens',
       state: 'kubernetes.user-tokens.list',
       icon: icons.kubernetesTokens,
-      featureFlag: featureFlagKeys.kubernetesTokens
+      featureFlags: [featureFlagKeys.kubernetesTokens]
     },
     {
       title: 'Kubernetes Robot Tokens',
       state: 'kubernetes.robot-tokens.list',
       icon: icons.kubernetesTokens,
-      featureFlag: featureFlagKeys.kubernetesTokens
+      featureFlags: [featureFlagKeys.kubernetesTokens]
     },
     {
       title: 'Feature Flags',
@@ -205,7 +208,7 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
 
   function shouldShowSection(section) {
     return section.some(e => {
-      return !_.has(e, 'featureFlag') || FeatureFlags.isEnabled(e.featureFlag);
+      return !_.has(e, 'featureFlags') || FeatureFlags.allEnabled(e.featureFlags);
     });
   }
 }

--- a/platform-hub-web/src/app/layout/shell.html
+++ b/platform-hub-web/src/app/layout/shell.html
@@ -87,7 +87,7 @@
 
             <md-sidemenu-button
               ng-repeat="item in $ctrl.myAccountNavStates"
-              ng-if="!_.has(item, 'featureFlag') || $ctrl.FeatureFlags.isEnabled(item.featureFlag)"
+              ng-if="!_.has(item, 'featureFlags') || $ctrl.FeatureFlags.allEnabled(item.featureFlags)"
               ui-sref="{{item.state}}"
               ui-sref-active="{ 'active': item.activeState || item.state }">
               <md-icon ng-if="item.icon">{{item.icon}}</md-icon>
@@ -100,7 +100,7 @@
 
             <md-sidemenu-button
               ng-repeat="item in $ctrl.orgNavStates"
-              ng-if="!_.has(item, 'featureFlag') || $ctrl.FeatureFlags.isEnabled(item.featureFlag)"
+              ng-if="!_.has(item, 'featureFlags') || $ctrl.FeatureFlags.allEnabled(item.featureFlags)"
               ui-sref="{{item.state}}"
               ui-sref-active="{ 'active': item.activeState || item.state }">
               <md-icon ng-if="item.icon">{{item.icon}}</md-icon>
@@ -113,7 +113,7 @@
 
             <md-sidemenu-button
               ng-repeat="item in $ctrl.helpNavStates"
-              ng-if="!_.has(item, 'featureFlag') || $ctrl.FeatureFlags.isEnabled(item.featureFlag)"
+              ng-if="!_.has(item, 'featureFlags') || $ctrl.FeatureFlags.allEnabled(item.featureFlags)"
               ui-sref="{{item.state}}"
               ui-sref-active="{ 'active': item.activeState || item.state }">
               <md-icon ng-if="item.icon">{{item.icon}}</md-icon>
@@ -126,7 +126,7 @@
 
             <md-sidemenu-button
               ng-repeat="item in $ctrl.adminNavStates"
-              ng-if="!_.has(item, 'featureFlag') || $ctrl.FeatureFlags.isEnabled(item.featureFlag)"
+              ng-if="!_.has(item, 'featureFlags') || $ctrl.FeatureFlags.allEnabled(item.featureFlags)"
               ui-sref="{{item.state}}"
               ui-sref-active="{ 'active': item.activeState || item.state }">
               <md-icon ng-if="item.icon">{{item.icon}}</md-icon>

--- a/platform-hub-web/src/app/shared/model/feature-flags.js
+++ b/platform-hub-web/src/app/shared/model/feature-flags.js
@@ -11,6 +11,7 @@ export const FeatureFlags = function ($window, hubApiService, apiBackoffTimeMs, 
 
   model.refresh = refresh;
   model.isEnabled = isEnabled;
+  model.allEnabled = allEnabled;
   model.update = update;
 
   return model;
@@ -34,7 +35,12 @@ export const FeatureFlags = function ($window, hubApiService, apiBackoffTimeMs, 
     if (_.includes(featureFlagKeys, featureKey)) {
       return model.data[featureKey] || false;
     }
+    logger.debug(`Unknown feature flag used: ${featureKey}`);
     return false;
+  }
+
+  function allEnabled(flags) {
+    return _.every(flags, isEnabled);
   }
 
   function update(flag, state) {


### PR DESCRIPTION
This provides finer grained control over the Kubernetes tokens features.

Note:
- The existing `kubernetes_tokens` flag still exists and is used as a "master" toggle of all Kubernetes tokens features in the hub.
- Thus, this commit adds support for configuring and inspecting multiple feature flags for UI routes, shell nav and API endpoints.
- The tokens privilege expirer job will run regardless of the new `kubernetes_tokens_escalate_privilege` flag (but can be turned off using the existing `kubernetes_tokens` flag).