### PR TITLE
Kubernetes Cluster additional properties for generating kubecfg

### DIFF
--- a/platform-hub-api/app/controllers/kubernetes/clusters_controller.rb
+++ b/platform-hub-api/app/controllers/kubernetes/clusters_controller.rb
@@ -93,7 +93,9 @@ class Kubernetes::ClustersController < ApiJsonController
       :s3_bucket_name,
       :s3_access_key_id,
       :s3_secret_access_key,
-      :s3_object_key
+      :s3_object_key,
+      :api_url,
+      :ca_cert_encoded
     )
   end
 

--- a/platform-hub-api/app/models/kubernetes_cluster.rb
+++ b/platform-hub-api/app/models/kubernetes_cluster.rb
@@ -20,7 +20,8 @@ class KubernetesCluster < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   validates :description, :s3_region, :s3_bucket_name, :s3_object_key,
-            :s3_access_key_id, :s3_secret_access_key, presence: true
+            :s3_access_key_id, :s3_secret_access_key,
+            :api_url, :ca_cert_encoded, presence: true
 
   has_many :tokens, class_name: KubernetesToken, foreign_key: :cluster_id
 

--- a/platform-hub-api/config/initializers/filter_parameter_logging.rb
+++ b/platform-hub-api/config/initializers/filter_parameter_logging.rb
@@ -16,5 +16,6 @@ Rails.application.config.filter_parameters += [
   :s3_bucket_name,
   :s3_access_key_id,
   :s3_secret_access_key,
-  :object_key
+  :object_key,
+  :ca_cert_encoded
 ]

--- a/platform-hub-api/db/migrate/20171121125850_add_kubecfg_extra_fields_to_kubernetes_clusters.rb
+++ b/platform-hub-api/db/migrate/20171121125850_add_kubecfg_extra_fields_to_kubernetes_clusters.rb
@@ -1,0 +1,6 @@
+class AddKubecfgExtraFieldsToKubernetesClusters < ActiveRecord::Migration[5.0]
+  def change
+    add_column :kubernetes_clusters, :api_url, :string, null: false
+    add_column :kubernetes_clusters, :ca_cert_encoded, :string, null: false
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 9.6.1
--- Dumped by pg_dump version 9.6.2
+-- Dumped by pg_dump version 10.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -265,7 +265,9 @@ CREATE TABLE kubernetes_clusters (
     s3_secret_access_key character varying NOT NULL,
     s3_object_key character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    api_url character varying NOT NULL,
+    ca_cert_encoded character varying NOT NULL
 );
 
 
@@ -1045,6 +1047,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171010111440'),
 ('20171012110416'),
 ('20171031164247'),
-('20171114100517');
+('20171114100517'),
+('20171121125850');
 
 

--- a/platform-hub-api/spec/controllers/kubernetes/clusters_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/clusters_controller_spec.rb
@@ -108,7 +108,9 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
           s3_bucket_name: 's3_bucket_name',
           s3_access_key_id: 's3_access_key_id',
           s3_secret_access_key: 's3_secret_access_key',
-          s3_object_key: 's3_object_key'
+          s3_object_key: 's3_object_key',
+          api_url: 'https://api.production.example.com:8443',
+          ca_cert_encoded: 'ZXhhbXBsZSBzdHJpbmcK'
         }
       }
     end

--- a/platform-hub-api/spec/factories/kubernetes_clusters.rb
+++ b/platform-hub-api/spec/factories/kubernetes_clusters.rb
@@ -11,6 +11,8 @@ FactoryGirl.define do
     s3_access_key_id { ENCRYPTOR.encrypt('s3_access_key_id') }
     s3_secret_access_key { ENCRYPTOR.encrypt('s3_secret_access_key') }
     s3_object_key { 's3/object/key.csv' }
+    api_url { 'https://cluster-api.environment.example.com:8443' }
+    ca_cert_encoded { 'CACertBase64EncodedString' }
 
     transient do
       allocate_to nil

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
@@ -43,7 +43,7 @@
           </md-input-container>
 
           <fieldset>
-            <legend>S3 bucket config for tokens sync</legend>
+            <legend>Additional configuration for S3 token sync and kubeconfig generation</legend>
 
             <p
               "md-body-1"
@@ -54,6 +54,30 @@
             </p>
 
             <br />
+
+            <md-input-container class="md-block">
+              <label for="api_url">Cluster API URL:</label>
+              <input
+                name="api_url"
+                ng-model="$ctrl.cluster.api_url"
+                placeholder="e.g.: https://cluster-api.environment.example.com:8443"
+                required>
+              <div ng-messages="$ctrl.clusterForm.api_url.$error">
+                <div ng-message="required">This is required.</div>
+              </div>
+            </md-input-container>
+
+            <md-input-container class="md-block">
+              <label for="ca_cert_encoded">CA Cert Content (base64 encoded):</label>
+              <input
+                name="ca_cert_encoded"
+                ng-model="$ctrl.cluster.ca_cert_encoded"
+                placeholder="CACertBase64EncodedString"
+                required>
+              <div ng-messages="$ctrl.clusterForm.ca_cert_encoded.$error">
+                <div ng-message="required">This is required.</div>
+              </div>
+            </md-input-container>
 
             <md-input-container class="md-block">
               <label for="s3_region">AWS region:</label>
@@ -101,7 +125,7 @@
             </md-input-container>
 
             <md-input-container class="md-block">
-              <label for="s3_object_key">Object key:</label>
+              <label for="s3_object_key">Tokens file object key:</label>
               <input
                 name="s3_object_key"
                 ng-model="$ctrl.cluster.s3_object_key"


### PR DESCRIPTION
Adds the following additional fields to Kubernetes Cluster:
- `api_url`: String value containing the full API url for the Kubernetes Cluster, which a user would specify within their kubeconfig (e.g. `https://api.production.example.com:8443`)
- `ca_cert_encoded`: String value of the CA Certificate, base64 encoded

These values can later be used in generating an example kubeconfig for a token assigned to a user, easing the user journey in getting their local environment correctly configured.