### PR TITLE
Rename project 'manager' to 'admin'

### DIFF
--- a/platform-hub-api/app/controllers/projects_controller.rb
+++ b/platform-hub-api/app/controllers/projects_controller.rb
@@ -165,9 +165,9 @@ class ProjectsController < ApiJsonController
   # GET /projects/:id/memberships/role_check/:role
   def role_check
     case params[:role]
-    when 'manager'
-      is_manager = ProjectMembershipsService.is_user_a_manager_of_project?(@project.id, current_user.id)
-      render json: { result: is_manager }
+    when 'admin'
+      is_admin = ProjectMembershipsService.is_user_an_admin_of_project?(@project.id, current_user.id)
+      render json: { result: is_admin }
     else
       not_found_error
     end

--- a/platform-hub-api/app/models/ability.rb
+++ b/platform-hub-api/app/models/ability.rb
@@ -64,7 +64,7 @@ class Ability
 
     can do |action, subject_class, subject|
       if action == :search && subject_class == User
-        ProjectMembershipsService.is_user_a_manager_of_any_project?(user.id)
+        ProjectMembershipsService.is_user_an_admin_of_any_project?(user.id)
       end
     end
 
@@ -73,7 +73,7 @@ class Ability
   private
 
   def can_administer_project project, user
-    ProjectMembershipsService.is_user_a_manager_of_project?(
+    ProjectMembershipsService.is_user_an_admin_of_project?(
       project.id,
       user.id
     )
@@ -88,7 +88,7 @@ class Ability
 
   def can_onboard_or_offboard_github user, target_user
     (user == target_user) ||
-    ProjectMembershipsService.is_user_a_manager_of_a_common_project?(
+    ProjectMembershipsService.is_user_an_admin_of_a_common_project?(
       user,
       target_user
     )

--- a/platform-hub-api/app/models/project_membership.rb
+++ b/platform-hub-api/app/models/project_membership.rb
@@ -3,7 +3,7 @@ class ProjectMembership < ApplicationRecord
   self.primary_keys = :project_id, :user_id
 
   enum role: {
-    manager: 'manager'
+    admin: 'admin'
   }
 
   belongs_to :project

--- a/platform-hub-api/app/serializers/project_serializer.rb
+++ b/platform-hub-api/app/serializers/project_serializer.rb
@@ -12,15 +12,15 @@ class ProjectSerializer < BaseSerializer
 
   attributes :members_count
 
-  attribute :cost_centre_code, if: :is_admin_or_project_manager?
+  attribute :cost_centre_code, if: :is_admin_or_project_admin?
 
   attribute :members_count do
     object.memberships.count
   end
 
   # Note: `scope` here is actually `current_user` (passed in from controller)
-  def is_admin_or_project_manager?
-    is_admin? || ProjectMembershipsService.is_user_a_manager_of_project?(object.id, scope.id)
+  def is_admin_or_project_admin?
+    is_admin? || ProjectMembershipsService.is_user_an_admin_of_project?(object.id, scope.id)
   end
 
 end

--- a/platform-hub-api/app/services/project_memberships_service.rb
+++ b/platform-hub-api/app/services/project_memberships_service.rb
@@ -5,22 +5,22 @@ module ProjectMembershipsService
     scope.exists? project_id: project_id, user_id: user_id
   end
 
-  def is_user_a_manager_of_project? project_id, user_id
-    manager_scope.exists? project_id: project_id, user_id: user_id
+  def is_user_an_admin_of_project? project_id, user_id
+    admin_scope.exists? project_id: project_id, user_id: user_id
   end
 
-  def is_user_a_manager_of_any_project? user_id
-    manager_scope.exists? user_id: user_id
+  def is_user_an_admin_of_any_project? user_id
+    admin_scope.exists? user_id: user_id
   end
 
-  def is_user_a_manager_of_a_common_project? user, target_user
+  def is_user_an_admin_of_a_common_project? user, target_user
     # Find common projects between the two users
     target_user_projects = target_user.project_ids
     user_projects = user.project_ids
     common_projects = target_user_projects & user_projects
 
-    # Now check to see if user is a manager of any of these common projects
-    manager_scope.exists? project_id: common_projects, user_id: user.id
+    # Now check to see if user is an admin of any of these common projects
+    admin_scope.exists? project_id: common_projects, user_id: user.id
   end
 
   private
@@ -29,8 +29,8 @@ module ProjectMembershipsService
     ProjectMembership
   end
 
-  def manager_scope
-    ProjectMembership.manager
+  def admin_scope
+    ProjectMembership.admin
   end
 
 end

--- a/platform-hub-api/db/migrate/20171114100517_change_project_membership_manager_role_to_admin.rb
+++ b/platform-hub-api/db/migrate/20171114100517_change_project_membership_manager_role_to_admin.rb
@@ -1,0 +1,9 @@
+class ChangeProjectMembershipManagerRoleToAdmin < ActiveRecord::Migration[5.0]
+  def up
+    ProjectMembership.connection.execute("UPDATE project_memberships SET role = 'admin' WHERE role = 'manager'")
+  end
+
+  def down
+    ProjectMembership.connection.execute("UPDATE project_memberships SET role = 'manager' WHERE role = 'admin'")
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -318,7 +318,7 @@ CREATE TABLE platform_themes (
     slug character varying NOT NULL,
     description text NOT NULL,
     image_url character varying NOT NULL,
-    colour character varying NOT NULL,
+    colour character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     resources json
@@ -1044,6 +1044,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171005115420'),
 ('20171010111440'),
 ('20171012110416'),
-('20171031164247');
+('20171031164247'),
+('20171114100517');
 
 

--- a/platform-hub-api/spec/controllers/allocations_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/allocations_controller_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe AllocationsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :destroy, params: { id: @allocation.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should delete the specified allocation' do
           expect(Allocation.exists?(@allocation.id)).to be true

--- a/platform-hub-api/spec/controllers/announcement_templates_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/announcement_templates_controller_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe AnnouncementTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :index
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         before do
           @announcement_templates = create_list :announcement_template, 3
@@ -58,13 +58,13 @@ RSpec.describe AnnouncementTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :show, params: { id: @announcement_template.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for a non-existent announcement template' do
           it 'should return a 404' do
@@ -114,13 +114,13 @@ RSpec.describe AnnouncementTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :create, params: post_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'creates a new announcement template as expected' do
           expect(AnnouncementTemplate.count).to eq 0
@@ -173,13 +173,13 @@ RSpec.describe AnnouncementTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'updates the specified announcement template' do
           expect(AnnouncementTemplate.count).to eq 1
@@ -216,13 +216,13 @@ RSpec.describe AnnouncementTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :destroy, params: { id: @announcement_template.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should delete the specified announcement template' do
           expect(AnnouncementTemplate.exists?(@announcement_template.id)).to be true
@@ -250,13 +250,13 @@ RSpec.describe AnnouncementTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :form_field_types
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
         it 'should return the available form field types' do
           get :form_field_types
           expect(response).to be_success
@@ -297,13 +297,13 @@ RSpec.describe AnnouncementTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :preview, params: params
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should handle a missing "templates" param' do
           post :preview, params: {}

--- a/platform-hub-api/spec/controllers/announcements_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/announcements_controller_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe AnnouncementsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :index
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         before do
           @announcements = create_list :announcement, 3
@@ -128,13 +128,13 @@ RSpec.describe AnnouncementsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :create, params: post_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for an announcement with provided content' do
           let :post_data do
@@ -263,13 +263,13 @@ RSpec.describe AnnouncementsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for non readonly announcement' do
           it 'updates the specified announcement' do
@@ -373,13 +373,13 @@ RSpec.describe AnnouncementsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :destroy, params: { id: @announcement.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for non readonly announcement' do
           it 'should delete the specified announcement' do
@@ -431,13 +431,13 @@ RSpec.describe AnnouncementsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :mark_sticky, params: { id: @announcement.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should mark the specified announcement as sticky' do
           expect(@announcement.is_sticky).to be false
@@ -470,13 +470,13 @@ RSpec.describe AnnouncementsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :unmark_sticky, params: { id: @announcement.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should unmark the specified announcement as sticky' do
           expect(@announcement.is_sticky).to be true
@@ -509,13 +509,13 @@ RSpec.describe AnnouncementsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :resend, params: { id: @announcement.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for a published announcement' do
           before do

--- a/platform-hub-api/spec/controllers/api_json_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/api_json_controller_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe ApiJsonController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :show, params: { id: 'foo' }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when not requesting JSON' do
           before do

--- a/platform-hub-api/spec/controllers/app_settings_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/app_settings_controller_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe AppSettingsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
         it 'allows updating of the whole app settings data' do
           expect(HashRecord.webapp.where(id: key).count).to eq 1
           put :update, params: put_data

--- a/platform-hub-api/spec/controllers/contact_lists_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/contact_lists_controller_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe ContactListsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :index
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         before do
           @contact_lists = create_list :contact_list, 3
@@ -59,13 +59,13 @@ RSpec.describe ContactListsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :show, params: { id: @contact_list.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for a non-existent contact list' do
           it 'should return a 404' do
@@ -113,13 +113,13 @@ RSpec.describe ContactListsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_params
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
         context 'for a contact list that doesn\'t yet exist' do
           it 'should create a new contact list with the ID specified' do
             expect(ContactList.count).to eq 0
@@ -174,13 +174,13 @@ RSpec.describe ContactListsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :destroy, params: { id: @contact_list.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should delete the specified contact list' do
           expect(ContactList.exists?(@contact_list.id)).to be true

--- a/platform-hub-api/spec/controllers/feature_flag_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/feature_flag_controller_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe FeatureFlagsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update_flag, params: { flag: flag1 }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'sets an existing flag to true' do
           put :update_flag, params: { flag: flag1, feature_flag: { state: true } }

--- a/platform-hub-api/spec/controllers/kubernetes/changeset_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/changeset_controller_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Kubernetes::ChangesetController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden' do
+      it_behaves_like 'not a hub admin so forbidden' do
         before do
           get :index, params: { cluster: @cluster.name }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         before do
           auditable = build :user_kubernetes_token, cluster: @cluster

--- a/platform-hub-api/spec/controllers/kubernetes/clusters_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/clusters_controller_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :index
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when no kubernetes clusters exist' do
           before do
@@ -66,13 +66,13 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :show, params: { id: @cluster.friendly_id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for a non-existent cluster' do
           it 'should return a 404' do
@@ -121,13 +121,13 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :create, params: post_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'creates a new kubernetes cluster config as expected' do
           expect(KubernetesCluster.count).to eq 0
@@ -200,13 +200,13 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'updates the specified cluster' do
           expect(KubernetesCluster.count).to eq 1
@@ -243,13 +243,13 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :allocate, params: { id: @cluster.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for a non-existent project' do
           it 'should return a 404' do
@@ -301,13 +301,13 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :allocations, params: { id: @cluster.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when no allocations exist' do
           it 'returns an empty list' do

--- a/platform-hub-api/spec/controllers/kubernetes/groups_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/groups_controller_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Kubernetes::GroupsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :index
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when no kubernetes groups exist' do
           it 'returns an empty list' do
@@ -68,13 +68,13 @@ RSpec.describe Kubernetes::GroupsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :show, params: { id: @group.friendly_id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for a non-existent group' do
           it 'should return a 404' do
@@ -126,13 +126,13 @@ RSpec.describe Kubernetes::GroupsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :create, params: post_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'creates a new group as expected' do
           expect(KubernetesGroup.count).to eq 0
@@ -208,13 +208,13 @@ RSpec.describe Kubernetes::GroupsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'updates the specified group' do
           expect(KubernetesGroup.count).to eq 1
@@ -254,13 +254,13 @@ RSpec.describe Kubernetes::GroupsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :destroy, params: { id: @group.friendly_id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should delete the specified group' do
           expect(KubernetesGroup.exists?(@group.id)).to be true
@@ -290,13 +290,13 @@ RSpec.describe Kubernetes::GroupsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :privileged
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
         let!(:not_privileged_group) { create :kubernetes_group, is_privileged: false }
         let!(:privileged_group) { create :kubernetes_group, is_privileged: true }
         let!(:default_privileged_group) { create :kubernetes_group }
@@ -332,13 +332,13 @@ RSpec.describe Kubernetes::GroupsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :allocate, params: { id: @group.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for a non-existent project' do
           it 'should return a 404' do
@@ -418,13 +418,13 @@ RSpec.describe Kubernetes::GroupsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :allocations, params: { id: @group.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when no allocations exist' do
           it 'returns an empty list' do

--- a/platform-hub-api/spec/controllers/kubernetes/revoke_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/revoke_controller_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Kubernetes::RevokeController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :revoke, params: { token: @token.decrypted_token }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for existing token' do
           it 'should remove token' do

--- a/platform-hub-api/spec/controllers/kubernetes/sync_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/sync_controller_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe Kubernetes::SyncController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :sync, params: { cluster: cluster_name }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should upload tokens to selected cluster' do
           expect(Kubernetes::TokenSyncService).to receive(:sync_tokens).with(cluster_name)

--- a/platform-hub-api/spec/controllers/kubernetes/tokens_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/tokens_controller_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :index, params: { user_id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for user tokens' do
 
@@ -121,13 +121,13 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :show, params: { id: @token.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for a non-existent token' do
           it 'should return a 404' do
@@ -306,13 +306,13 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :create, params: { token: token_data }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for user' do
 
@@ -414,13 +414,13 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for user token' do
 
@@ -510,13 +510,13 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :destroy, params: { id: @token.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should delete the specified token' do
           expect(KubernetesToken.exists?(@token.id)).to be true
@@ -568,13 +568,13 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           patch :escalate, params: escalate_params
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
         it 'should escalate token and return it' do
           move_time_to now
 
@@ -637,13 +637,13 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           patch :deescalate, params: { id: @token.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
         before do
           move_time_to (escalation_time_in_secs + 1).seconds.from_now
         end

--- a/platform-hub-api/spec/controllers/platform_themes_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/platform_themes_controller_spec.rb
@@ -98,13 +98,13 @@ RSpec.describe PlatformThemesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :create, params: post_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'creates a new platform theme as expected' do
           expect(PlatformTheme.count).to eq 0
@@ -160,13 +160,13 @@ RSpec.describe PlatformThemesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'updates the specified platform theme' do
           expect(PlatformTheme.count).to eq 1
@@ -203,13 +203,13 @@ RSpec.describe PlatformThemesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :destroy, params: { id: @platform_theme.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should delete the specified platform theme' do
           expect(PlatformTheme.exists?(@platform_theme.id)).to be true

--- a/platform-hub-api/spec/controllers/projects_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/projects_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ProjectsController, type: :controller do
           end
         end
 
-        it_behaves_like 'an admin' do
+        it_behaves_like 'a hub admin' do
           it 'should return the specified project resource with protected fields' do
             get :show, params: { id: @project.friendly_id }
             expect(response).to be_success
@@ -89,9 +89,9 @@ RSpec.describe ProjectsController, type: :controller do
           end
         end
 
-        context 'not an admin but is project manager' do
+        context 'not an admin but is project admin' do
           before do
-            create :project_membership_as_manager, project: @project, user: current_user
+            create :project_membership_as_admin, project: @project, user: current_user
           end
 
           it 'should return the specified project resource with protected fields' do
@@ -134,13 +134,13 @@ RSpec.describe ProjectsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :create, params: post_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'creates a new project as expected' do
           expect(Project.count).to eq 0
@@ -220,13 +220,13 @@ RSpec.describe ProjectsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'updates the specified project' do
           expect(Project.count).to eq 1
@@ -264,13 +264,13 @@ RSpec.describe ProjectsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :destroy, params: { id: @project.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should delete the specified project' do
           expect(Project.exists?(@project.id)).to be true
@@ -356,13 +356,13 @@ RSpec.describe ProjectsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :add_membership, params: { id: @project.id, user_id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should add the specified user to the project membership list' do
           expect(@project.memberships.count).to eq 0
@@ -381,9 +381,9 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is project manager of same project' do
+      context 'not an admin but is project admin of same project' do
         before do
-          create :project_membership_as_manager, project: @project, user: current_user
+          create :project_membership_as_admin, project: @project, user: current_user
         end
 
         it 'should add the specified user to the project membership list' do
@@ -402,10 +402,10 @@ RSpec.describe ProjectsController, type: :controller do
         end
       end
 
-      context 'not an admin but is project manager of a different project' do
+      context 'not an admin but is project admin of a different project' do
         before do
           another_project = create :project
-          create :project_membership_as_manager, project: another_project, user: current_user
+          create :project_membership_as_admin, project: another_project, user: current_user
         end
 
         it 'should not be able to add the user to the project team - returning 403 Forbidden' do
@@ -432,13 +432,13 @@ RSpec.describe ProjectsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :remove_membership, params: { id: @project.id, user_id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should remove the specified user from the project membership list' do
           expect(@project.memberships.count).to eq 1
@@ -456,9 +456,9 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is project manager of same project' do
+      context 'not an admin but is project admin of same project' do
         before do
-          create :project_membership_as_manager, project: @project, user: current_user
+          create :project_membership_as_admin, project: @project, user: current_user
         end
 
         it 'should remove the specified user from the project membership list' do
@@ -476,10 +476,10 @@ RSpec.describe ProjectsController, type: :controller do
         end
       end
 
-      context 'not an admin but is project manager of a different project' do
+      context 'not an admin but is project admin of a different project' do
         before do
           another_project = create :project
-          create :project_membership_as_manager, project: another_project, user: current_user
+          create :project_membership_as_admin, project: another_project, user: current_user
         end
 
         it 'should not be able to remove the user from the project team - returning 403 Forbidden' do
@@ -493,7 +493,7 @@ RSpec.describe ProjectsController, type: :controller do
 
   describe 'GET #role_check' do
     let :role do
-      'manager'
+      'admin'
     end
 
     before do
@@ -514,7 +514,7 @@ RSpec.describe ProjectsController, type: :controller do
         expect(json_response['result']).to eq result
       end
 
-      context 'not an admin' do
+      context 'not a hub admin' do
 
         context 'and not a member of the project' do
           it 'should return a false result' do
@@ -522,7 +522,7 @@ RSpec.describe ProjectsController, type: :controller do
           end
         end
 
-        context 'is a member of the project but not a manager' do
+        context 'is a member of the project but not an admin' do
           before do
             create :project_membership, project: @project, user: current_user
           end
@@ -532,9 +532,9 @@ RSpec.describe ProjectsController, type: :controller do
           end
         end
 
-        context 'is a manager for the project' do
+        context 'is an admin for the project' do
           before do
-            create :project_membership_as_manager, project: @project, user: current_user
+            create :project_membership_as_admin, project: @project, user: current_user
           end
 
           it 'should return a true result' do
@@ -542,10 +542,10 @@ RSpec.describe ProjectsController, type: :controller do
           end
         end
 
-        context 'is manager of a different project' do
+        context 'is an admin of a different project' do
           before do
             another_project = create :project
-            create :project_membership_as_manager, project: another_project, user: current_user
+            create :project_membership_as_admin, project: another_project, user: current_user
           end
 
           it 'should return a false result' do
@@ -555,17 +555,17 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
-        context 'but not a member or manager for the project' do
+        context 'but not a member or admin for the project' do
           it 'should return a false result' do
             expect_result false
           end
         end
 
-        context 'is a manager for the project' do
+        context 'is an admin for the project' do
           before do
-            create :project_membership_as_manager, project: @project, user: current_user
+            create :project_membership_as_admin, project: @project, user: current_user
           end
 
           it 'should return a true result' do
@@ -580,7 +580,7 @@ RSpec.describe ProjectsController, type: :controller do
 
   describe 'PUT #set_role' do
     let :role do
-      'manager'
+      'admin'
     end
 
     before do
@@ -596,13 +596,13 @@ RSpec.describe ProjectsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :set_role, params: { id: @project.id, user_id: @user.id, role: role }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when user is not a project team member' do
           it 'should return a 400 Bad Request error' do
@@ -641,7 +641,7 @@ RSpec.describe ProjectsController, type: :controller do
 
   describe 'DELETE #unset_role' do
     let :role do
-      'manager'
+      'admin'
     end
 
     before do
@@ -657,13 +657,13 @@ RSpec.describe ProjectsController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :unset_role, params: { id: @project.id, user_id: @user.id, role: role }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when user is not a project team member' do
           it 'should return a 400 Bad Request error' do
@@ -743,7 +743,7 @@ RSpec.describe ProjectsController, type: :controller do
         expect(pluck_from_json_response('name')).to match_array clusters.map(&:name)
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can fetch clusters for the project as expected' do
           expect_clusters @project, project_clusters
@@ -755,10 +755,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: @project, user: current_user
+          create :project_membership_as_admin, project: @project, user: current_user
         end
 
         it 'can fetch clusters for the project as expected' do
@@ -789,10 +789,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: @other_project, user: current_user
+          create :project_membership_as_admin, project: @other_project, user: current_user
         end
 
         it 'cannot fetch clusters for the project - returning 403 Forbidden' do
@@ -848,7 +848,7 @@ RSpec.describe ProjectsController, type: :controller do
         expect(pluck_from_json_response('name')).to match_array groups.map(&:name)
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'no target specified' do
           it 'can fetch groups for the project as expected' do
@@ -889,10 +889,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       # NOTE: we don't need to repeat the target filtering specs anymore
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: @project, user: current_user
+          create :project_membership_as_admin, project: @project, user: current_user
         end
 
         it 'can fetch groups for the project as expected' do
@@ -923,10 +923,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: @other_project, user: current_user
+          create :project_membership_as_admin, project: @other_project, user: current_user
         end
 
         it 'cannot fetch groups for the project - returning 403 Forbidden' do
@@ -986,7 +986,7 @@ RSpec.describe ProjectsController, type: :controller do
         expect(pluck_from_json_response('id')).to match_array tokens.map(&:id)
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can fetch user tokens for the project as expected' do
           expect_tokens @project, @tokens
@@ -998,10 +998,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: @project, user: current_user
+          create :project_membership_as_admin, project: @project, user: current_user
         end
 
         it 'can fetch user tokens for the project as expected' do
@@ -1033,10 +1033,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: @other_project, user: current_user
+          create :project_membership_as_admin, project: @other_project, user: current_user
         end
 
         it 'cannot fetch user tokens for the project - returning 403 Forbidden' do
@@ -1124,7 +1124,7 @@ RSpec.describe ProjectsController, type: :controller do
         })
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can fetch a user token for the project as expected' do
           expect_token @project, @token, @user
@@ -1146,10 +1146,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: @project, user: current_user
+          create :project_membership_as_admin, project: @project, user: current_user
         end
 
         it 'can fetch a user token for the project as expected' do
@@ -1181,10 +1181,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: @other_project, user: current_user
+          create :project_membership_as_admin, project: @other_project, user: current_user
         end
 
         it 'cannot fetch a user token for the project - returning 403 Forbidden' do
@@ -1291,7 +1291,7 @@ RSpec.describe ProjectsController, type: :controller do
         expect(audit.user).to eq current_user
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can create a user token for the project as expected' do
           expect_create @project, @user
@@ -1330,10 +1330,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: @project, user: current_user
+          create :project_membership_as_admin, project: @project, user: current_user
         end
 
         it 'can create a user token for the project as expected' do
@@ -1368,10 +1368,10 @@ RSpec.describe ProjectsController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: @other_project, user: current_user
+          create :project_membership_as_admin, project: @other_project, user: current_user
         end
 
         it 'cannot create a user token for the project - returning 403 Forbidden' do

--- a/platform-hub-api/spec/controllers/services_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/services_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ServicesController, type: :controller do
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should return a list of all services for the project' do
           expect_project_services
@@ -148,7 +148,7 @@ RSpec.describe ServicesController, type: :controller do
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should return the service' do
           expect_service
@@ -241,7 +241,7 @@ RSpec.describe ServicesController, type: :controller do
         expect(audit.user).to eq current_user
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can create a new service in the project as expected' do
           expect_create_service project
@@ -253,10 +253,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'can create a new service in the project as expected' do
@@ -288,10 +288,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: other_project, user: current_user
+          create :project_membership_as_admin, project: other_project, user: current_user
         end
 
         it 'cannot create a new service in the project - returning 403 Forbidden' do
@@ -371,7 +371,7 @@ RSpec.describe ServicesController, type: :controller do
         expect(audit.user).to eq current_user
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can update a service in the project as expected' do
           expect_update_service project, @service
@@ -388,10 +388,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'can update a service in the project as expected' do
@@ -423,10 +423,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: other_project, user: current_user
+          create :project_membership_as_admin, project: other_project, user: current_user
         end
 
         it 'cannot update a service in the project - returning 403 Forbidden' do
@@ -489,7 +489,7 @@ RSpec.describe ServicesController, type: :controller do
         expect(audit.user.id).to eq current_user_id
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can delete a service in the project as expected' do
           expect_destroy_service project, @service
@@ -506,10 +506,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'can delete a service in the project as expected' do
@@ -541,10 +541,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: other_project, user: current_user
+          create :project_membership_as_admin, project: other_project, user: current_user
         end
 
         it 'cannot delete a service in the project - returning 403 Forbidden' do
@@ -649,7 +649,7 @@ RSpec.describe ServicesController, type: :controller do
         expect(pluck_from_json_response('name')).to match_array groups.map(&:name)
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'no target specified' do
           it 'can fetch groups for service in the project as expected' do
@@ -695,10 +695,10 @@ RSpec.describe ServicesController, type: :controller do
 
       # NOTE: we don't need to repeat the target filtering specs anymore
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'can fetch groups for service in the project as expected' do
@@ -729,10 +729,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: other_project, user: current_user
+          create :project_membership_as_admin, project: other_project, user: current_user
         end
 
         it 'cannot fetch groups for service in the project - returning 403 Forbidden' do
@@ -794,7 +794,7 @@ RSpec.describe ServicesController, type: :controller do
         expect(pluck_from_json_response('token')).to match_array tokens.map(&:decrypted_token)
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can fetch robot tokens for service in the project as expected' do
           expect_tokens project, @service, @tokens
@@ -811,10 +811,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'can fetch robot tokens for service in the project as expected' do
@@ -845,10 +845,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: other_project, user: current_user
+          create :project_membership_as_admin, project: other_project, user: current_user
         end
 
         it 'cannot fetch robot tokens for service in the project - returning 403 Forbidden' do
@@ -933,7 +933,7 @@ RSpec.describe ServicesController, type: :controller do
         })
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can fetch a robot token for the service in the project as expected' do
           expect_token project, @service, @token
@@ -960,10 +960,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'can fetch a robot token for the service in the project as expected' do
@@ -994,10 +994,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: other_project, user: current_user
+          create :project_membership_as_admin, project: other_project, user: current_user
         end
 
         it 'cannot fetch a robot token for the service in the project - returning 403 Forbidden' do
@@ -1105,7 +1105,7 @@ RSpec.describe ServicesController, type: :controller do
         expect(audit.user).to eq current_user
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can create a robot token for the service in the project as expected' do
           expect_create project, @service
@@ -1135,10 +1135,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'can create a robot token for the service in the project as expected' do
@@ -1173,10 +1173,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: other_project, user: current_user
+          create :project_membership_as_admin, project: other_project, user: current_user
         end
 
         it 'cannot create a robot token for the service in the project - returning 403 Forbidden' do
@@ -1280,7 +1280,7 @@ RSpec.describe ServicesController, type: :controller do
         expect(audit.user).to eq current_user
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can update a robot token for the service in the project as expected' do
           expect_update project, @service, @token
@@ -1307,10 +1307,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'can update a robot token for the service in the project as expected' do
@@ -1342,10 +1342,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: other_project, user: current_user
+          create :project_membership_as_admin, project: other_project, user: current_user
         end
 
         it 'cannot update a robot token for the service in the project - returning 403 Forbidden' do
@@ -1409,7 +1409,7 @@ RSpec.describe ServicesController, type: :controller do
         expect(audit.user).to eq current_user
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'can delete a robot token for the service in the project as expected' do
           expect_destroy project, @service, @token
@@ -1436,10 +1436,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the project' do
+      context 'not an admin but is an admin of the project' do
 
         before do
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'can delete a robot token for the service in the project as expected' do
@@ -1471,10 +1471,10 @@ RSpec.describe ServicesController, type: :controller do
 
       end
 
-      context 'not an admin but is manager of the other project' do
+      context 'not an admin but is an admin of the other project' do
 
         before do
-          create :project_membership_as_manager, project: other_project, user: current_user
+          create :project_membership_as_admin, project: other_project, user: current_user
         end
 
         it 'cannot delete a robot token for the service in the project - returning 403 Forbidden' do

--- a/platform-hub-api/spec/controllers/support_request_templates_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/support_request_templates_controller_spec.rb
@@ -102,13 +102,13 @@ RSpec.describe SupportRequestTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :create, params: post_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'creates a new support request template as expected' do
           expect(SupportRequestTemplate.count).to eq 0
@@ -171,13 +171,13 @@ RSpec.describe SupportRequestTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           put :update, params: put_data
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'updates the specified support request template' do
           expect(SupportRequestTemplate.count).to eq 1
@@ -216,13 +216,13 @@ RSpec.describe SupportRequestTemplatesController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           delete :destroy, params: { id: @support_request_template.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should delete the specified support request template' do
           expect(SupportRequestTemplate.exists?(@support_request_template.id)).to be true

--- a/platform-hub-api/spec/controllers/users_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/users_controller_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe UsersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :index
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when only the authenticated user exists' do
           it 'should return a list with only the authenticated user' do
@@ -69,13 +69,13 @@ RSpec.describe UsersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :show, params: { id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'for a non-existent user' do
           it 'should return a 404' do
@@ -117,13 +117,13 @@ RSpec.describe UsersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :search, params: { q: 'foo' }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when no users exist' do
           it 'should not return any results' do
@@ -161,10 +161,10 @@ RSpec.describe UsersController, type: :controller do
         end
       end
 
-      context 'not an admin but is a project manager of some project' do
+      context 'not an admin but is a project admin of some project' do
         before do
           project = create :project
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
 
           create_list :user, 3
           @user = create :user, name: 'foobar'
@@ -213,13 +213,13 @@ RSpec.describe UsersController, type: :controller do
         ])
       end
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :identities, params: { id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
         it 'should return the user\'s list of identities' do
           expect_identities @user, identity
         end
@@ -268,7 +268,7 @@ RSpec.describe UsersController, type: :controller do
             @user = @identity.user
           end
 
-          it_behaves_like 'an admin' do
+          it_behaves_like 'a hub admin' do
             it 'should return it without revealing token value' do
               get :identities, params: { id: @user.id }
               expect(response).to be_success
@@ -299,13 +299,13 @@ RSpec.describe UsersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :make_admin, params: { id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should make the specified user an admin' do
           expect(@user.admin?).to be false
@@ -338,13 +338,13 @@ RSpec.describe UsersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :revoke_admin, params: { id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         it 'should revoke the admin role for the specified user' do
           expect(@user.admin?).to be true
@@ -382,13 +382,13 @@ RSpec.describe UsersController, type: :controller do
         instance_double('Agents::GitHubAgentService')
       end
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :onboard_github, params: { id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when user does not have a GitHub identity connected' do
           it 'should return a 400 Bad Request with an appropriate error message' do
@@ -417,11 +417,11 @@ RSpec.describe UsersController, type: :controller do
 
       end
 
-      context 'not an admin but is project manager of same project' do
+      context 'not an admin but is project admin of same project' do
         before do
           project = create :project
           create :project_membership, project: project, user: @user
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'should onboard the user and return a success response with no content' do
@@ -437,13 +437,13 @@ RSpec.describe UsersController, type: :controller do
         end
       end
 
-      context 'not an admin but is project manager but of a different and not common project' do
+      context 'not an admin but is project admin but of a different and not common project' do
         before do
           project1 = create :project
           project2 = create :project
           create :project_membership, project: project1, user: @user
           create :project_membership, project: project1, user: current_user
-          create :project_membership_as_manager, project: project2, user: current_user
+          create :project_membership_as_admin, project: project2, user: current_user
         end
 
         it 'should not be able to onboard the user on GitHub - returning 403 Forbidden' do
@@ -474,13 +474,13 @@ RSpec.describe UsersController, type: :controller do
         instance_double('Agents::GitHubAgentService')
       end
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :offboard_github, params: { id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
 
         context 'when user does not have a GitHub identity connected' do
           it 'should return a 400 Bad Request with an appropriate error message' do
@@ -509,11 +509,11 @@ RSpec.describe UsersController, type: :controller do
 
       end
 
-      context 'not an admin but is project manager of same project' do
+      context 'not an admin but is project admin of same project' do
         before do
           project = create :project
           create :project_membership, project: project, user: @user
-          create :project_membership_as_manager, project: project, user: current_user
+          create :project_membership_as_admin, project: project, user: current_user
         end
 
         it 'should offboard the user and return a success response with no content' do
@@ -529,13 +529,13 @@ RSpec.describe UsersController, type: :controller do
         end
       end
 
-      context 'not an admin but is project manager but of a different and not common project' do
+      context 'not an admin but is project admin but of a different and not common project' do
         before do
           project1 = create :project
           project2 = create :project
           create :project_membership, project: project1, user: @user
           create :project_membership, project: project1, user: current_user
-          create :project_membership_as_manager, project: project2, user: current_user
+          create :project_membership_as_admin, project: project2, user: current_user
         end
 
         it 'should not be able to offboard the user on GitHub - returning 403 Forbidden' do
@@ -562,13 +562,13 @@ RSpec.describe UsersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           get :activate, params: { id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
         let(:keycloak_agent_service) { instance_double('Agents::KeycloakAgentService') }
         let(:user_representation) { double }
 
@@ -615,13 +615,13 @@ RSpec.describe UsersController, type: :controller do
 
     it_behaves_like 'authenticated' do
 
-      it_behaves_like 'not an admin so forbidden'  do
+      it_behaves_like 'not a hub admin so forbidden'  do
         before do
           post :deactivate, params: { id: @user.id }
         end
       end
 
-      it_behaves_like 'an admin' do
+      it_behaves_like 'a hub admin' do
         let(:keycloak_agent_service) { instance_double('Agents::KeycloakAgentService') }
         let(:user_representation) { double }
 

--- a/platform-hub-api/spec/factories/project_memberships.rb
+++ b/platform-hub-api/spec/factories/project_memberships.rb
@@ -3,8 +3,8 @@ FactoryGirl.define do
     project
     user
 
-    factory :project_membership_as_manager do
-      role 'manager'
+    factory :project_membership_as_admin do
+      role 'admin'
     end
   end
 end

--- a/platform-hub-api/spec/routing/projects_routing_spec.rb
+++ b/platform-hub-api/spec/routing/projects_routing_spec.rb
@@ -46,15 +46,15 @@ RSpec.describe ProjectsController, type: :routing do
       end
 
       it 'routes to #role_check' do
-        expect(:get => '/projects/1/memberships/role_check/manager').to route_to('projects#role_check', :id => '1', :role => 'manager')
+        expect(:get => '/projects/1/memberships/role_check/admin').to route_to('projects#role_check', :id => '1', :role => 'admin')
       end
 
       it 'routes to #set_role' do
-        expect(:put => '/projects/1/memberships/25/role/manager').to route_to('projects#set_role', :id => '1', :user_id => '25', :role => 'manager')
+        expect(:put => '/projects/1/memberships/25/role/admin').to route_to('projects#set_role', :id => '1', :user_id => '25', :role => 'admin')
       end
 
       it 'routes to #unset_role' do
-        expect(:delete => '/projects/1/memberships/25/role/manager').to route_to('projects#unset_role', :id => '1', :user_id => '25', :role => 'manager')
+        expect(:delete => '/projects/1/memberships/25/role/admin').to route_to('projects#unset_role', :id => '1', :user_id => '25', :role => 'admin')
       end
 
       it 'does not route when given an unidentified "role"' do
@@ -134,15 +134,15 @@ RSpec.describe ProjectsController, type: :routing do
       end
 
       it 'route to #role_check is not routable' do
-        expect(:get => '/projects/1/memberships/role_check/manager').to_not be_routable
+        expect(:get => '/projects/1/memberships/role_check/admin').to_not be_routable
       end
 
       it 'route to #set_role is not routable' do
-        expect(:put => '/projects/1/memberships/25/role/manager').to_not be_routable
+        expect(:put => '/projects/1/memberships/25/role/admin').to_not be_routable
       end
 
       it 'route to #unset_role is not routable' do
-        expect(:delete => '/projects/1/memberships/25/role/manager').to_not be_routable
+        expect(:delete => '/projects/1/memberships/25/role/admin').to_not be_routable
       end
 
       it 'route to #kubernetes_clusters is not routable' do

--- a/platform-hub-api/spec/services/project_memberships_service_spec.rb
+++ b/platform-hub-api/spec/services/project_memberships_service_spec.rb
@@ -11,7 +11,7 @@ describe ProjectMembershipsService, type: :service do
   let!(:user_3) { create :user }
 
   before do
-    create :project_membership_as_manager,
+    create :project_membership_as_admin,
       project: project_1,
       user: user_1
     create :project_membership,
@@ -21,11 +21,11 @@ describe ProjectMembershipsService, type: :service do
     create :project_membership,
       project: project_2,
       user: user_1
-    create :project_membership_as_manager,
+    create :project_membership_as_admin,
       project: project_2,
       user: user_2
 
-    create :project_membership_as_manager,
+    create :project_membership_as_admin,
       project: project_3,
       user: user_2
     create :project_membership,
@@ -59,7 +59,7 @@ describe ProjectMembershipsService, type: :service do
 
   end
 
-  describe '.is_user_a_manager_of_project?' do
+  describe '.is_user_an_admin_of_project?' do
 
     let :mappings do
       {
@@ -75,35 +75,35 @@ describe ProjectMembershipsService, type: :service do
       }
     end
 
-    it 'should only return true for actual project managers' do
+    it 'should only return true for actual project admins' do
       mappings.each do |((p_id, u_id), result)|
         expect(
-          subject.is_user_a_manager_of_project?(p_id, u_id)
+          subject.is_user_an_admin_of_project?(p_id, u_id)
         ).to be result
       end
     end
 
   end
 
-  describe '.is_user_a_manager_of_any_project?' do
+  describe '.is_user_an_admin_of_any_project?' do
 
-    it 'should only return true if user is a manager of any project' do
+    it 'should only return true if user is an admin of any project' do
       expect(
-        subject.is_user_a_manager_of_any_project?(user_1.id)
+        subject.is_user_an_admin_of_any_project?(user_1.id)
       ).to be true
 
       expect(
-        subject.is_user_a_manager_of_any_project?(user_2.id)
+        subject.is_user_an_admin_of_any_project?(user_2.id)
       ).to be true
 
       expect(
-        subject.is_user_a_manager_of_any_project?(user_3.id)
+        subject.is_user_an_admin_of_any_project?(user_3.id)
       ).to be false
     end
 
   end
 
-  describe '.is_user_a_manager_of_a_common_project?' do
+  describe '.is_user_an_admin_of_a_common_project?' do
 
     let :mappings do
       {
@@ -116,10 +116,10 @@ describe ProjectMembershipsService, type: :service do
       }
     end
 
-    it 'should only return true for cases where the two users share a project and the first user is a manager of any of those projects' do
+    it 'should only return true for cases where the two users share a project and the first user is an admin of any of those projects' do
       mappings.each do |((user, target_user), result)|
         expect(
-          subject.is_user_a_manager_of_a_common_project?(user, target_user)
+          subject.is_user_an_admin_of_a_common_project?(user, target_user)
         ).to be result
       end
     end

--- a/platform-hub-api/spec/support/admin_authorization_helpers.rb
+++ b/platform-hub-api/spec/support/admin_authorization_helpers.rb
@@ -12,13 +12,13 @@ module AdminAuthorizationHelpers
 
   end
 
-  RSpec.shared_examples 'not an admin so forbidden' do
+  RSpec.shared_examples 'not a hub admin so forbidden' do
     it 'will return a 403 Forbidden' do
       expect(response).to have_http_status(403)
     end
   end
 
-  RSpec.shared_examples 'an admin' do
+  RSpec.shared_examples 'a hub admin' do
     include_context 'admin authorization helpers'
 
     before do

--- a/platform-hub-web/src/app/help/faq/faq-entries.html
+++ b/platform-hub-web/src/app/help/faq/faq-entries.html
@@ -70,7 +70,7 @@
         </ul>
 
         <p ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.projects)">
-          If you are made a project manager, you can:
+          If you are made a project admin, you can:
         </p>
         <ul ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.projects)">
           <li>
@@ -100,7 +100,7 @@
         </p>
         <ul>
           <li>
-            <strong>Project managers</strong> can manage a project's team and onboard/offboard team members
+            <strong>Project admins</strong> can manage a project's team and onboard/offboard team members
           </li>
           <li>
             <strong>Admins</strong> manage announcements, users, projects and much more on the hub and grant special permissions to others

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.js
@@ -70,7 +70,7 @@ function KubernetesRobotTokensFormController($q, $state, $mdSelect, roleCheckerS
     return loadAdminStatus()
       .then(() => {
         // If not an admin, then `fromProject` and `fromService` params must be
-        // provided, and verified for project manager status.
+        // provided, and verified for project admin status.
 
         if (!ctrl.isAdmin) {
           if (!fromProject || !fromService) {
@@ -78,7 +78,7 @@ function KubernetesRobotTokensFormController($q, $state, $mdSelect, roleCheckerS
           }
 
           return Projects
-            .membershipRoleCheck(fromProject, 'manager')
+            .membershipRoleCheck(fromProject, 'admin')
             .then(data => data.result);
         }
 

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.spec.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.spec.js
@@ -72,10 +72,10 @@ describe('kubernetes robot tokens form', () => {
       .resolves(result);
   }
 
-  function stubProjectManagerRole(projectId, result) {
+  function stubProjectAdminRole(projectId, result) {
     sandbox
       .stub(Projects, 'membershipRoleCheck')
-      .withArgs(projectId, 'manager')
+      .withArgs(projectId, 'admin')
       .usingPromise($q)
       .resolves({result});
   }
@@ -229,11 +229,11 @@ describe('kubernetes robot tokens form', () => {
       stubAdmin(false);
     });
 
-    describe('for a project manager of project foo', () => {
+    describe('for a project admin of project foo', () => {
       describe('for a new robot token', () => {
         describe('when not providing fromProject and fromService params', () => {
           beforeEach(() => {
-            stubProjectManagerRole('foo', true);
+            stubProjectAdminRole('foo', true);
 
             renderComponentWithTransitionParams(params);
           });
@@ -246,7 +246,7 @@ describe('kubernetes robot tokens form', () => {
 
         describe('when providing fromProject=foo and fromService=bar params', () => {
           beforeEach(() => {
-            stubProjectManagerRole('foo', true);
+            stubProjectAdminRole('foo', true);
 
             params.fromProject = 'foo';
             params.fromService = 'bar';
@@ -263,7 +263,7 @@ describe('kubernetes robot tokens form', () => {
 
         describe('when providing fromProject=other and fromService=bar params', () => {
           beforeEach(() => {
-            stubProjectManagerRole('other', false);
+            stubProjectAdminRole('other', false);
 
             params.fromProject = 'other';
             params.fromService = 'bar';
@@ -286,7 +286,7 @@ describe('kubernetes robot tokens form', () => {
 
         describe('when not providing fromProject and fromService params', () => {
           beforeEach(() => {
-            stubProjectManagerRole('foo', true);
+            stubProjectAdminRole('foo', true);
 
             sandbox.spy(KubernetesTokens, 'getToken');
             sandbox.spy(Projects, 'getServiceKubernetesRobotToken');
@@ -304,7 +304,7 @@ describe('kubernetes robot tokens form', () => {
 
         describe('when providing fromProject=foo and fromService=bar params', () => {
           beforeEach(() => {
-            stubProjectManagerRole('foo', true);
+            stubProjectAdminRole('foo', true);
 
             params.fromProject = 'foo';
             params.fromService = 'bar';
@@ -323,7 +323,7 @@ describe('kubernetes robot tokens form', () => {
 
         describe('when providing fromProject=other and fromService=bar params', () => {
           beforeEach(() => {
-            stubProjectManagerRole('other', false);
+            stubProjectAdminRole('other', false);
 
             params.fromProject = 'other';
             params.fromService = 'bar';
@@ -342,7 +342,7 @@ describe('kubernetes robot tokens form', () => {
       });
     });
 
-    describe('for a user that is not a project manager of any project', () => {
+    describe('for a user that is not a project admin of any project', () => {
       beforeEach(() => {
         sandbox
           .stub(Projects, 'membershipRoleCheck')

--- a/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.component.js
@@ -85,7 +85,7 @@ function KubernetesUserTokensFormController($q, $state, $mdSelect, Projects, App
     return loadAdminStatus()
       .then(() => {
         // If not an admin, then `fromProject` param must be provided, and
-        // verified for project manager status.
+        // verified for project admin status.
 
         if (!ctrl.isAdmin) {
           if (!fromProject) {
@@ -93,7 +93,7 @@ function KubernetesUserTokensFormController($q, $state, $mdSelect, Projects, App
           }
 
           return Projects
-            .membershipRoleCheck(fromProject, 'manager')
+            .membershipRoleCheck(fromProject, 'admin')
             .then(data => data.result);
         }
 

--- a/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.component.spec.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.component.spec.js
@@ -71,10 +71,10 @@ describe('kubernetes user tokens form', () => {
       .resolves(result);
   }
 
-  function stubProjectManagerRole(projectId, result) {
+  function stubProjectAdminRole(projectId, result) {
     sandbox
       .stub(Projects, 'membershipRoleCheck')
-      .withArgs(projectId, 'manager')
+      .withArgs(projectId, 'admin')
       .usingPromise($q)
       .resolves({result});
   }
@@ -245,11 +245,11 @@ describe('kubernetes user tokens form', () => {
       stubAdmin(false);
     });
 
-    describe('for a project manager of project foo', () => {
+    describe('for a project admin of project foo', () => {
       describe('for a new user token', () => {
         describe('when not providing the fromProject param', () => {
           beforeEach(() => {
-            stubProjectManagerRole('foo', true);
+            stubProjectAdminRole('foo', true);
 
             renderComponentWithTransitionParams(params);
           });
@@ -262,7 +262,7 @@ describe('kubernetes user tokens form', () => {
 
         describe('when providing fromProject=foo param', () => {
           beforeEach(() => {
-            stubProjectManagerRole('foo', true);
+            stubProjectAdminRole('foo', true);
 
             params.fromProject = 'foo';
 
@@ -280,7 +280,7 @@ describe('kubernetes user tokens form', () => {
 
         describe('when providing fromProject=other param', () => {
           beforeEach(() => {
-            stubProjectManagerRole('other', false);
+            stubProjectAdminRole('other', false);
 
             params.fromProject = 'other';
 
@@ -304,7 +304,7 @@ describe('kubernetes user tokens form', () => {
 
         describe('when not providing the fromProject param', () => {
           beforeEach(() => {
-            stubProjectManagerRole('foo', true);
+            stubProjectAdminRole('foo', true);
 
             renderComponentWithTransitionParams(params);
           });
@@ -317,7 +317,7 @@ describe('kubernetes user tokens form', () => {
 
         describe('when providing fromProject=foo param', () => {
           beforeEach(() => {
-            stubProjectManagerRole('foo', true);
+            stubProjectAdminRole('foo', true);
 
             params.fromProject = 'foo';
 
@@ -335,7 +335,7 @@ describe('kubernetes user tokens form', () => {
 
         describe('when providing fromProject=other param', () => {
           beforeEach(() => {
-            stubProjectManagerRole('other', false);
+            stubProjectAdminRole('other', false);
 
             params.fromProject = 'other';
 
@@ -352,7 +352,7 @@ describe('kubernetes user tokens form', () => {
       });
     });
 
-    describe('for a user that is not a project manager of any project', () => {
+    describe('for a user that is not a project admin of any project', () => {
       beforeEach(() => {
         sandbox
           .stub(Projects, 'membershipRoleCheck')

--- a/platform-hub-web/src/app/onboarding/hub-setup.html
+++ b/platform-hub-web/src/app/onboarding/hub-setup.html
@@ -23,7 +23,7 @@
                 name="is_managerial"
                 ng-model="$ctrl.data.is_managerial"
                 aria-label="Select this if your role involves managerial duties">
-                <strong>Managerial</strong> duties (e.g.: managing projects and team members)
+                <strong>Managerial</strong> duties (e.g.: managing schedules and people)
               </md-checkbox>
 
               <md-checkbox
@@ -35,7 +35,7 @@
             </div>
 
             <p class="md-body-1">
-              This will determine what you see and can do within the hub.
+              This will determine what you <strong>see</strong> within the hub, but <strong>does not</strong> automatically give you more privileges etc.
             </p>
           </fieldset>
 

--- a/platform-hub-web/src/app/projects/projects-detail.html
+++ b/platform-hub-web/src/app/projects/projects-detail.html
@@ -71,7 +71,7 @@
                     <span ng-if="$ctrl.isAdmin">Why not add some?</span>
                   </p>
 
-                  <md-toolbar md-colors="{background: 'primary-50'}" ng-if="$ctrl.isAdmin || $ctrl.isProjectManager">
+                  <md-toolbar md-colors="{background: 'primary-50'}" ng-if="$ctrl.isAdmin || $ctrl.isProjectAdmin">
                     <div class="md-toolbar-tools">
                       <md-autocomplete
                         md-no-cache="true"
@@ -111,7 +111,7 @@
                       <div class="md-list-item-text">
                         <h3>
                           {{m.user.name}}
-                          <small class="badge" ng-if="m.role == 'manager'" md-colors="{background: 'accent'}">Manager</small>
+                          <small class="badge" ng-if="m.role == 'admin'" md-colors="{background: 'accent'}">Admin</small>
                           <small class="badge" ng-if="!m.user.is_active" md-colors="{background: 'blue-grey'}">Deactivated</small>
                         </h3>
                         <h4>{{m.user.email}}</h4>
@@ -138,23 +138,23 @@
                               Offboard GitHub
                             </md-button>
                           </md-menu-item>
-                          <md-menu-item ng-if="$ctrl.isAdmin && m.role != 'manager'">
+                          <md-menu-item ng-if="$ctrl.isAdmin && m.role != 'admin'">
                             <md-button
                               ng-if="m.user.is_active"
-                              ng-click="$ctrl.makeManager(m, $event)"
-                              aria-label="Make this person a team manager">
-                              Make manager
+                              ng-click="$ctrl.makeAdmin(m, $event)"
+                              aria-label="Make this person a project admin">
+                              Make admin
                             </md-button>
                           </md-menu-item>
-                          <md-menu-item ng-if="$ctrl.isAdmin && m.role == 'manager'">
+                          <md-menu-item ng-if="$ctrl.isAdmin && m.role == 'admin'">
                             <md-button
                               ng-if="m.user.is_active"
-                              ng-click="$ctrl.demoteManager(m, $event)"
-                              aria-label="Demote this person from their team manager role">
-                              Demote manager
+                              ng-click="$ctrl.demoteAdmin(m, $event)"
+                              aria-label="Demote this person from their project admin role">
+                              Demote admin
                             </md-button>
                           </md-menu-item>
-                          <md-menu-item ng-if="$ctrl.isAdmin || $ctrl.isProjectManager">
+                          <md-menu-item ng-if="$ctrl.isAdmin || $ctrl.isProjectAdmin">
                             <md-button
                               ng-click="$ctrl.removeMembership(m, $event)"
                               aria-label="Remove this person from this project team">
@@ -238,7 +238,7 @@
 
       <md-tab
         id="kube-user-tokens-tab"
-        ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetesTokens) && ($ctrl.isAdmin || $ctrl.isProjectManager)"
+        ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetesTokens) && ($ctrl.isAdmin || $ctrl.isProjectAdmin)"
         md-on-select="$ctrl.loadKubernetesUserTokens()">
         <md-tab-label>Kube User Tokens</md-tab-label>
         <md-tab-body>

--- a/platform-hub-web/src/app/projects/services/project-services-detail.component.js
+++ b/platform-hub-web/src/app/projects/services/project-services-detail.component.js
@@ -20,7 +20,7 @@ function ProjectServicesDetailController($q, $mdDialog, $state, roleCheckerServi
   ctrl.projectId = projectId;
   ctrl.loading = true;
   ctrl.isAdmin = false;
-  ctrl.isProjectManager = false;
+  ctrl.isProjectAdmin = false;
   ctrl.service = null;
   ctrl.kubernetesRobotTokens = [];
   ctrl.processingKubernetesRobotTokens = false;
@@ -55,14 +55,14 @@ function ProjectServicesDetailController($q, $mdDialog, $state, roleCheckerServi
         ctrl.service = service;
       });
 
-    const managerCheck = Projects
-      .membershipRoleCheck(projectId, 'manager')
+    const adminCheck = Projects
+      .membershipRoleCheck(projectId, 'admin')
       .then(data => {
-        ctrl.isProjectManager = data.result;
+        ctrl.isProjectAdmin = data.result;
       });
 
     return $q
-      .all([serviceFetch, managerCheck])
+      .all([serviceFetch, adminCheck])
       .finally(() => {
         ctrl.loading = false;
       });
@@ -95,7 +95,7 @@ function ProjectServicesDetailController($q, $mdDialog, $state, roleCheckerServi
   }
 
   function shouldShowCreateKubernetesRobotTokenButton() {
-    return ctrl.isAdmin || ctrl.isProjectManager;
+    return ctrl.isAdmin || ctrl.isProjectAdmin;
   }
 
   function loadKubernetesRobotTokens() {

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -325,7 +325,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       .get(`${apiEndpoint}/projects/${projectId}/memberships/role_check/${role}`)
       .then(response => response.data)
       .catch(response => {
-        logger.error(buildErrorMessageFromResponse('Failed to check if user if a manager for the specific project', response));
+        logger.error(buildErrorMessageFromResponse(`Failed to check if user is ${role} for the specific project`, response));
         return $q.reject(response);
       });
   }


### PR DESCRIPTION
This includes a live data migration.

Rationale for this change: the term 'manager' sounded too non-technical and could easily be confused with Project Manager (PM) roles within the org.