### PR TITLE
Backend: handle Kube RBAC group rename

### DIFF
--- a/platform-hub-api/spec/models/kubernetes_group_spec.rb
+++ b/platform-hub-api/spec/models/kubernetes_group_spec.rb
@@ -20,4 +20,35 @@ RSpec.describe KubernetesGroup, type: :model do
     it { is_expected.not_to allow_value(':foo').for(:name) }
   end
 
+  describe 'after_update :handle_name_rename' do
+    let!(:project) { create :project }
+    let!(:group) { create :kubernetes_group, :for_user, allocate_to: project }
+    let!(:other_group) { create :kubernetes_group, :for_user, allocate_to: project }
+
+    let(:assigned_groups) do
+      [
+        group.name,
+        other_group.name
+      ]
+    end
+
+    let!(:token) { create :user_kubernetes_token, project: project, groups: assigned_groups }
+
+    context 'when name has not chaned' do
+      it 'should not amend the token\'s groups' do
+        group.update! description: 'new description'
+        expect(token.reload.groups).to eq assigned_groups
+      end
+    end
+
+    context 'when name has changed' do
+      let(:updated_name) { 'updated-group-name' }
+
+      it 'should amend the token\'s groups' do
+        group.update! name: updated_name
+        expect(token.reload.groups).to eq [updated_name, other_group.name]
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This atomically updates all tokens that have the updated group