### PR TITLE
Handle deletions of projects, services, allocations, groups, clusters and tokens

### DIFF
--- a/platform-hub-api/app/models/allocation.rb
+++ b/platform-hub-api/app/models/allocation.rb
@@ -4,6 +4,8 @@ class Allocation < ApplicationRecord
 
   audited associated_field: :allocation_receivable
 
+  after_destroy :handle_destroy
+
   belongs_to :allocatable, polymorphic: true
   validates :allocatable_type, presence: true
   validates :allocatable_id, presence: true
@@ -18,6 +20,51 @@ class Allocation < ApplicationRecord
   scope :by_allocation_receivable, -> (ar) { where(allocation_receivable: ar) }
 
   private
+
+  def handle_destroy
+    # Note: we assume we are running in a db transaction when this is called
+    case self.allocatable_type
+    when KubernetesCluster.name
+      handle_destroy_for_kubernetes_cluster_allocatable
+    when KubernetesGroup.name
+      handle_destroy_for_kubernetes_group_allocatable
+    else
+      Rails.logger.info "Allocation destroyed but no further deletion handling carried out, for allocatable_type: #{self.allocatable_type}"
+    end
+  end
+
+  def handle_destroy_for_kubernetes_cluster_allocatable
+    cluster = self.allocatable
+    project = self.allocation_receivable
+    project.kubernetes_user_tokens.by_cluster(cluster).each(&:destroy)
+    project.services.each do |service|
+      service.kubernetes_robot_tokens.by_cluster(cluster).each(&:destroy)
+    end
+  end
+
+  def handle_destroy_for_kubernetes_group_allocatable
+    group = self.allocatable
+    case self.allocation_receivable_type
+    when Project.name
+      project = self.allocation_receivable
+
+      # First handle robot tokens for all services within the project
+      project.services.pluck(:id).each do |service_id|
+        KubernetesToken.update_all_group_removal group.name, kind: 'robot', service_id: service_id
+      end
+
+      # Then handle user tokens for the project
+      KubernetesToken.update_all_group_removal group.name, kind: 'user', project_id: project.id
+    when Service.name
+      service = self.allocation_receivable
+
+      # First handle robot tokens for the service
+      KubernetesToken.update_all_group_removal group.name, kind: 'robot', service_id: service.id
+
+      # Then handle user tokens for the project (in case they use a service level group)
+      KubernetesToken.update_all_group_removal group.name, kind: 'user', project_id: service.project.id
+    end
+  end
 
   def ensure_uniqueness
     if Allocation.where(

--- a/platform-hub-api/app/models/concerns/allocatable.rb
+++ b/platform-hub-api/app/models/concerns/allocatable.rb
@@ -6,7 +6,7 @@ module Allocatable
     def allocatable
       has_many :allocations,
         as: :allocatable,
-        dependent: :delete_all
+        dependent: :destroy
     end
 
   end

--- a/platform-hub-api/app/models/concerns/allocation_receivable.rb
+++ b/platform-hub-api/app/models/concerns/allocation_receivable.rb
@@ -6,7 +6,7 @@ module AllocationReceivable
     def allocation_receivable
       has_many :allocations,
         as: :allocation_receivable,
-        dependent: :delete_all
+        dependent: :destroy
     end
 
   end

--- a/platform-hub-api/app/models/kubernetes_cluster.rb
+++ b/platform-hub-api/app/models/kubernetes_cluster.rb
@@ -2,14 +2,18 @@ class KubernetesCluster < ApplicationRecord
 
   NAME_REGEX = /\A[a-zA-Z][\w-]*\z/
 
-  include FriendlyId
   include Audited
-
-  before_save :downcase_name
+  include FriendlyId
+  include Allocatable
 
   audited descriptor_field: :name
 
   friendly_id :name
+
+  allocatable
+
+  before_save :downcase_name
+  after_destroy :handle_destroy
 
   validates :name,
     format: {
@@ -22,7 +26,10 @@ class KubernetesCluster < ApplicationRecord
   validates :description, :s3_region, :s3_bucket_name, :s3_object_key,
             :s3_access_key_id, :s3_secret_access_key, presence: true
 
-  has_many :tokens, class_name: KubernetesToken, foreign_key: :cluster_id
+  has_many :tokens,
+    class_name: KubernetesToken,
+    foreign_key: :cluster_id,
+    dependent: :destroy
 
   def s3_access_key_id=(val)
     self['s3_access_key_id'] = ENCRYPTOR.encrypt(val)
@@ -48,6 +55,12 @@ class KubernetesCluster < ApplicationRecord
 
   def downcase_name
     self.name.downcase!
+  end
+
+  private
+
+  def handle_destroy
+    KubernetesGroup.update_all_cluster_removal self
   end
 
 end

--- a/platform-hub-api/app/models/kubernetes_group.rb
+++ b/platform-hub-api/app/models/kubernetes_group.rb
@@ -49,31 +49,12 @@ class KubernetesGroup < ApplicationRecord
 
   def handle_name_rename
     if self.name_changed?
-      connection = ActiveRecord::Base.connection
-      sql = <<-SQL
-        UPDATE kubernetes_tokens
-        SET groups =
-          array_replace(
-            groups,
-            #{connection.quote(self.name_was)},
-            #{connection.quote(self.name)}
-          )
-      SQL
-      connection.execute(sql)
+      KubernetesToken.update_all_group_rename self.name_was, self.name
     end
   end
 
   def handle_destroy
-    connection = ActiveRecord::Base.connection
-    sql = <<-SQL
-      UPDATE kubernetes_tokens
-      SET groups =
-        array_remove(
-          groups,
-          #{connection.quote(self.name)}
-        )
-    SQL
-    connection.execute(sql)
+    KubernetesToken.update_all_group_removal self.name
   end
 
 end

--- a/platform-hub-api/app/models/kubernetes_token.rb
+++ b/platform-hub-api/app/models/kubernetes_token.rb
@@ -49,6 +49,31 @@ class KubernetesToken < ApplicationRecord
   validate :allowed_clusters_only
   validate :allowed_groups_only
 
+  def self.update_all_group_rename old_name, new_name
+    sql = <<-SQL
+      UPDATE kubernetes_tokens
+      SET groups =
+        array_replace(
+          groups,
+          #{connection.quote(old_name)},
+          #{connection.quote(new_name)}
+        )
+    SQL
+    connection.execute(sql)
+  end
+
+  def self.update_all_group_removal name
+    sql = <<-SQL
+      UPDATE kubernetes_tokens
+      SET groups =
+        array_remove(
+          groups,
+          #{connection.quote(name)}
+        )
+    SQL
+    connection.execute(sql)
+  end
+
   def token=(val)
     self['token'] = ENCRYPTOR.encrypt(val)
   end

--- a/platform-hub-api/app/models/project.rb
+++ b/platform-hub-api/app/models/project.rb
@@ -24,14 +24,14 @@ class Project < ApplicationRecord
 
   has_many :memberships,
     class_name: 'ProjectMembership',
-    dependent: :delete_all
+    dependent: :destroy
 
   has_many :members,
     through: :memberships,
     source: :user
 
   has_many :services,
-    dependent: :delete_all
+    dependent: :destroy
 
   has_many :kubernetes_clusters,
     through: :allocations,
@@ -45,7 +45,8 @@ class Project < ApplicationRecord
 
   has_many :kubernetes_user_tokens,
     -> { where kind: 'user' },
-    class_name: 'KubernetesToken'
+    class_name: 'KubernetesToken',
+    dependent: :destroy
 
   def memberships_ordered_by_users_name
     memberships

--- a/platform-hub-api/app/models/service.rb
+++ b/platform-hub-api/app/models/service.rb
@@ -24,6 +24,7 @@ class Service < ApplicationRecord
   has_many :kubernetes_robot_tokens,
     -> { where kind: 'robot' },
     as: :tokenable,
-    class_name: KubernetesToken
+    class_name: KubernetesToken,
+    dependent: :destroy
 
 end

--- a/platform-hub-api/app/models/user.rb
+++ b/platform-hub-api/app/models/user.rb
@@ -20,11 +20,11 @@ class User < ApplicationRecord
     uniqueness: { case_sensitive: false }
 
   has_many :identities,
-    dependent: :delete_all
+    dependent: :destroy
 
   has_many :memberships,
     class_name: 'ProjectMembership',
-    dependent: :delete_all
+    dependent: :destroy
 
   has_many :projects, through: :memberships
 

--- a/platform-hub-api/spec/factories/kubernetes_tokens.rb
+++ b/platform-hub-api/spec/factories/kubernetes_tokens.rb
@@ -43,7 +43,7 @@ FactoryGirl.define do
 
       trait :user_is_not_member_of_project do
         after(:build) do |token, _|
-          ProjectMembership.where(project_id: token.project_id, user_id: token.tokenable.user_id).delete_all
+          ProjectMembership.where(project_id: token.project_id, user_id: token.tokenable.user_id).map(&:destroy)
         end
       end
     end

--- a/platform-hub-api/spec/factories/kubernetes_tokens.rb
+++ b/platform-hub-api/spec/factories/kubernetes_tokens.rb
@@ -12,10 +12,10 @@ FactoryGirl.define do
       name { "user_#{SecureRandom.uuid}@example.com" }
 
       transient do
-        groups_count 2
+        groups_count 0
       end
 
-      after(:build) do |token, _|
+      after(:build) do |token, evaluator|
         if token.cluster.blank? && token.project.present?
           token.cluster = create :kubernetes_cluster, allocate_to: token.project
         end
@@ -24,10 +24,14 @@ FactoryGirl.define do
           create :project_membership, project: token.project, user: token.tokenable.user
         end
 
-        if token.groups.nil? && !evaluator.groups_count.zero?
-          token.groups = evaluator.groups_count.map do |i|
-            create :kubernetes_group, :not_privileged, :for_user, allocate_to: token.project
-          end
+        if token.groups.blank? && !evaluator.groups_count.zero?
+          token.groups = create_list(
+            :kubernetes_group,
+            evaluator.groups_count,
+            :not_privileged,
+            :for_user,
+            allocate_to: token.project
+          ).map(&:name)
         end
       end
 
@@ -53,7 +57,7 @@ FactoryGirl.define do
       description { "Mr Robot" }
 
       transient do
-        groups_count 2
+        groups_count 0
       end
 
       after(:build) do |token, evaluator|
@@ -61,10 +65,14 @@ FactoryGirl.define do
           token.cluster = create :kubernetes_cluster, allocate_to: token.tokenable.project
         end
 
-        if token.groups.nil? && !evaluator.groups_count.zero?
-          token.groups = evaluator.groups_count.map do |i|
-            create :kubernetes_group, :not_privileged, :for_robot, allocate_to: token.tokenable
-          end
+        if token.groups.blank? && !evaluator.groups_count.zero?
+          token.groups = create_list(
+            :kubernetes_group,
+            evaluator.groups_count,
+            :not_privileged,
+            :for_robot,
+            allocate_to: token.project
+          ).map(&:name)
         end
       end
     end

--- a/platform-hub-api/spec/integration/tokens_deletion_integration_spec.rb
+++ b/platform-hub-api/spec/integration/tokens_deletion_integration_spec.rb
@@ -1,0 +1,292 @@
+require 'rails_helper'
+
+RSpec.describe 'Tokens deletion integration' do
+
+  # All possible scenarios that lead to Kubernetes Tokens needing to be deleted
+
+  let!(:user) { create :user }
+  let!(:identity) { create :kubernetes_identity, user: user }
+  let!(:project) { create :project }
+  let!(:project_membership) { create :project_membership, user: user, project: project }
+  let!(:service) { create :service, project: project }
+  let!(:cluster) { create :kubernetes_cluster }
+  let!(:cluster_to_project_allocation) do
+    create :allocation, allocatable: cluster, allocation_receivable: project
+  end
+  let!(:user_group) { create :kubernetes_group, :not_privileged, :for_user }
+  let!(:robot_group) { create :kubernetes_group, :not_privileged, :for_robot }
+  let!(:user_group_to_project_allocation) do
+    create :allocation, allocatable: user_group, allocation_receivable: project
+  end
+  let!(:robot_group_to_service_allocation) do
+    create :allocation, allocatable: robot_group, allocation_receivable: service
+  end
+  let!(:user_token_groups) { [ user_group.name ] }
+  let!(:user_token) do
+    create :user_kubernetes_token, tokenable: identity, project: project, cluster: cluster, groups: user_token_groups
+  end
+  let!(:robot_token_groups) { [ robot_group.name ] }
+  let!(:robot_token) do
+    create :robot_kubernetes_token, tokenable: service, cluster: cluster, groups: robot_token_groups
+  end
+
+  # Other tokens associated with the project and service, but different everything else
+  let!(:other_cluster) { create :kubernetes_cluster }
+  let!(:other_cluster_to_project_allocation) do
+    create :allocation, allocatable: other_cluster, allocation_receivable: project
+  end
+  let!(:other_user_group) { create :kubernetes_group, :not_privileged, :for_user }
+  let!(:other_robot_group) { create :kubernetes_group, :not_privileged, :for_robot }
+  let!(:other_user_group_to_project_allocation) do
+    create :allocation, allocatable: other_user_group, allocation_receivable: project
+  end
+  let!(:other_robot_group_to_service_allocation) do
+    create :allocation, allocatable: other_robot_group, allocation_receivable: service
+  end
+  let!(:other_user_token_groups) { [ other_user_group.name ] }
+  let!(:other_user_token) do
+    create :user_kubernetes_token, project: project, cluster: other_cluster, groups: other_user_token_groups
+  end
+  let!(:other_robot_token_groups) { [ other_robot_group.name ] }
+  let!(:other_robot_token) do
+    create :robot_kubernetes_token, tokenable: service, cluster: other_cluster, groups: other_robot_token_groups
+  end
+
+  # Other tokens that belong to different projects/services
+  let!(:other_other_user_token) { create :user_kubernetes_token }
+  let!(:other_other_robot_token) { create :robot_kubernetes_token }
+
+  def exists model, id
+    expect(model.exists?(id: id)).to be true
+  end
+
+  def deleted model, id
+    expect(model.exists?(id: id)).to be false
+  end
+
+  describe 'on project deletion' do
+    before { project.destroy }
+
+    it 'should delete the associated token(s) only' do
+      deleted KubernetesToken, user_token.id
+      deleted KubernetesToken, robot_token.id
+
+      deleted KubernetesToken, other_user_token.id
+      deleted KubernetesToken, other_robot_token.id
+
+      exists KubernetesToken, other_other_user_token.id
+      exists KubernetesToken, other_other_robot_token.id
+    end
+  end
+
+  describe 'on user\'s project membership deletion' do
+    before { project_membership.destroy }
+
+    it 'should delete the user\'s tokens for that project only' do
+      deleted KubernetesToken, user_token.id
+      exists KubernetesToken, robot_token.id
+
+      exists KubernetesToken, other_user_token.id
+      exists KubernetesToken, other_robot_token.id
+
+      exists KubernetesToken, other_other_user_token.id
+      exists KubernetesToken, other_other_robot_token.id
+    end
+  end
+
+  describe 'on service deletion' do
+    before { service.destroy }
+
+    it 'should delete the associated token(s) only' do
+      exists KubernetesToken, user_token.id
+      deleted KubernetesToken, robot_token.id
+
+      exists KubernetesToken, other_user_token.id
+      deleted KubernetesToken, other_robot_token.id
+
+      exists KubernetesToken, other_other_user_token.id
+      exists KubernetesToken, other_other_robot_token.id
+    end
+  end
+
+  describe 'on cluster deletion' do
+    context 'when no groups have restricted clusters' do
+      before { cluster.destroy }
+
+      it 'should delete the associated allocation(s) and token(s) only' do
+        deleted Allocation, cluster_to_project_allocation.id
+        deleted KubernetesToken, user_token.id
+        deleted KubernetesToken, robot_token.id
+
+        exists Allocation, other_cluster_to_project_allocation.id
+        exists KubernetesToken, other_user_token.id
+        exists KubernetesToken, other_robot_token.id
+
+        exists KubernetesToken, other_other_user_token.id
+        exists KubernetesToken, other_other_robot_token.id
+      end
+    end
+
+    context 'when groups have the cluster in their \'restricted_to_clusters\' list' do
+      let!(:c_group_1) do
+        create :kubernetes_group, :not_privileged, :for_user, restricted_to_clusters: [ cluster.name ]
+      end
+      let!(:c_group_1_to_project_allocation) do
+        create :allocation, allocatable: c_group_1, allocation_receivable: project
+      end
+      let!(:c_group_2) do
+        create :kubernetes_group, :not_privileged, :for_user, restricted_to_clusters: [ cluster.name, other_cluster.name ]
+      end
+      let!(:c_group_2_to_project_allocation) do
+        create :allocation, allocatable: c_group_2, allocation_receivable: project
+      end
+      let!(:c_token_1) do
+        create :user_kubernetes_token, project: project, cluster: cluster, groups: [ c_group_1.name ]
+      end
+      let!(:c_token_2) do
+        create :user_kubernetes_token, project: project, cluster: other_cluster, groups: [ other_user_group.name, c_group_2.name ]
+      end
+
+      before { cluster.destroy }
+
+      it 'should remove the cluster from any groups, deleting the group if needed' do
+        deleted Allocation, cluster_to_project_allocation.id
+
+        deleted KubernetesGroup, c_group_1.id
+        deleted Allocation, c_group_1_to_project_allocation.id
+        exists KubernetesGroup, c_group_2.id
+        expect(c_group_2.reload.restricted_to_clusters).to eq [ other_cluster.name ]
+        exists Allocation, c_group_2_to_project_allocation.id
+
+        deleted KubernetesToken, c_token_1.id  # Because the associated cluster was deleted
+
+        c_token_2_groups = c_token_2.groups
+        expect(c_token_2.reload.groups).to eq c_token_2_groups
+      end
+    end
+  end
+
+  describe 'on cluster-to-project allocation deletion' do
+    let!(:c_project) { create(:project) }
+    let!(:c_allocation) do
+      create :allocation, allocatable: cluster, allocation_receivable: c_project
+    end
+    let!(:c_token) do
+      create :user_kubernetes_token, project: c_project, cluster: cluster
+    end
+
+    before { cluster_to_project_allocation.destroy }
+
+    it 'should delete all tokens within that project that are associated with that cluster' do
+      deleted KubernetesToken, user_token.id
+      deleted KubernetesToken, robot_token.id
+
+      exists KubernetesToken, c_token.id
+
+      exists KubernetesToken, other_user_token.id
+      exists KubernetesToken, other_robot_token.id
+
+      exists KubernetesToken, other_other_user_token.id
+      exists KubernetesToken, other_other_robot_token.id
+    end
+  end
+
+  describe 'on group deletion' do
+    before { user_group.destroy }
+
+    it 'should remove that group only from tokens that have it' do
+      expect(user_token.reload.groups).to be_empty
+      expect(robot_token.reload.groups).to eq robot_token_groups
+
+      expect(other_user_token.reload.groups).to eq other_user_token_groups
+      expect(other_robot_token.reload.groups).to eq other_robot_token_groups
+    end
+  end
+
+  describe 'on user-group-to-project allocation deletion' do
+    before { user_group_to_project_allocation.destroy }
+
+    it 'should remove that group only from tokens (within the project) that have it' do
+      expect(user_token.reload.groups).to be_empty
+      expect(robot_token.reload.groups).to eq robot_token_groups
+
+      expect(other_user_token.reload.groups).to eq other_user_token_groups
+      expect(other_robot_token.reload.groups).to eq other_robot_token_groups
+    end
+  end
+
+  describe 'on user-group-to-service allocation deletion' do
+    let!(:s_user_group) { create :kubernetes_group, :not_privileged, :for_user }
+    let!(:s_user_group_to_service_allocation) do
+      create :allocation, allocatable: s_user_group, allocation_receivable: service
+    end
+    let!(:s_user_token) do
+      create :user_kubernetes_token, project: project, cluster: cluster, groups: [s_user_group.name]
+    end
+
+    before { s_user_group_to_service_allocation.destroy }
+
+    it 'should remove that group only from robot tokens (within the project) that have it' do
+      expect(s_user_token.reload.groups).to be_empty
+
+      expect(user_token.reload.groups).to eq user_token_groups
+      expect(robot_token.reload.groups).to eq robot_token_groups
+
+      expect(other_user_token.reload.groups).to eq other_user_token_groups
+      expect(other_robot_token.reload.groups).to eq other_robot_token_groups
+    end
+  end
+
+  describe 'on robot-group-to-project allocation deletion' do
+    let!(:p_robot_group) { create :kubernetes_group, :not_privileged, :for_robot }
+    let!(:p_robot_group_to_project_allocation) do
+      create :allocation, allocatable: p_robot_group, allocation_receivable: project
+    end
+    let!(:p_robot_token_1) do
+      create :robot_kubernetes_token, tokenable: service, cluster: cluster, groups: [p_robot_group.name]
+    end
+
+    let!(:other_service) { create :service, project: project }
+    let!(:p_robot_token_2) do
+      create :robot_kubernetes_token, tokenable: other_service, cluster: cluster, groups: [p_robot_group.name]
+    end
+
+    before { p_robot_group_to_project_allocation.destroy }
+
+    it 'should remove that group only from robot tokens (within the project) that have it' do
+      expect(p_robot_token_1.reload.groups).to be_empty
+      expect(p_robot_token_2.reload.groups).to be_empty
+
+      expect(user_token.reload.groups).to eq user_token_groups
+      expect(robot_token.reload.groups).to eq robot_token_groups
+
+      expect(other_user_token.reload.groups).to eq other_user_token_groups
+      expect(other_robot_token.reload.groups).to eq other_robot_token_groups
+    end
+  end
+
+  describe 'on robot-group-to-service allocation deletion' do
+    before { robot_group_to_service_allocation.destroy }
+
+    it 'should remove that group only from robot tokens (within the service) that have it' do
+      expect(user_token.reload.groups).to eq user_token_groups
+      expect(robot_token.reload.groups).to be_empty
+
+      expect(other_user_token.reload.groups).to eq other_user_token_groups
+      expect(other_robot_token.reload.groups).to eq other_robot_token_groups
+    end
+  end
+
+  describe 'on token deletion' do
+    before { user_token.destroy }
+
+    it 'none of the associated objects should be deleted' do
+      exists Project, project.id
+      exists Service, service.id
+      exists KubernetesCluster, cluster.id
+      exists KubernetesGroup, user_group.id
+      exists KubernetesGroup, robot_group.id
+    end
+  end
+
+end

--- a/platform-hub-api/spec/models/kubernetes_group_spec.rb
+++ b/platform-hub-api/spec/models/kubernetes_group_spec.rb
@@ -49,4 +49,39 @@ RSpec.describe KubernetesGroup, type: :model do
     end
   end
 
+  describe 'scopes' do
+
+    describe 'with_restricted_cluster' do
+      let!(:cluster) { create :kubernetes_cluster }
+
+      subject { KubernetesGroup.with_restricted_cluster(cluster) }
+
+      context 'when no restricted clusters are set' do
+        let!(:group) { create :kubernetes_group, restricted_to_clusters: [] }
+
+        it 'should not find any groups' do
+          expect(subject.count).to be 0
+        end
+      end
+
+      context 'when the cluster is set in the restricted list' do
+        let!(:group) { create :kubernetes_group, restricted_to_clusters: [ cluster.name ] }
+
+        it 'should find the group' do
+          expect(subject.entries).to eq [ group ]
+        end
+      end
+
+      context 'when a diffrent cluster is set in the restricted list' do
+        let!(:other_cluster) { create :kubernetes_cluster }
+        let!(:group) { create :kubernetes_group, restricted_to_clusters: [ other_cluster.name ] }
+
+        it 'should not find any groups' do
+          expect(subject.count).to be 0
+        end
+      end
+    end
+
+  end
+
 end

--- a/platform-hub-api/spec/models/kubernetes_group_spec.rb
+++ b/platform-hub-api/spec/models/kubernetes_group_spec.rb
@@ -21,23 +21,12 @@ RSpec.describe KubernetesGroup, type: :model do
   end
 
   describe 'after_update :handle_name_rename' do
-    let!(:project) { create :project }
-    let!(:group) { create :kubernetes_group, :for_user, allocate_to: project }
-    let!(:other_group) { create :kubernetes_group, :for_user, allocate_to: project }
+    let!(:group) { create :kubernetes_group, :for_user }
 
-    let(:assigned_groups) do
-      [
-        group.name,
-        other_group.name
-      ]
-    end
-
-    let!(:token) { create :user_kubernetes_token, project: project, groups: assigned_groups }
-
-    context 'when name has not chaned' do
+    context 'when name has not changed' do
       it 'should not amend the token\'s groups' do
+        expect(KubernetesToken).to receive(:update_all_group_rename).never
         group.update! description: 'new description'
-        expect(token.reload.groups).to eq assigned_groups
       end
     end
 
@@ -45,30 +34,18 @@ RSpec.describe KubernetesGroup, type: :model do
       let(:updated_name) { 'updated-group-name' }
 
       it 'should amend the token\'s groups' do
+        expect(KubernetesToken).to receive(:update_all_group_rename).with(group.name, updated_name).once
         group.update! name: updated_name
-        expect(token.reload.groups).to eq [updated_name, other_group.name]
       end
     end
   end
 
   describe 'after_destroy :handle_destroy' do
-    let!(:project) { create :project }
-    let!(:group) { create :kubernetes_group, :for_user, allocate_to: project }
-
-    let!(:other_group) { create :kubernetes_group, :for_user, allocate_to: project }
-
-    let(:assigned_groups) do
-      [
-        group.name,
-        other_group.name
-      ]
-    end
-
-    let!(:token) { create :user_kubernetes_token, project: project, groups: assigned_groups }
+    let!(:group) { create :kubernetes_group, :for_user }
 
     it 'should remove the group from token\'s groups' do
+      expect(KubernetesToken).to receive(:update_all_group_removal).with(group.name).once
       group.destroy!
-      expect(token.reload.groups).to eq [other_group.name]
     end
   end
 

--- a/platform-hub-api/spec/models/kubernetes_token_spec.rb
+++ b/platform-hub-api/spec/models/kubernetes_token_spec.rb
@@ -786,4 +786,40 @@ RSpec.describe KubernetesToken, type: :model do
 
   end
 
+  describe 'class methods' do
+
+    describe '.update_all_group_rename' do
+      let!(:token) { create :user_kubernetes_token, groups_count: 2 }
+
+      let!(:old_name) { token.groups.first }
+      let!(:new_name) { 'updated-group-name' }
+
+      let! :expected_groups do
+        [
+          new_name,
+          token.groups.second
+        ]
+      end
+
+      it 'should amend the token\'s groups' do
+        KubernetesToken.update_all_group_rename old_name, new_name
+        expect(token.reload.groups).to eq expected_groups
+      end
+    end
+
+    describe '.update_all_group_removal' do
+      let!(:token) { create :user_kubernetes_token, groups_count: 2 }
+
+      let!(:group_to_remove) { token.groups.first }
+
+      let!(:expected_groups) { [ token.groups.second ] }
+
+      it 'should remove the group from token\'s groups' do
+        KubernetesToken.update_all_group_removal group_to_remove
+        expect(token.reload.groups).to eq expected_groups
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
* [x] For deletion of projects
    * [x] Delete all services
        * [x] Make sure this cascades down to robot tokens too!
    * [x] Delete all user tokens for that project
    * [x] Delete all allocations (with clusters)
        * [x] Make sure this cascades down (see later)
* [x] For deletion of services
    * [x] Delete all robot tokens for that service
    * [x] Delete all allocations
        * [x] Make sure this cascades down (see later)
* [x] For deletion of allocations
    * [x] If allocatable_type == 'KubernetesCluster' -> delete all tokens for allocation_receivable project that are for that cluster
    * [x] If allocatable_type == 'KubernetesGroup` -> make sure to remove that group from all tokens that have it, for tokens that belong to either the allocation_receivable project (user tokens or robot tokens) or allocation_receivable service of (robot tokens only for service, or user token)
* [x] For deletion of groups
    * [x] Remove that particular group from all tokens that have it
* [x] For deletion of a cluster
    * [x] Delete all tokens
    * [x] Remove the cluster from any KubernetesGroup#restricted_to_clusters list
        * [x] If group has just the one cluster in `restricted_to_clusters` then we actually need to delete the group (since otherwise `restricted_to_clusters` would become empty and allow all clusters)
* [x] For deletion of a token
    * [x] Rejoice!