### PR TITLE
Backend: only output the audit message to logs in debug mode

### DIFF
--- a/platform-hub-api/app/models/audit.rb
+++ b/platform-hub-api/app/models/audit.rb
@@ -63,7 +63,7 @@ class Audit < ApplicationRecord
   end
 
   def output_log_message
-    logger.info self.message
+    logger.debug self.message
   end
 
 end


### PR DESCRIPTION
This is to prevent any potential leaking of audit data into logs.