### PR TITLE
Re-do the token escalation of privileges to restrict it per project

### DIFF
--- a/platform-hub-api/app/controllers/concerns/kubernetes_groups_sub_collection.rb
+++ b/platform-hub-api/app/controllers/concerns/kubernetes_groups_sub_collection.rb
@@ -3,7 +3,7 @@ module KubernetesGroupsSubCollection
 
   # `resource` is expected to have a `#kubernetes_groups` association
   def kubernetes_groups_sub_collection resource, target = nil
-    scope = resource.kubernetes_groups.not_privileged
+    scope = resource.kubernetes_groups
     groups = if target.present?
       unless KubernetesGroup.targets.keys.include?(target)
         bad_request_error('Invalid `target` param specified') and return

--- a/platform-hub-api/app/controllers/kubernetes/groups_controller.rb
+++ b/platform-hub-api/app/controllers/kubernetes/groups_controller.rb
@@ -64,12 +64,6 @@ class Kubernetes::GroupsController < ApiJsonController
     head :no_content
   end
 
-  # GET /kubernetes/groups/privileged
-  def privileged
-    groups = KubernetesGroup.privileged.order(:name)
-    render json: groups
-  end
-
   # POST /kubernetes/groups/:id/allocate
   def allocate
     project = Project.friendly.find(params.require(:project_id))

--- a/platform-hub-api/app/controllers/kubernetes/tokens_controller.rb
+++ b/platform-hub-api/app/controllers/kubernetes/tokens_controller.rb
@@ -4,7 +4,7 @@ class Kubernetes::TokensController < ApiJsonController
 
   before_action :find_token, only: [ :show, :update, :destroy, :escalate, :deescalate ]
 
-  authorize_resource class: KubernetesToken
+  authorize_resource class: KubernetesToken, except: [ :escalate, :deescalate ]
 
   # GET /kubernetes/tokens
   def index
@@ -47,6 +47,8 @@ class Kubernetes::TokensController < ApiJsonController
 
   # PATCH /kubernetes/tokens/:id/escalate
   def escalate
+    authorize! :administer_projects, @token.project
+
     privileged_group, expires_in_secs = params.require([:privileged_group, :expires_in_secs])
 
     if @token.escalate(privileged_group, expires_in_secs)
@@ -68,6 +70,8 @@ class Kubernetes::TokensController < ApiJsonController
 
   # PATCH /kubernetes/tokens/:id/deescalate
   def deescalate
