### PR TITLE
Backend: handle Kube RBAC group deletions

### DIFF
--- a/platform-hub-api/app/models/kubernetes_group.rb
+++ b/platform-hub-api/app/models/kubernetes_group.rb
@@ -13,6 +13,7 @@ class KubernetesGroup < ApplicationRecord
   allocatable
 
   after_update :handle_name_rename
+  after_destroy :handle_destroy
 
   validates :name,
     presence: true,
@@ -60,6 +61,19 @@ class KubernetesGroup < ApplicationRecord
       SQL
       connection.execute(sql)
     end
+  end
+
+  def handle_destroy
+    connection = ActiveRecord::Base.connection
+    sql = <<-SQL
+      UPDATE kubernetes_tokens
+      SET groups =
+        array_remove(
+          groups,
+          #{connection.quote(self.name)}
+        )
+    SQL
+    connection.execute(sql)
   end
 
 end

--- a/platform-hub-api/spec/models/kubernetes_group_spec.rb
+++ b/platform-hub-api/spec/models/kubernetes_group_spec.rb
@@ -51,4 +51,25 @@ RSpec.describe KubernetesGroup, type: :model do
     end
   end
 
+  describe 'after_destroy :handle_destroy' do
+    let!(:project) { create :project }
+    let!(:group) { create :kubernetes_group, :for_user, allocate_to: project }
+
+    let!(:other_group) { create :kubernetes_group, :for_user, allocate_to: project }
+
+    let(:assigned_groups) do
+      [
+        group.name,
+        other_group.name
+      ]
+    end
+
+    let!(:token) { create :user_kubernetes_token, project: project, groups: assigned_groups }
+
+    it 'should remove the group from token\'s groups' do
+      group.destroy!
+      expect(token.reload.groups).to eq [other_group.name]
+    end
+  end
+
 end


### PR DESCRIPTION
This atomically updates all tokens that have the removed group