### PR TITLE
Backend: remove the `kubernetes:cluster:*` rake tasks

### DIFF
--- a/platform-hub-api/lib/tasks/kubernetes.rake
+++ b/platform-hub-api/lib/tasks/kubernetes.rake
@@ -27,26 +27,4 @@ namespace :kubernetes do
     end
   end
 
-  namespace :cluster do
-
-    desc "Add kubernetes cluster to list of managed clusters"
-    task :create, [:name, :description, :s3_region, :s3_bucket_name, :s3_access_key_id, :s3_secret_access_key, :s3_object_key] => [:environment] do |t, args|
-
-      unless [args.name, args.description, args.s3_region, args.s3_bucket_name, args.s3_access_key_id, args.s3_secret_access_key, args.s3_object_key].all?
-        raise "ERROR: Missing arguments!"
-      end
-
-      puts KubernetesCluster.create(args)
-    end
-
-    desc "Delete kubernetes cluster from list of managed clusters"
-    task :delete, [:name] => [:environment] do |t, args|
-
-      raise "ERROR: Missing argument!" if args.name.blank?
-
-      puts KubernetesCluster.friendly.destroy(args.name)
-    end
-
-  end
-
 end


### PR DESCRIPTION
We can now manage clusters directly in the UI.