### PR TITLE
Only return certain fields in the /app_settings API when not logged in

### DIFF
--- a/platform-hub-api/app/controllers/app_settings_controller.rb
+++ b/platform-hub-api/app/controllers/app_settings_controller.rb
@@ -1,5 +1,10 @@
 class AppSettingsController < ApiJsonController
 
+  PUBLIC_FIELDS = [
+    'platformName',
+    'platform_overview'
+  ]
+
   skip_before_action :require_authentication, only: :show
 
   before_action :load_app_settings_hash_record
@@ -8,7 +13,11 @@ class AppSettingsController < ApiJsonController
 
   # GET /app_settings
   def show
-    render json: @app_settings.data
+    if authenticated?
+      render json: @app_settings.data
+    else
+      render json: @app_settings.data.select { |k,_| PUBLIC_FIELDS.include? k }
+    end
   end
 
   # PATCH/PUT /app_settings

--- a/platform-hub-web/src/app/app.run.js
+++ b/platform-hub-web/src/app/app.run.js
@@ -6,12 +6,7 @@ export const appRun = function ($q, $rootScope, $transitions, $state, authServic
   // Inject lodash into templates that have rootScope access.
   $rootScope._ = _;
 
-  // Fetch public AppSettings and inject into templates that have rootScope access.
-  AppSettings
-    .refresh()
-    .then(() => {
-      $rootScope.AppSettings = AppSettings;
-    });
+  refreshAppSettings();
 
   // Fetch feature flags now if user is logged in (otherwise they will be
   // fetched later when user does log in).
@@ -19,11 +14,21 @@ export const appRun = function ($q, $rootScope, $transitions, $state, authServic
     FeatureFlags.refresh();
   }
 
+  function refreshAppSettings() {
+    // Fetch public AppSettings and inject into templates that have rootScope access.
+    return AppSettings
+      .refresh()
+      .then(() => {
+        $rootScope.AppSettings = AppSettings;
+      });
+  }
+
   // Listen for auth data change and react accordingly.
   const authDataHandler = $rootScope.$on(events.auth.updated, () => {
     Me.clear();
 
     if (authService.isAuthenticated()) {
+      refreshAppSettings();
       Me.refresh();
       FeatureFlags.refresh();
     }


### PR DESCRIPTION
Only the platform name and platform overview text should be made public to non-logged in users.