+    authorize! :administer_projects, @token.project
+
     if @token.deescalate
       AuditService.log(
         context: audit_context,

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -126,8 +126,6 @@ Rails.application.routes.draw do
         post '/revoke', to: 'revoke#revoke'
 
         resources :groups do
-          get :privileged, on: :collection
-
           post :allocate, on: :member
           get :allocations, on: :member
         end

--- a/platform-hub-api/spec/controllers/kubernetes/groups_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/groups_controller_spec.rb
@@ -281,44 +281,6 @@ RSpec.describe Kubernetes::GroupsController, type: :controller do
     end
   end
 
-  describe 'GET #privileged' do
-    it_behaves_like 'unauthenticated not allowed' do
-      before do
-        get :privileged
-      end
-    end
-
-    it_behaves_like 'authenticated' do
-
-      it_behaves_like 'not a hub admin so forbidden'  do
-        before do
-          get :privileged
-        end
-      end
-
-      it_behaves_like 'a hub admin' do
-        let!(:not_privileged_group) { create :kubernetes_group, is_privileged: false }
-        let!(:privileged_group) { create :kubernetes_group, is_privileged: true }
-        let!(:default_privileged_group) { create :kubernetes_group }
-
-        it 'returns the list of privileged kubernetes groups' do
-          get :privileged
-          expect(response).to be_success
-          expect(json_response).to eq([{
-            'id' => privileged_group.friendly_id,
-            'name' => privileged_group.name,
-            'kind' => privileged_group.kind,
-            'target' => privileged_group.target,
-            'description' => privileged_group.description,
-            'is_privileged' => privileged_group.is_privileged,
-            'restricted_to_clusters' => privileged_group.restricted_to_clusters
-          }])
-        end
-
-      end
-    end
-  end
-
   describe 'POST #allocate' do
     before do
       @group = create :kubernetes_group

--- a/platform-hub-api/spec/controllers/services_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/services_controller_spec.rb
@@ -605,13 +605,16 @@ RSpec.describe ServicesController, type: :controller do
     let :service_user_groups do
       [
         @service_group_namespace_user_not_privileged,
-        @service_group_clusterwide_user_not_privileged
+        @service_group_namespace_user_privileged,
+        @service_group_clusterwide_user_not_privileged,
+        @service_group_clusterwide_user_privileged
       ].sort_by(&:name)
     end
 
     let :service_robot_groups do
       [
-        @service_group_namespace_robot_not_privileged
+        @service_group_namespace_robot_not_privileged,
+        @service_group_namespace_robot_privileged
       ]
     end
 
@@ -621,7 +624,8 @@ RSpec.describe ServicesController, type: :controller do
 
     let :other_service_user_groups do
       [
-        @other_service_group_namespace_user_not_privileged
+        @other_service_group_namespace_user_not_privileged,
+        @other_service_group_namespace_user_privileged
       ]
     end
 

--- a/platform-hub-api/spec/models/kubernetes_token_spec.rb
+++ b/platform-hub-api/spec/models/kubernetes_token_spec.rb
@@ -170,6 +170,19 @@ RSpec.describe KubernetesToken, type: :model do
         end
       end
 
+      context 'for a group that hasn\'t been allocated' do
+        let(:group) { create(:kubernetes_group, :privileged) }
+
+        it 'should set an error on the token and not change any groups' do
+          result = @t.escalate(group.name, 2000)
+          expect(result).to be false
+          expect(@t.errors.size).to eq 1
+          expect(@t.errors.messages).to eq({
+            base: ["group '#{group.name}' cannot be used to escalate privilege for this token"]
+          })
+        end
+      end
+
       context 'for invalid token' do
         before do
           @t.uid = nil

--- a/platform-hub-api/spec/routing/kubernetes_groups_routing_spec.rb
+++ b/platform-hub-api/spec/routing/kubernetes_groups_routing_spec.rb
@@ -33,10 +33,6 @@ RSpec.describe Kubernetes::GroupsController, type: :routing do
         expect(:delete => '/kubernetes/groups/1').to route_to('kubernetes/groups#destroy', :id => '1')
       end
 
-      it 'routes to #privileged' do
-        expect(:get => '/kubernetes/groups/privileged').to route_to('kubernetes/groups#privileged')
-      end
-
       it 'routes to #allocate' do
         expect(:post => '/kubernetes/groups/1/allocate').to route_to('kubernetes/groups#allocate', :id => '1')
       end
@@ -75,10 +71,6 @@ RSpec.describe Kubernetes::GroupsController, type: :routing do
 
       it 'route to #destroy is not routable' do
         expect(:delete => '/kubernetes/groups/1').to_not be_routable
-      end
-
-      it 'route to #privileged is not routable' do
-        expect(:get => '/kubernetes/groups/privileged').to_not be_routable
       end
 
       it 'route to #allocate is not routable' do

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.component.js
@@ -238,7 +238,9 @@ function KubernetesRobotTokensFormController($q, $state, $mdSelect, roleCheckerS
     const clusterName = _.get(ctrl.token, 'cluster.name');
 
     if (clusterName) {
-      ctrl.allowedGroups = KubernetesGroups.filterGroupsForCluster(ctrl.possibleGroups, clusterName);
+      ctrl.allowedGroups = KubernetesGroups
+        .filterGroupsForCluster(ctrl.possibleGroups, clusterName)
+        .filter(g => !g.is_privileged);
     }
   }
 

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-form.html
@@ -110,7 +110,7 @@
             <md-select
               name="groups"
               ng-model="$ctrl.token.groups"
-              md-selected-text="$ctrl.token.groups.length ? $ctrl.token.groups.join(', ') : 'Select RBAC group(s) *'"
+              md-selected-text="$ctrl.token.groups.length ? $ctrl.token.groups.join(', ') : 'Select RBAC group(s):'"
               ng-disabled="$ctrl.processing || !$ctrl.allowedGroups.length || !$ctrl.service || !$ctrl.token.cluster.name"
               multiple>
               <md-option

--- a/platform-hub-web/src/app/kubernetes/kubernetes-token-escalate-privilege-popup.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-token-escalate-privilege-popup.html
@@ -1,6 +1,11 @@
 <md-dialog aria-label="Escalate privilege for a kubernetes token">
   <md-toolbar class="md-toolbar-tools md-accent">
-    <h2>Temporarily escalate privilege for user '{{$ctrl.user.name}}' on cluster '{{$ctrl.cluster}}'</h2>
+    <h2>
+      Temporarily escalate privilege for user:
+      {{$ctrl.token.user.name}}
+      - on cluster:
+      {{$ctrl.token.cluster.name}}
+    </h2>
     <span flex></span>
     <md-button
       class="close-button md-icon-button"
@@ -14,19 +19,34 @@
 
   <md-dialog-content class="md-dialog-content" layout="column" layout-padding>
 
-    <form name="$ctrl.form" ng-if="!$ctrl.loading && $ctrl.groups.length > 0">
+    <p
+      ng-if="!$ctrl.loading && _.isEmpty($ctrl.groups)"
+      class="md-body-2"
+      md-colors="{background: 'default-accent-50'}"
+      layout-padding>
+      No privileged RBAC groups have been allocated to the project (or any of it's services), so escalation of privileges for this token is not possible just yet.
+    </p>
+
+    <form name="$ctrl.form" ng-if="!$ctrl.loading && !_.isEmpty($ctrl.groups)">
       <md-input-container class="md-block">
         <label for="group">Escalation group to set:</label>
         <md-select
           name="group"
           ng-model="$ctrl.data.group"
+          md-selected-text="$ctrl.data.group ? $ctrl.data.group : 'Escalation group to set:'"
           required
           aria-label="The escalation group (a.k.a. role) to set for the time limited period">
-          <md-option
-            ng-repeat="g in $ctrl.groups"
-            ng-value="g.id">
-            {{g.id}}
-          </md-option>
+          <md-optgroup
+            ng-repeat="(label, groups) in $ctrl.groups track by label"
+            label="{{label}}">
+            <md-option
+              ng-repeat="g in groups track by g.name"
+              ng-value="g.name">
+              {{g.name}}
+              <br />
+              <small>{{g.description}}</small>
+            </md-option>
+          </md-optgroup>
         </md-select>
       </md-input-container>
       <md-input-container class="md-block">
@@ -56,6 +76,7 @@
     <md-button
       class="md-primary"
       ng-click="$ctrl.escalate()"
+      ng-if="!_.isEmpty($ctrl.groups)"
       ng-disabled="$ctrl.processing || !$ctrl.form || $ctrl.form.$invalid"
       ng-class="{'md-raised': ($ctrl.form.$dirty && $ctrl.form.$valid) }"
       aria-label="Perform escalation">

--- a/platform-hub-web/src/app/kubernetes/kubernetes-token-escalate-privilege-popup.service.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-token-escalate-privilege-popup.service.js
@@ -7,7 +7,7 @@ export const kubernetesTokenEscalatePrivilegePopupService = function ($document,
 
   return service;
 
-  function open(tokenId, targetEvent) {
+  function open(token, targetEvent) {
     return $mdDialog.show({
       template: require('./kubernetes-token-escalate-privilege-popup.html'),
       controller: 'KubernetesTokenEscalatePrivilegePopupController',
@@ -18,7 +18,7 @@ export const kubernetesTokenEscalatePrivilegePopupService = function ($document,
       clickOutsideToClose: false,
       escapeToClose: false,
       locals: {
-        tokenId
+        token
       }
     });
   }

--- a/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.component.js
@@ -8,8 +8,10 @@ export const KubernetesUserTokensFormComponent = {
   controller: KubernetesUserTokensFormController
 };
 
-function KubernetesUserTokensFormController($q, $state, $mdSelect, Projects, AppSettings, KubernetesTokens, KubernetesGroups, roleCheckerService, hubApiService, logger, _) {
+function KubernetesUserTokensFormController($scope, $q, $state, $mdSelect, Projects, AppSettings, KubernetesTokens, KubernetesGroups, roleCheckerService, hubApiService, logger, _) {
   'ngInject';
+
+  $scope._ = _;
 
   const ctrl = this;
 
@@ -19,7 +21,6 @@ function KubernetesUserTokensFormController($q, $state, $mdSelect, Projects, App
   const tokenId = _.get(transitionParams, 'tokenId');
   const fromProject = _.get(transitionParams, 'fromProject');
 
-  ctrl._ = _;
   ctrl.AppSettings = AppSettings;
   ctrl.Projects = Projects;
 
@@ -247,7 +248,7 @@ function KubernetesUserTokensFormController($q, $state, $mdSelect, Projects, App
   }
 
   function filterGroups() {
-    ctrl.allowedGroups = [];
+    ctrl.allowedGroups = {};
 
     const clusterName = _.get(ctrl.token, 'cluster.name');
 

--- a/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.html
@@ -112,7 +112,7 @@
             <md-select
               name="groups"
               ng-model="$ctrl.token.groups"
-              md-selected-text="$ctrl.token.groups.length ? $ctrl.token.groups.join(', ') : 'Select RBAC group(s) *'"
+              md-selected-text="$ctrl.token.groups.length ? $ctrl.token.groups.join(', ') : 'Select RBAC group(s):'"
               ng-disabled="$ctrl.processing || _.isEmpty($ctrl.allowedGroups) || !$ctrl.token.project.id || !$ctrl.token.cluster.name"
               multiple>
               <md-optgroup

--- a/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-form.html
@@ -98,7 +98,7 @@
           <br />
 
           <p
-            ng-if="!$ctrl.processing && $ctrl.token.project.id && $ctrl.token.cluster.name && !$ctrl.allowedGroups.length == 0"
+            ng-if="!$ctrl.processing && $ctrl.token.project.id && $ctrl.token.cluster.name && _.isEmpty($ctrl.allowedGroups)"
             class="md-body-2"
             md-colors="{background: 'accent-50'}"
             layout-padding>

--- a/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-list.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-list.component.js
@@ -85,9 +85,9 @@ function KubernetesUserTokensListController($state, roleCheckerService, hubApiSe
       });
   }
 
-  function escalatePrivilege(tokenId, targetEvent) {
-    kubernetesTokenEscalatePrivilegePopupService.open(
-      tokenId,
+  function escalatePrivilege(token, targetEvent) {
+    return kubernetesTokenEscalatePrivilegePopupService.open(
+      token,
       targetEvent
     ).then(filterKubernetesTokensByUser);
   }

--- a/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-list.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-user-tokens-list.html
@@ -140,9 +140,9 @@
           View and edit
         </md-button>
         <md-button
-          ng-if="$ctrl.user.is_active && $ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetes_tokens_escalate_privilege)"
+          ng-if="$ctrl.user.is_active && $ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetesTokensEscalatePrivilege)"
           aria-label="Escalate privilege for this particular token. Opens up a popup where you can choose details for the escalation."
-          ng-click="$ctrl.escalatePrivilege(t.id, $event)">
+          ng-click="$ctrl.escalatePrivilege(t, $event)">
           Escalate privilege
           <md-tooltip md-direction="bottom">
             Grant a short lived escalation of privilege for this token. Opens a popup where you can configure and apply this escalation.

--- a/platform-hub-web/src/app/projects/projects-detail.component.js
+++ b/platform-hub-web/src/app/projects/projects-detail.component.js
@@ -6,7 +6,7 @@ export const ProjectsDetailComponent = {
   controller: ProjectsDetailController
 };
 
-function ProjectsDetailController($rootScope, $q, $mdDialog, $state, roleCheckerService, hubApiService, FeatureFlags, featureFlagKeys, Me, Projects, logger, _) {
+function ProjectsDetailController($rootScope, $q, $mdDialog, $state, roleCheckerService, hubApiService, kubernetesTokenEscalatePrivilegePopupService, FeatureFlags, featureFlagKeys, Me, Projects, logger, _) {
   'ngInject';
 
   const ctrl = this;
@@ -46,6 +46,7 @@ function ProjectsDetailController($rootScope, $q, $mdDialog, $state, roleChecker
   ctrl.loadServices = loadServices;
   ctrl.shouldShowCreateServiceButton = shouldShowCreateServiceButton;
   ctrl.loadKubernetesUserTokens = loadKubernetesUserTokens;
+  ctrl.escalatePrivilegeForKubernetesUserToken = escalatePrivilegeForKubernetesUserToken;
   ctrl.deleteKubernetesUserToken = deleteKubernetesUserToken;
 
   init();
@@ -373,6 +374,13 @@ function ProjectsDetailController($rootScope, $q, $mdDialog, $state, roleChecker
       .finally(() => {
         ctrl.processingKubernetesUserTokens = false;
       });
+  }
+
+  function escalatePrivilegeForKubernetesUserToken(token, targetEvent) {
+    return kubernetesTokenEscalatePrivilegePopupService.open(
+      token,
+      targetEvent
+    ).then(loadKubernetesUserTokens);
   }
 
   function deleteKubernetesUserToken(id, targetEvent) {

--- a/platform-hub-web/src/app/projects/projects-detail.html
+++ b/platform-hub-web/src/app/projects/projects-detail.html
@@ -327,6 +327,15 @@
                   View and edit
                 </md-button>
                 <md-button
+                  ng-if="t.user.is_active && $ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetesTokensEscalatePrivilege)"
+                  aria-label="Escalate privilege for this particular token. Opens up a popup where you can choose details for the escalation."
+                  ng-click="$ctrl.escalatePrivilegeForKubernetesUserToken(t, $event)">
+                  Escalate privilege
+                  <md-tooltip md-direction="bottom">
+                    Grant a short lived escalation of privilege for this token. Opens a popup where you can configure and apply this escalation.
+                  </md-tooltip>
+                </md-button>
+                <md-button
                   ng-click="$ctrl.deleteKubernetesUserToken(t.id, $event)"
                   aria-label="Remove kubernetes user token">
                   Delete

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -126,7 +126,6 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.getKubernetesTokensChangeset = getKubernetesTokensChangeset;
   service.syncKubernetesTokens = syncKubernetesTokens;
   service.revokeKubernetesToken = revokeKubernetesToken;
-  service.getPrivilegedGroupsForKubernetesTokens = buildSimpleFetcher('kubernetes/groups/privileged', 'kubernetes privileged groups');
   service.escalatePrivilegeForKubernetesTokens = escalatePrivilegeForKubernetesTokens;
 
   service.getFeatureFlags = buildSimpleFetcher('feature_flags', 'feature flags');

--- a/platform-hub-web/src/app/shared/model/kubernetes-groups.js
+++ b/platform-hub-web/src/app/shared/model/kubernetes-groups.js
@@ -60,12 +60,11 @@ export const KubernetesGroups = function ($window, hubApiService, apiBackoffTime
 
   function filterGroupsForCluster(groups, clusterName) {
     return _.filter(groups, g => {
-      return !g.is_privileged &&
-        (
-          !g.restricted_to_clusters ||
-          _.isEmpty(g.restricted_to_clusters) ||
-          g.restricted_to_clusters.includes(clusterName)
-        );
+      return (
+        !g.restricted_to_clusters ||
+        _.isEmpty(g.restricted_to_clusters) ||
+        g.restricted_to_clusters.includes(clusterName)
+      );
     });
   }
 };

--- a/platform-hub-web/src/app/shared/model/kubernetes-tokens.js
+++ b/platform-hub-web/src/app/shared/model/kubernetes-tokens.js
@@ -15,6 +15,7 @@ export const KubernetesTokens = function (hubApiService) {
   model.updateRobotToken = hubApiService.updateKubernetesRobotToken;
 
   model.revokeToken = revokeToken;
+  model.escalatePrivilege = hubApiService.escalatePrivilegeForKubernetesTokens;
 
   return model;
 


### PR DESCRIPTION
Given that tokens are now scoped to projects only (and only using groups that are allowed within that project), this commit now scopes the escalation of privileges to just the privileged groups for that project on that token.

This also adds the escalate privilege button for user tokens within projects (for project admins only).

Important caveat: when a token has escalated privileges, you can't currently edit that token until the privilege has expired. This is due to the privileged group being in the `groups` field, and the form/API not allowing this.