### PR TITLE
API: order the project memberships by user name

### DIFF
--- a/platform-hub-api/app/controllers/projects_controller.rb
+++ b/platform-hub-api/app/controllers/projects_controller.rb
@@ -118,7 +118,8 @@ class ProjectsController < ApiJsonController
 
   # GET /projects/:id/memberships
   def memberships
-    render json: @project.memberships, each_serializer: ProjectMembershipSerializer
+    memberships = @project.memberships_ordered_by_users_name
+    render json: memberships, each_serializer: ProjectMembershipSerializer
   end
 
   # PUT /projects/:id/memberships/:user_id

--- a/platform-hub-api/app/models/project.rb
+++ b/platform-hub-api/app/models/project.rb
@@ -47,4 +47,10 @@ class Project < ApplicationRecord
     -> { where kind: 'user' },
     class_name: 'KubernetesToken'
 
+  def memberships_ordered_by_users_name
+    memberships
+      .includes(:user)  # Eager load users for performance
+      .joins(:user).order("users.name")  # Order by user name
+  end
+
 end

--- a/platform-hub-api/spec/controllers/projects_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/projects_controller_spec.rb
@@ -313,24 +313,27 @@ RSpec.describe ProjectsController, type: :controller do
         # Important: we shouldn't be able to see the user's identities here
         # (since we're not a hub admin)
 
-        @memberships.map do |m|
-          user = m.user
+        @memberships
+          .sort { |a,b|
+            a.user.name <=> b.user.name
+          }.map do |m|
+            user = m.user
 
-          {
-            'user' => {
-              'id' => user.id,
-              'name' => user.name,
-              'email' => user.email,
-              'role' =>  user.role,
-              'last_seen_at' => now_json_value,
-              'enabled_identities' => [],
-              'is_active' => true,
-              'is_managerial' => true,
-              'is_technical' => true
-            },
-            'role' => nil
-          }
-        end
+            {
+              'user' => {
+                'id' => user.id,
+                'name' => user.name,
+                'email' => user.email,
+                'role' =>  user.role,
+                'last_seen_at' => now_json_value,
+                'enabled_identities' => [],
+                'is_active' => true,
+                'is_managerial' => true,
+                'is_technical' => true
+              },
+              'role' => nil
+            }
+          end
       end
 
       it 'should return a list of memberships' do


### PR DESCRIPTION
Note: as part of this, we eager load the `membership.user` field, prevent N+1 queries.