### PR TITLE
Hub admins can now manage Kubernetes namespaces, assigned to project services

### DIFF
--- a/platform-hub-api/app/controllers/kubernetes/namespaces_controller.rb
+++ b/platform-hub-api/app/controllers/kubernetes/namespaces_controller.rb
@@ -1,0 +1,101 @@
+class Kubernetes::NamespacesController < ApiJsonController
+
+  before_action :find_namespace, only: [ :show, :update, :destroy ]
+
+  authorize_resource class: KubernetesNamespace
+
+  # GET /kubernetes/namespaces
+  def index
+    scope = KubernetesNamespace.all
+
+    if params[:service_id]
+      service = Service.find params[:service_id]
+      scope = scope.by_service(service)
+    end
+
+    if params[:cluster_name]
+      cluster = KubernetesCluster.friendly.find params[:cluster_name]
+      scope = scope.by_cluster(cluster)
+    end
+
+    namespaces = scope.order(:name)
+
+    render json: namespaces
+  end
+
+  # GET /kubernetes/namespaces/:id
+  def show
+    render json: @namespace
+  end
+
+  # POST /kubernetes/namespaces
+  def create
+    params = namespace_create_params
+
+    service = Service.find params[:service_id]
+    cluster = KubernetesCluster.friendly.find params[:cluster_name]
+
+    namespace = KubernetesNamespace.new(
+      service: service,
+      cluster: cluster,
+      name: params[:name],
+      description: params[:description]
+    )
+
+    if namespace.save
+      AuditService.log(
+        context: audit_context,
+        action: 'create',
+        auditable: namespace
+      )
+
+      render json: namespace, status: :created
+    else
+      render_model_errors namespace.errors
+    end
+  end
+
+  # PATCH/PUT /kubernetes/namespaces/:id
+  def update
+    if @namespace.update(namespace_update_params)
+      AuditService.log(
+        context: audit_context,
+        action: 'update',
+        auditable: @namespace
+      )
+
+      render json: @namespace
+    else
+      render_model_errors @namespace.errors
+    end
+  end
+
+  # DELETE /kubernetes/namespaces/:id
+  def destroy
+    @namespace.destroy
+
+    AuditService.log(
+      context: audit_context,
+      action: 'destroy',
+      auditable: @namespace,
+      comment: "User '#{current_user.email}' deleted kubernetes namespace: '#{@namespace.name}' (ID: #{@namespace.id})"
+    )
+
+    head :no_content
+  end
+
+  private
+
+  def find_namespace
+    @namespace = KubernetesNamespace.find params[:id]
+  end
+
+  def namespace_create_params
+    params.require(:namespace).permit(:service_id, :cluster_name, :name, :description)
+  end
+
+  def namespace_update_params
+    params.require(:namespace).permit(:description)
+  end
+
+end

--- a/platform-hub-api/app/models/kubernetes_namespace.rb
+++ b/platform-hub-api/app/models/kubernetes_namespace.rb
@@ -1,0 +1,40 @@
+class KubernetesNamespace < ApplicationRecord
+
+  NAME_REGEX = /\A[a-z0-9]([-a-z0-9]*[a-z0-9])?\z/
+
+  include Audited
+
+  audited descriptor_field: :name, associated_field: :service
+
+  belongs_to :service, -> { readonly }
+  belongs_to :cluster, -> { readonly }, class_name: KubernetesCluster
+
+  scope :by_service, ->(s) { where(service: s) }
+  scope :by_cluster, ->(c) { where(cluster: c) }
+
+  validates :name,
+    format: {
+      with: NAME_REGEX,
+      message: "should consist of lowercase letters, numbers and dashes, and must start and end with an alphanumeric character"
+    },
+    uniqueness: {
+      scope: :cluster_id,
+      message: "already exists for the cluster"
+    }
+
+  validate :allowed_clusters_only
+
+  protected
+
+  def allowed_clusters_only
+    return unless service.present? && cluster.present?
+
+    unless Allocation.exists?(
+      allocatable: cluster,
+      allocation_receivable: service.project
+    )
+      errors.add(:cluster_id, "is not allowed for this namespace")
+    end
+  end
+
+end

--- a/platform-hub-api/app/serializers/kubernetes_namespace_serializer.rb
+++ b/platform-hub-api/app/serializers/kubernetes_namespace_serializer.rb
@@ -1,0 +1,7 @@
+class KubernetesNamespaceSerializer < BaseSerializer
+  attributes :id, :name, :description
+
+  belongs_to :service
+
+  belongs_to :cluster
+end

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
 
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-
   scope :format => false do
 
     root to: 'root#index'
@@ -129,6 +127,8 @@ Rails.application.routes.draw do
           post :allocate, on: :member
           get :allocations, on: :member
         end
+
+        resources :namespaces
       end
     end
 

--- a/platform-hub-api/db/migrate/20171127115843_create_kubernetes_namespaces.rb
+++ b/platform-hub-api/db/migrate/20171127115843_create_kubernetes_namespaces.rb
@@ -1,0 +1,14 @@
+class CreateKubernetesNamespaces < ActiveRecord::Migration[5.0]
+  def change
+    create_table :kubernetes_namespaces, id: :uuid do |t|
+      t.references :service, type: :uuid, null: false, index: true
+      t.references :cluster, type: :uuid, null: false, index: true
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps
+
+      t.index [ :name, :cluster_id ], unique: true
+    end
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -287,6 +287,21 @@ CREATE TABLE kubernetes_groups (
 
 
 --
+-- Name: kubernetes_namespaces; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE kubernetes_namespaces (
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    service_id uuid NOT NULL,
+    cluster_id uuid NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
 -- Name: kubernetes_tokens; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -571,6 +586,14 @@ ALTER TABLE ONLY kubernetes_groups
 
 
 --
+-- Name: kubernetes_namespaces kubernetes_namespaces_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY kubernetes_namespaces
+    ADD CONSTRAINT kubernetes_namespaces_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: kubernetes_tokens kubernetes_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -840,6 +863,27 @@ CREATE INDEX index_kubernetes_groups_on_target ON kubernetes_groups USING btree 
 
 
 --
+-- Name: index_kubernetes_namespaces_on_cluster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_kubernetes_namespaces_on_cluster_id ON kubernetes_namespaces USING btree (cluster_id);
+
+
+--
+-- Name: index_kubernetes_namespaces_on_name_and_cluster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_kubernetes_namespaces_on_name_and_cluster_id ON kubernetes_namespaces USING btree (name, cluster_id);
+
+
+--
+-- Name: index_kubernetes_namespaces_on_service_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_kubernetes_namespaces_on_service_id ON kubernetes_namespaces USING btree (service_id);
+
+
+--
 -- Name: index_kubernetes_tokens_on_cluster_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1045,6 +1089,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171010111440'),
 ('20171012110416'),
 ('20171031164247'),
-('20171114100517');
+('20171114100517'),
+('20171127115843');
 
 

--- a/platform-hub-api/spec/controllers/kubernetes/namespaces_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/namespaces_controller_spec.rb
@@ -1,0 +1,316 @@
+require 'rails_helper'
+
+RSpec.describe Kubernetes::NamespacesController, type: :controller do
+
+  include_context 'time helpers'
+
+  describe 'GET #index' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        get :index
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          get :index
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        context 'when no kubernetes namespaces exist' do
+          it 'returns an empty list' do
+            get :index
+            expect(response).to be_success
+            expect(json_response).to be_empty
+          end
+        end
+
+        context 'when kubernetes namespaces exist' do
+          before do
+            @namespaces = create_list :kubernetes_namespace, 3
+          end
+
+          let :total_namespaces do
+            @namespaces.length
+          end
+
+          let :all_namespace_ids do
+            @namespaces.map(&:id)
+          end
+
+          it 'returns all the existing kubernetes namespaces ordered by name descending' do
+            get :index
+            expect(response).to be_success
+            expect(json_response.length).to eq total_namespaces
+            expect(pluck_from_json_response('id')).to match_array all_namespace_ids
+          end
+
+          it 'returns namespaces by service' do
+            namespace = @namespaces.last
+            get :index, params: { service_id: namespace.service.id }
+            expect(json_response.length).to eq 1
+            expect(pluck_from_json_response('id')).to eq [namespace.id]
+          end
+
+          it 'returns namespaces by cluster' do
+            namespace = @namespaces.last
+            get :index, params: { cluster_name: namespace.cluster.id }
+            expect(json_response.length).to eq 1
+            expect(pluck_from_json_response('id')).to eq [namespace.id]
+          end
+        end
+
+      end
+
+    end
+  end
+
+  describe 'GET #show' do
+    before do
+      @namespace = create :kubernetes_namespace
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        get :show, params: { id: @namespace.id }
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          get :show, params: { id: @namespace.id }
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        context 'for a non-existent namespace' do
+          it 'should return a 404' do
+            get :show, params: { id: 'unknown' }
+            expect(response).to have_http_status(404)
+          end
+        end
+
+        context 'for a namespace that exists' do
+          it 'should return the specified namespace resource' do
+            get :show, params: { id: @namespace.id }
+            expect(response).to be_success
+            expect(json_response).to eq({
+              'id' => @namespace.id,
+              'name' => @namespace.name,
+              'description' => @namespace.description,
+              'cluster' => {
+                'id' => @namespace.cluster.friendly_id,
+                'name' => @namespace.cluster.name,
+                'description' => @namespace.cluster.description
+              },
+              'service' => {
+                'id' => @namespace.service.id,
+                'name' => @namespace.service.name,
+                'description' => @namespace.service.description,
+                'project'=> {
+                  'id' => @namespace.service.project.friendly_id,
+                  'shortname' => @namespace.service.project.shortname,
+                  'name' => @namespace.service.project.name
+                }
+              }
+            })
+          end
+        end
+
+      end
+
+    end
+  end
+
+  describe 'POST #create' do
+    let(:service) { create :service }
+    let(:cluster) { create :kubernetes_cluster, allocate_to: service.project }
+
+    let :post_data do
+      {
+        namespace: {
+          service_id: service.id,
+          cluster_name: cluster.name,
+          name: 'foobar',
+          description: 'foobar desc'
+        }
+      }
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        post :create, params: post_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          post :create, params: post_data
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        it 'creates a new namespace as expected' do
+          expect(KubernetesNamespace.count).to eq 0
+          expect(Audit.count).to eq 0
+          post :create, params: post_data
+          expect(response).to be_success
+          expect(KubernetesNamespace.count).to eq 1
+          namespace = KubernetesNamespace.first
+          expect(json_response).to eq({
+            'id' => namespace.id,
+            'name' => post_data[:namespace][:name],
+            'description' => post_data[:namespace][:description],
+            'cluster' => {
+              'id' => namespace.cluster.friendly_id,
+              'name' => post_data[:namespace][:cluster_name],
+              'description' => namespace.cluster.description
+            },
+            'service' => {
+              'id' => post_data[:namespace][:service_id],
+              'name' => namespace.service.name,
+              'description' => namespace.service.description,
+              'project'=> {
+                'id' => namespace.service.project.friendly_id,
+                'shortname' => namespace.service.project.shortname,
+                'name' => namespace.service.project.name
+              }
+            }
+          });
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'create'
+          expect(audit.auditable.id).to eq namespace.id
+          expect(audit.associated).to eq namespace.service
+          expect(audit.user.id).to eq current_user_id
+        end
+
+        context 'with existing namespace' do
+          before do
+            @existing_namespace = create :kubernetes_namespace
+          end
+
+          it 'fails to create a new namespace with a name that\'s already taken for that cluster' do
+            post_data_with_same_name_and_cluster = {
+              namespace: post_data[:namespace].clone.tap do |h|
+                h[:name] = @existing_namespace.name
+                h[:cluster_name] = @existing_namespace.cluster.name
+              end
+            }
+            expect(KubernetesNamespace.count).to eq 1
+            expect(Audit.count).to eq 0
+            post :create, params: post_data_with_same_name_and_cluster
+            expect(response).to have_http_status(422)
+            expect(json_response['error']['message']).not_to be_empty
+            expect(KubernetesNamespace.count).to eq 1
+            expect(Audit.count).to eq 0
+          end
+        end
+
+      end
+
+    end
+  end
+
+  describe 'PUT #update' do
+    let :put_data do
+      {
+        id: @namespace.id,
+        namespace: {
+          description: 'different foobar description'
+        }
+      }
+    end
+
+    before do
+      @namespace = create :kubernetes_namespace, description: 'foo'
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        put :update, params: put_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          put :update, params: put_data
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        it 'updates the specified namespace' do
+          expect(KubernetesNamespace.count).to eq 1
+          expect(Audit.count).to eq 0
+          put :update, params: put_data
+          expect(response).to be_success
+          expect(KubernetesNamespace.count).to eq 1
+          updated = KubernetesNamespace.first
+          expect(updated.name).to eq @namespace.name
+          expect(updated.description).to eq put_data[:namespace][:description]
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'update'
+          expect(audit.auditable.id).to eq @namespace.id
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before do
+      @namespace = create :kubernetes_namespace
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        delete :destroy, params: { id: @namespace.id }
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          delete :destroy, params: { id: @namespace.id }
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        it 'should delete the specified namespace' do
+          expect(KubernetesNamespace.exists?(@namespace.id)).to be true
+          expect(Audit.count).to eq 0
+          delete :destroy, params: { id: @namespace.id }
+          expect(response).to be_success
+          expect(KubernetesNamespace.exists?(@namespace.id)).to be false
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'destroy'
+          expect(audit.auditable_type).to eq KubernetesNamespace.name
+          expect(audit.auditable_id).to eq @namespace.id
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+end

--- a/platform-hub-api/spec/factories/kubernetes_namespaces.rb
+++ b/platform-hub-api/spec/factories/kubernetes_namespaces.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :kubernetes_namespace do
+    service
+    sequence(:name) { |n| "#{service.name.parameterize}-namespace-#{n}" }
+
+    after(:build) do |namespace, evaluator|
+      if namespace.cluster.blank? && namespace.service.present?
+        namespace.cluster = create :kubernetes_cluster, allocate_to: namespace.service.project
+      end
+    end
+  end
+end

--- a/platform-hub-api/spec/models/kubernetes_namespace_spec.rb
+++ b/platform-hub-api/spec/models/kubernetes_namespace_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe KubernetesNamespace, type: :model do
+
+  describe '#name' do
+    it { is_expected.to allow_value('f').for(:name) }
+    it { is_expected.to allow_value('foo').for(:name) }
+    it { is_expected.to allow_value('foo-bar').for(:name) }
+    it { is_expected.to allow_value('foo-1').for(:name) }
+    it { is_expected.to allow_value('1').for(:name) }
+    it { is_expected.to allow_value('1-foo').for(:name) }
+
+    it { is_expected.not_to allow_value('foo_bar').for(:name) }
+    it { is_expected.not_to allow_value('foo_1').for(:name) }
+    it { is_expected.not_to allow_value('foo bar').for(:name) }
+    it { is_expected.not_to allow_value('foo 1').for(:name) }
+    it { is_expected.not_to allow_value('-foo').for(:name) }
+    it { is_expected.not_to allow_value('foo-').for(:name) }
+    it { is_expected.not_to allow_value('_foo').for(:name) }
+
+    context 'for an existing namespace' do
+      subject { create :kubernetes_namespace }
+
+      it 'should only allow unique names per cluster' do
+        expect { create :kubernetes_namespace, name: subject.name, service: subject.service, cluster: subject.cluster }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          "Validation failed: Name already exists for the cluster"
+        )
+      end
+    end
+  end
+
+  describe 'custom validations' do
+
+    describe '#allowed_clusters_only' do
+      let!(:service) { create :service }
+      let!(:allocated_cluster) { create :kubernetes_cluster, allocate_to: service.project }
+      let!(:unallocated_cluster) { create :kubernetes_cluster }
+      let!(:other_allocated_cluster) { create :kubernetes_cluster, allocate_to: create(:project) }
+
+      it 'allows using the allocated cluster' do
+        namespace = build :kubernetes_namespace, service: service, cluster: allocated_cluster
+        expect(namespace).to be_valid
+      end
+
+      it 'raises error when using unallocated cluster' do
+        expect { create :kubernetes_namespace, service: service, cluster: unallocated_cluster }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          "Validation failed: Cluster is not allowed for this namespace"
+        )
+      end
+
+      it 'raises error when using other allocated cluster' do
+        expect { create :kubernetes_namespace, service: service, cluster: other_allocated_cluster }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          "Validation failed: Cluster is not allowed for this namespace"
+        )
+      end
+    end
+
+  end
+
+end

--- a/platform-hub-api/spec/routing/kubernetes_namespaces_routing_spec.rb
+++ b/platform-hub-api/spec/routing/kubernetes_namespaces_routing_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe Kubernetes::NamespacesController, type: :routing do
+  describe "routing" do
+
+    context 'with kubernetes_tokens feature flag enabled' do
+
+      before do
+        FeatureFlagService.create_or_update(:kubernetes_tokens, true)
+      end
+
+      it 'routes to #index' do
+        expect(:get => '/kubernetes/namespaces').to route_to('kubernetes/namespaces#index')
+      end
+
+      it 'routes to #show' do
+        expect(:get => '/kubernetes/namespaces/1').to route_to('kubernetes/namespaces#show', :id => '1')
+      end
+
+      it 'routes to #create' do
+        expect(:post => '/kubernetes/namespaces').to route_to('kubernetes/namespaces#create')
+      end
+
+      it 'routes to #update via PUT' do
+        expect(:put => '/kubernetes/namespaces/1').to route_to('kubernetes/namespaces#update', :id => '1')
+      end
+
+      it 'routes to #update via PATCH' do
+        expect(:patch => '/kubernetes/namespaces/1').to route_to('kubernetes/namespaces#update', :id => '1')
+      end
+
+      it 'routes to #destroy' do
+        expect(:delete => '/kubernetes/namespaces/1').to route_to('kubernetes/namespaces#destroy', :id => '1')
+      end
+
+    end
+
+    context 'with kubernetes_tokens feature flag disabled' do
+
+      before do
+        FeatureFlagService.create_or_update(:kubernetes_tokens, false)
+      end
+
+      it 'route to #index is not routable' do
+        expect(:get => '/kubernetes/namespaces').to_not be_routable
+      end
+
+      it 'route to #show is not routable' do
+        expect(:get => '/kubernetes/namespaces/1').to_not be_routable
+      end
+
+      it 'route to #create is not routable' do
+        expect(:post => '/kubernetes/namespaces').to_not be_routable
+      end
+
+      it 'route to #update via PUT is not routable' do
+        expect(:put => '/kubernetes/namespaces/1').to_not be_routable
+      end
+
+      it 'route to #update via PATCH is not routable' do
+        expect(:patch => '/kubernetes/namespaces/1').to_not be_routable
+      end
+
+      it 'route to #destroy is not routable' do
+        expect(:delete => '/kubernetes/namespaces/1').to_not be_routable
+      end
+
+    end
+
+  end
+end

--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -32,6 +32,8 @@ import {
   KubernetesGroupsDetail,
   KubernetesGroupsForm,
   KubernetesGroupsList,
+  KubernetesNamespacesForm,
+  KubernetesNamespacesList,
   KubernetesRobotTokensForm,
   KubernetesRobotTokensList,
   KubernetesTokensSync,
@@ -223,6 +225,59 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
             authenticate: true,
             featureFlags: [featureFlagKeys.kubernetesTokens],
             rolePermitted: 'admin'
+          }
+        })
+      .state('kubernetes.namespaces', {
+        abstract: true,
+        url: '/namespaces',
+        template: '<ui-view></ui-view>'
+      })
+        .state('kubernetes.namespaces.list', {
+          url: '/list/:cluster',
+          component: KubernetesNamespacesList,
+          data: {
+            authenticate: true,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
+            rolePermitted: 'admin'
+          },
+          resolve: {
+            transition: '$transition$'
+          },
+          params: {
+            cluster: ''
+          }
+        })
+        .state('kubernetes.namespaces.new', {
+          url: '/new/:cluster?fromProject&fromService',
+          component: KubernetesNamespacesForm,
+          resolve: {
+            transition: '$transition$'
+          },
+          data: {
+            authenticate: true,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
+            rolePermitted: 'admin'
+          },
+          params: {
+            cluster: '',
+            fromProject: null,
+            fromService: null
+          }
+        })
+        .state('kubernetes.namespaces.edit', {
+          url: '/edit/:cluster/:namespaceId?fromProject&fromService',
+          component: KubernetesNamespacesForm,
+          resolve: {
+            transition: '$transition$'
+          },
+          data: {
+            authenticate: true,
+            featureFlags: [featureFlagKeys.kubernetesTokens],
+            rolePermitted: 'admin'
+          },
+          params: {
+            fromProject: null,
+            fromService: null
           }
         })
       .state('kubernetes.user-tokens', {

--- a/platform-hub-web/src/app/kubernetes/kubernetes-namespaces-form.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-namespaces-form.component.js
@@ -1,0 +1,188 @@
+/* eslint camelcase: 0 */
+
+export const KubernetesNamespacesFormComponent = {
+  bindings: {
+    transition: '<'
+  },
+  template: require('./kubernetes-namespaces-form.html'),
+  controller: KubernetesNamespacesFormController
+};
+
+function KubernetesNamespacesFormController($q, $state, $mdSelect, projectServiceSelectorPopupService, AppSettings, KubernetesNamespaces, Projects, logger, _) {
+  'ngInject';
+
+  const ctrl = this;
+
+  const transitionParams = ctrl.transition && ctrl.transition.params();
+
+  const cluster = _.get(transitionParams, 'cluster');
+  const namespaceId = _.get(transitionParams, 'namespaceId');
+  const fromProject = _.get(transitionParams, 'fromProject');
+  const fromService = _.get(transitionParams, 'fromService');
+
+  ctrl.AppSettings = AppSettings;
+
+  ctrl.fromProject = fromProject;
+  ctrl.fromService = fromService;
+  ctrl.loading = true;
+  ctrl.processing = false;
+  ctrl.saving = false;
+  ctrl.isNew = true;
+  ctrl.namespace = null;
+  ctrl.service = null;
+  ctrl.allowedClusters = {};
+
+  ctrl.canChangeService = canChangeService;
+  ctrl.chooseService = chooseService;
+  ctrl.createOrUpdate = createOrUpdate;
+
+  init();
+
+  function init() {
+    ctrl.loading = true;
+
+    ctrl.isNew = !namespaceId;
+    ctrl.namespace = null;
+
+    if (
+      (!fromProject && fromService) ||
+      (fromProject && !fromService)
+    ) {
+      logger.error('Bug detected: both `fromProject` and `fromService` need to be provided, or neither');
+      $state.go('home');
+      return;
+    }
+
+    return setupNamespaceAndFetchService()
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function setupNamespaceAndFetchService() {
+    if (ctrl.isNew) {
+      ctrl.namespace = {
+        cluster: {
+          name: cluster
+        }
+      };
+
+      if (fromService) {
+        return fetchService(fromProject, fromService);
+      }
+
+      return $q.when();
+    }
+
+    return KubernetesNamespaces
+      .get(namespaceId)
+      .then(namespace => {
+        ctrl.namespace = namespace;
+
+        if (fromService && ctrl.namespace.service.id !== fromService) {
+          logger.error('Bad data detected: namespace has a service assigned that doesn\'t match the service expected');
+          $state.go('home');
+          return $q.reject();
+        }
+
+        return fetchService(ctrl.namespace.service.project.id, ctrl.namespace.service.id);
+      });
+  }
+
+  function fetchService(projectId, serviceId) {
+    return Projects
+      .getService(projectId, serviceId)
+      .then(service => {
+        ctrl.service = service;
+      })
+      .then(handleServiceChange);
+  }
+
+  function canChangeService() {
+    return ctrl.isNew && !ctrl.fromService;
+  }
+
+  function chooseService(targetEvent) {
+    if (!canChangeService()) {
+      return;
+    }
+
+    return projectServiceSelectorPopupService
+      .openForServiceOnly(targetEvent)
+      .then(result => {
+        ctrl.service = result.service;
+      })
+      .then(handleServiceChange);
+  }
+
+  function handleServiceChange() {
+    ctrl.processing = true;
+
+    return fetchClusters()
+      .finally(() => {
+        ctrl.processing = false;
+      });
+  }
+
+  function fetchClusters() {
+    ctrl.allowedClusters = [];
+
+    if (ctrl.service) {
+      return Projects
+        .getKubernetesClusters(ctrl.service.project.id)
+        .then(clusters => {
+          ctrl.allowedClusters = clusters;
+        });
+    }
+
+    return $q.when();
+  }
+
+  function createOrUpdate() {
+    if (ctrl.kubernetesNamespaceForm.$invalid) {
+      logger.error('Check the form for issues before saving');
+      return;
+    }
+
+    ctrl.saving = true;
+
+    let promise = null;
+
+    if (ctrl.isNew) {
+      const data = {
+        service_id: ctrl.service.id,
+        cluster_name: ctrl.namespace.cluster.name,
+        name: ctrl.namespace.name,
+        description: ctrl.namespace.description
+      };
+
+      promise = KubernetesNamespaces
+        .create(data)
+        .then(() => {
+          logger.success('New Kubernetes namespace created');
+        });
+    } else {
+      const data = {
+        description: ctrl.namespace.description
+      };
+
+      promise = KubernetesNamespaces
+        .update(namespaceId, data)
+        .then(() => {
+          logger.success('Kubernetes namespace updated');
+        });
+    }
+
+    return promise
+      .then(() => {
+        if (fromService) {
+          $state.go('projects.services.detail', {projectId: fromProject, id: fromService});
+        } else {
+          $state.go('kubernetes.namespaces.list', {cluster: ctrl.namespace.cluster.name});
+        }
+      })
+      .finally(() => {
+        ctrl.saving = false;
+      });
+  }
+}

--- a/platform-hub-web/src/app/kubernetes/kubernetes-namespaces-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-namespaces-form.html
@@ -1,9 +1,9 @@
-<div class="kubernetes-robot-tokens-form">
+<div class="kubernetes-namespaces-form">
   <md-toolbar md-scroll-shrink>
     <div class="md-toolbar-tools">
       <h3>
-        <span ng-if="$ctrl.isNew">New Kubernetes Robot Token</span>
-        <span ng-if="!$ctrl.isNew">Edit Kubernetes Robot Token</span>
+        <span ng-if="$ctrl.isNew">New Kubernetes Namespace</span>
+        <span ng-if="!$ctrl.isNew">Edit Kubernetes Namespace</span>
       </h3>
     </div>
   </md-toolbar>
@@ -12,9 +12,16 @@
 
   <md-content layout-padding ng-if="!$ctrl.loading">
 
+    <p
+      class="md-body-1"
+      md-colors="{background: 'yellow-50'}">
+      NOTE: No namespaces are actually created/modified on the clusters by this – this is just to
+      register a namespace in the hub so it can be used and referred to later.
+    </p>
+
     <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z1">
       <md-content layout-padding>
-        <form name="$ctrl.kubernetesTokenForm" role="form" ng-submit="$ctrl.createOrUpdate()">
+        <form name="$ctrl.kubernetesNamespaceForm" role="form" ng-submit="$ctrl.createOrUpdate()">
 
           <div layout="row" flex>
             <md-input-container
@@ -25,10 +32,10 @@
               <input
                 name="service"
                 ng-value="$ctrl.service.name"
-                ng-class="{'pointer': $ctrl.isAdmin && !$ctrl.fromService}"
+                ng-class="{'pointer': $ctrl.isNew}"
                 disabled="true"
                 required>
-              <div ng-messages="$ctrl.kubernetesTokenForm.service.$error">
+              <div ng-messages="$ctrl.kubernetesNamespaceForm.service.$error">
                 <div ng-message="required">This is required.</div>
               </div>
               <p
@@ -72,92 +79,36 @@
           <md-input-container class="md-block">
             <label for="cluster">Cluster:</label>
             <md-select
-              ng-model="$ctrl.token.cluster.name"
+              ng-model="$ctrl.namespace.cluster.name"
               ng-change="$ctrl.handleClusterChange()"
               name="cluster"
               required
               placeholder="Select the cluster"
-              ng-disabled="$ctrl.processing || !$ctrl.service || (!$ctrl.isNew && $ctrl.token.cluster) || !$ctrl.allowedClusters.length">
+              ng-disabled="$ctrl.processing || !$ctrl.service || (!$ctrl.isNew && $ctrl.namespace.cluster) || !$ctrl.allowedClusters.length">
               <md-option
                 ng-repeat="c in $ctrl.allowedClusters track by c.name"
                 ng-value="c.name">
                 {{c.name}} ({{c.description}})
               </md-option>
             </md-select>
-            <div ng-messages="$ctrl.kubernetesTokenForm.cluster.$error">
+            <div ng-messages="$ctrl.kubernetesNamespaceForm.cluster.$error">
               <div ng-message="required">This is required.</div>
             </div>
           </md-input-container>
 
           <br />
 
-          <p
-            ng-if="!$ctrl.processing && $ctrl.service && $ctrl.token.cluster.name && $ctrl.allowedGroups.length == 0"
-            class="md-body-2"
-            md-colors="{background: 'accent-50'}"
-            layout-padding>
-            No RBAC groups (for robot tokens) have been allocated yet to the selected service or project, or they may not be accessible to the selected cluster.
-            <br />
-            You can still create this token and add in the groups later (by editing the token once you have a group allocated).
-          </p>
-
           <md-input-container class="md-block">
-            <label for="groups">RBAC groups</label>
-            <md-select
-              name="groups"
-              ng-model="$ctrl.token.groups"
-              md-selected-text="$ctrl.token.groups.length ? $ctrl.token.groups.join(', ') : 'Select RBAC group(s):'"
-              ng-disabled="$ctrl.processing || !$ctrl.allowedGroups.length || !$ctrl.service || !$ctrl.token.cluster.name"
-              multiple>
-              <md-option
-                ng-repeat="g in $ctrl.allowedGroups track by g.name"
-                ng-value="g.name">
-                {{g.name}}
-                <br />
-                <small>{{g.description}}</small>
-              </md-option>
-            </md-select>
-          </md-input-container>
-
-          <br />
-
-          <md-input-container class="md-block" ng-if="!$ctrl.isNew">
-            <label for="token">Token:</label>
-            <input
-              name="token"
-              ng-model="$ctrl.token.obfuscated_token"
-              ng-disabled="!$ctrl.service || $ctrl.token.obfuscated_token"
-              required
-              placeholder="Kubernetes access token">
-            <div ng-messages="$ctrl.kubernetesTokenForm.token.$error">
-              <div ng-message="required">This is required.</div>
-            </div>
-          </md-input-container>
-
-          <md-input-container class="md-block" ng-if="!$ctrl.isNew">
-            <label for="uid">UID:</label>
-            <input
-              name="uid"
-              ng-model="$ctrl.token.uid"
-              ng-disabled="!$ctrl.service || $ctrl.token.uid"
-              required
-              placeholder="Kubernetes user UID">
-            <div ng-messages="$ctrl.kubernetesTokenForm.uid.$error">
-              <div ng-message="required">This is required.</div>
-            </div>
-          </md-input-container>
-
-          <md-input-container class="md-block">
-            <label for="name">Name (Only letters, numbers, underscores, dashes, dots and @. Must start with a letter)</label>
+            <label for="name">Name (Only lowercase letters, numbers and dashes, and must start and end with an alphanumeric character)</label>
             <input
               name="name"
-              ng-model="$ctrl.token.name"
+              ng-model="$ctrl.namespace.name"
               ng-disabled="!$ctrl.service || !$ctrl.isNew"
               required
-              ng-pattern="/^[a-zA-Z][\@\.\w-]*$/">
-            <div ng-messages="$ctrl.kubernetesTokenForm.name.$error">
+              ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/">
+            <div ng-messages="$ctrl.kubernetesNamespaceForm.name.$error">
               <div ng-message="required">This is required.</div>
-              <div ng-message="pattern">Only letters, numbers, underscores, dashes, dots and @. Must start with a letter.</div>
+              <div ng-message="pattern">Only lowercase letters, numbers and dashes, and must start and end with an alphanumeric character.</div>
             </div>
           </md-input-container>
 
@@ -165,31 +116,27 @@
             <label for="description">Description</label>
             <textarea
               name="description"
-              ng-model="$ctrl.token.description"
+              ng-model="$ctrl.namespace.description"
               ng-disabled="!$ctrl.service"
-              required
               rows="2"
-              aria-label="Set a description for this robot token"
+              aria-label="Set a description for this namespace"
               md-select-on-focus>
             </textarea>
-            <div ng-messages="$ctrl.kubernetesTokenForm.description.$error">
-              <div ng-message="required">This is required.</div>
-            </div>
           </md-input-container>
 
           <div>
             <md-button
               type="submit"
               class="md-primary"
-              ng-disabled="!$ctrl.service || $ctrl.processing || $ctrl.saving || !$ctrl.kubernetesTokenForm.$valid"
-              ng-class="{'md-raised': ($ctrl.kubernetesTokenForm.$dirty && $ctrl.kubernetesTokenForm.$valid) }"
-              aria-label="Save Token">
+              ng-disabled="!$ctrl.service || $ctrl.processing || $ctrl.saving || !$ctrl.kubernetesNamespaceForm.$valid"
+              ng-class="{'md-raised': ($ctrl.kubernetesNamespaceForm.$dirty && $ctrl.kubernetesNamespaceForm.$valid) }"
+              aria-label="Save Namespace">
               <span ng-if="$ctrl.isNew">Create</span>
               <span ng-if="!$ctrl.isNew">Update</span>
             </md-button>
             <md-button
               ng-if="!$ctrl.fromService"
-              ui-sref="kubernetes.robot-tokens.list({cluster: $ctrl.token.cluster.name})"
+              ui-sref="kubernetes.namespaces.list({cluster: $ctrl.namespace.cluster.name})"
               ng-disabled="$ctrl.processing || $ctrl.saving">
               Cancel
             </md-button>

--- a/platform-hub-web/src/app/kubernetes/kubernetes-namespaces-list.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-namespaces-list.component.js
@@ -1,0 +1,87 @@
+export const KubernetesNamespacesListComponent = {
+  bindings: {
+    transition: '<'
+  },
+  template: require('./kubernetes-namespaces-list.html'),
+  controller: KubernetesNamespacesListController
+};
+
+function KubernetesNamespacesListController($state, $mdSelect, $mdDialog, KubernetesClusters, KubernetesNamespaces, logger) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.KubernetesClusters = KubernetesClusters;
+  ctrl.KubernetesNamespaces = KubernetesNamespaces;
+
+  ctrl.loading = true;
+  ctrl.busy = false;
+  ctrl.cluster = ctrl.transition && ctrl.transition.params().cluster;
+  ctrl.namespaces = [];
+
+  ctrl.handleClusterChange = handleClusterChange;
+  ctrl.deleteNamespace = deleteNamespace;
+
+  init();
+
+  function init() {
+    ctrl.loading = true;
+
+    KubernetesClusters
+      .refresh()
+      .then(fetchNamespaces)
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function fetchNamespaces() {
+    ctrl.namespaces = [];
+
+    if (ctrl.cluster) {
+      ctrl.busy = true;
+
+      return KubernetesNamespaces
+        .getAllByCluster(ctrl.cluster)
+        .then(namespaces => {
+          angular.copy(namespaces, ctrl.namespaces);
+        })
+        .finally(() => {
+          ctrl.busy = false;
+        });
+    }
+  }
+
+  function handleClusterChange() {
+    // See: https://github.com/angular/material/issues/10747
+    $mdSelect.hide().then(() => {
+      $state.go('kubernetes.namespaces.list', {cluster: ctrl.cluster});
+    });
+  }
+
+  function deleteNamespace(namespaceId, targetEvent) {
+    const confirm = $mdDialog.confirm()
+      .title('Are you sure?')
+      .textContent('This will delete this kubernetes namespace from the hub. NOTE: this doesn\'t actually delete the namespace from the cluster - it just deletes the entry in the hub.')
+      .ariaLabel('Confirm deletion of a kubernetes namespace from the hub')
+      .targetEvent(targetEvent)
+      .ok('Do it')
+      .cancel('Cancel');
+
+    $mdDialog
+      .show(confirm)
+      .then(() => {
+        ctrl.busy = true;
+
+        KubernetesNamespaces
+          .delete(namespaceId)
+          .then(() => {
+            logger.success('Namespace deleted');
+            return fetchNamespaces();
+          })
+          .finally(() => {
+            ctrl.busy = false;
+          });
+      });
+  }
+}

--- a/platform-hub-web/src/app/kubernetes/kubernetes-namespaces-list.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-namespaces-list.html
@@ -1,16 +1,16 @@
-<div class="kubernetes-robot-tokens-list">
+<div class="kubernetes-namespaces-list">
   <md-toolbar md-scroll-shrink>
     <div class="md-toolbar-tools">
       <h3>
-        <span>Kubernetes Robot Tokens By Cluster</span>
+        <span>Kubernetes Namespaces By Cluster</span>
         <span ng-if="$ctrl.cluster">'{{$ctrl.cluster}}'</span>
       </h3>
       <span flex></span>
       <md-button
         ng-if="!$ctrl.loading && $ctrl.KubernetesClusters.all.length > 0"
-        aria-label="Add new robot token for the specified cluster"
-        ui-sref="kubernetes.robot-tokens.new({cluster: $ctrl.cluster})">
-        <md-icon>{{$ctrl.addTokenIcon}}</md-icon>
+        aria-label="Add new namespace for the specified cluster"
+        ui-sref="kubernetes.namespaces.new({cluster: $ctrl.cluster})">
+        <md-icon>add_box</md-icon>
         New
       </md-button>
     </div>
@@ -36,27 +36,19 @@
 
   <md-content layout-padding>
 
-    <p
-      class="md-body-1"
-      md-colors="{background: 'yellow-50'}">
-      After making any changes make sure you
-      <a ui-sref="kubernetes.tokens-sync">sync the relevant cluster(s)</a>
-      to push your changes live
-    </p>
-
     <md-card
-      ng-if="!$ctrl.loading && $ctrl.tokens.length > 0"
-      ng-repeat="t in $ctrl.tokens track by t.name">
+      ng-if="!$ctrl.loading && $ctrl.namespaces.length > 0"
+      ng-repeat="n in $ctrl.namespaces track by n.name">
       <md-card-title>
         <md-card-title-text>
           <span class="md-headline">
-            {{t.name}}
+            {{n.name}}
             <span
               flex="none"
               class="badge"
               md-colors="{background: 'accent-100'}"
               style="margin-left: 0">
-              {{t.cluster.name}} cluster
+              {{n.cluster.name}} cluster
             </span>
           </span>
         </md-card-title-text>
@@ -66,52 +58,37 @@
         <p
           class="md-body-1"
           md-colors="{background: 'blue-grey-50'}"
-          ng-if="t.description"
-          ng-bind-html='t.description | simpleFormat'
+          ng-if="n.description"
+          ng-bind-html='n.description | simpleFormat'
           layout-padding>
         </p>
         <br />
         <p class="md-body-1">
-          <strong>Project: </strong>{{t.project.name}} ({{t.project.shortname}})
+          <strong>Project: </strong>{{n.service.project.name}} ({{n.service.project.shortname}})
         </p>
         <p class="md-body-1">
-          <strong>Service: </strong>{{t.service.name}}
-        </p>
-        <p class="md-body-1">
-          <strong>Token:</strong> <kubernetes-token-value item="t"></kubernetes-token-value>
-        </p>
-        <p class="md-body-1">
-          <strong>UID:</strong> {{t.uid}}
-        </p>
-        <p class="md-body-1">
-          <strong>Groups:</strong>
-          <span ng-if="t.groups.length > 0">
-            <span ng-repeat="g in t.groups" class="badge" md-colors="{background: 'green-100'}">{{g}}</span>
-          </span>
-          <span ng-if="!t.groups.length" class="none-text">
-            no RBAC groups assigned to this token
-          </span>
+          <strong>Service: </strong>{{n.service.name}}
         </p>
       </md-card-content>
 
       <md-card-actions layout="row" layout-align="start center">
         <md-button
           class="md-primary"
-          aria-label="View and edit details for this token"
-          ui-sref="kubernetes.robot-tokens.edit({cluster: t.cluster.name, tokenId: t.id})">
+          aria-label="View and edit details for this namespace"
+          ui-sref="kubernetes.namespaces.edit({cluster: n.cluster.name, namespaceId: n.id})">
           View and edit
         </md-button>
         <span flex></span>
         <md-button
           class="md-accent"
-          ng-click="$ctrl.deleteToken(t.id, $event)"
-          aria-label="Delete kubernetes robot token">
+          ng-click="$ctrl.deleteNamespace(n.id, $event)"
+          ng-disabled="$ctrl.busy"
+          aria-label="Delete kubernetes namespace">
           Delete
         </md-button>
       </md-card-actions>
     </md-card>
 
-    <br /><br />
-
   </md-content>
+
 </div>

--- a/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-list.component.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-robot-tokens-list.component.js
@@ -6,7 +6,7 @@ export const KubernetesRobotTokensListComponent = {
   controller: KubernetesRobotTokensListController
 };
 
-function KubernetesRobotTokensListController($state, $mdSelect, $mdDialog, icons, KubernetesClusters, KubernetesTokens) {
+function KubernetesRobotTokensListController($state, $mdSelect, $mdDialog, icons, KubernetesClusters, KubernetesTokens, logger) {
   'ngInject';
 
   const ctrl = this;
@@ -71,9 +71,17 @@ function KubernetesRobotTokensListController($state, $mdSelect, $mdDialog, icons
     $mdDialog
       .show(confirm)
       .then(() => {
+        ctrl.busy = true;
+
         KubernetesTokens
           .deleteToken(tokenId)
-          .then(fetchTokens);
+          .then(() => {
+            logger.success('Token deleted');
+            return fetchTokens();
+          })
+          .finally(() => {
+            ctrl.busy = false;
+          });
       });
   }
 }

--- a/platform-hub-web/src/app/kubernetes/kubernetes.module.js
+++ b/platform-hub-web/src/app/kubernetes/kubernetes.module.js
@@ -6,6 +6,8 @@ import {KubernetesClustersListComponent} from './kubernetes-clusters-list.compon
 import {KubernetesGroupsDetailComponent} from './kubernetes-groups-detail.component';
 import {KubernetesGroupsFormComponent} from './kubernetes-groups-form.component';
 import {KubernetesGroupsListComponent} from './kubernetes-groups-list.component';
+import {KubernetesNamespacesFormComponent} from './kubernetes-namespaces-form.component';
+import {KubernetesNamespacesListComponent} from './kubernetes-namespaces-list.component';
 import {KubernetesRobotTokensFormComponent} from './kubernetes-robot-tokens-form.component';
 import {KubernetesRobotTokensListComponent} from './kubernetes-robot-tokens-list.component';
 import {KubernetesTokenEscalatePrivilegePopupController} from './kubernetes-token-escalate-privilege-popup.controller';
@@ -21,6 +23,8 @@ export const KubernetesClustersList = 'kubernetesClustersList';
 export const KubernetesGroupsDetail = 'kubernetesGroupsDetail';
 export const KubernetesGroupsForm = 'kubernetesGroupsForm';
 export const KubernetesGroupsList = 'kubernetesGroupsList';
+export const KubernetesNamespacesForm = 'kubernetesNamespacesForm';
+export const KubernetesNamespacesList = 'kubernetesNamespacesList';
 export const KubernetesRobotTokensForm = 'kubernetesRobotTokensForm';
 export const KubernetesRobotTokensList = 'kubernetesRobotTokensList';
 export const KubernetesTokensSync = 'kubernetesTokensSync';
@@ -35,6 +39,8 @@ export const KubernetesModule = angular
   .component(KubernetesGroupsDetail, KubernetesGroupsDetailComponent)
   .component(KubernetesGroupsForm, KubernetesGroupsFormComponent)
   .component(KubernetesGroupsList, KubernetesGroupsListComponent)
+  .component(KubernetesNamespacesForm, KubernetesNamespacesFormComponent)
+  .component(KubernetesNamespacesList, KubernetesNamespacesListComponent)
   .component(KubernetesRobotTokensForm, KubernetesRobotTokensFormComponent)
   .component(KubernetesRobotTokensList, KubernetesRobotTokensListComponent)
   .controller('KubernetesTokenEscalatePrivilegePopupController', KubernetesTokenEscalatePrivilegePopupController)

--- a/platform-hub-web/src/app/layout/shell.component.js
+++ b/platform-hub-web/src/app/layout/shell.component.js
@@ -142,6 +142,12 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
       featureFlags: [featureFlagKeys.kubernetesTokens]
     },
     {
+      title: 'Kubernetes Namespaces',
+      state: 'kubernetes.namespaces.list',
+      icon: icons.kubernetesNamespaces,
+      featureFlags: [featureFlagKeys.kubernetesTokens]
+    },
+    {
       title: 'Kubernetes User Tokens',
       state: 'kubernetes.user-tokens.list',
       icon: icons.kubernetesTokens,

--- a/platform-hub-web/src/app/projects/services/project-services-detail.html
+++ b/platform-hub-web/src/app/projects/services/project-services-detail.html
@@ -143,6 +143,72 @@
         </md-tab-body>
       </md-tab>
 
+      <md-tab
+        id="kube-namespaces-tab"
+        ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetesTokens)"
+        md-on-select="$ctrl.loadKubernetesNamespaces()">
+        <md-tab-label>Kube Namespaces</md-tab-label>
+        <md-tab-body>
+          <loading-indicator loading="$ctrl.processingKubernetesNamespaces"></loading-indicator>
+
+          <div
+            ng-if="$ctrl.isAdmin"
+            layout="row"
+            layout-align="center center">
+            <md-button
+              class="md-primary md-raised"
+              aria-label="Register a Kubernetes namespace with this project service"
+              ui-sref="kubernetes.namespaces.new({fromProject: $ctrl.projectId, fromService: $ctrl.service.id})">
+              Register a Kubernetes namespace with this service
+            </md-button>
+          </div>
+
+          <md-card ng-repeat="n in $ctrl.kubernetesNamespaces track by n.id">
+            <md-card-title>
+              <md-card-title-text>
+                <span class="md-headline">
+                  {{n.name}}
+                  <span
+                    flex="none"
+                    class="badge"
+                    md-colors="{background: 'accent-100'}"
+                    style="margin-left: 0">
+                    {{n.cluster.name}} cluster
+                  </span>
+                </span>
+              </md-card-title-text>
+            </md-card-title>
+
+            <md-card-content>
+              <p
+                class="md-body-1"
+                md-colors="{background: 'blue-grey-50'}"
+                ng-if="n.description"
+                ng-bind-html='n.description | simpleFormat'
+                layout-padding>
+              </p>
+            </md-card-content>
+
+            <md-card-actions layout="row" layout-align="start center" ng-if="$ctrl.isAdmin">
+              <md-button
+                class="md-primary"
+                aria-label="View and edit details for this namespace"
+                ui-sref="kubernetes.namespaces.edit({cluster: n.cluster.name, namespaceId: n.id, fromProject: $ctrl.projectId, fromService: $ctrl.service.id})">
+                View and edit
+              </md-button>
+              <span flex></span>
+              <md-button
+                class="md-accent"
+                ng-click="$ctrl.deleteKubernetesNamespace(n.id, $event)"
+                ng-disabled="$ctrl.processingKubernetesNamespaces"
+                aria-label="Delete kubernetes namespace">
+                Delete
+              </md-button>
+            </md-card-actions>
+          </md-card>
+        </md-tab-body>
+      </md-tab>
+
     </md-tabs>
 
     <br /><br />

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -128,6 +128,12 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.revokeKubernetesToken = revokeKubernetesToken;
   service.escalatePrivilegeForKubernetesTokens = escalatePrivilegeForKubernetesTokens;
 
+  service.getKubernetesNamespaces = getKubernetesNamespaces;
+  service.getKubernetesNamespace = buildResourceFetcher('kubernetes/namespaces');
+  service.createKubernetesNamespace = buildResourceCreator('kubernetes/namespaces');
+  service.updateKubernetesNamespace = buildResourceUpdater('kubernetes/namespaces');
+  service.deleteKubernetesNamespace = buildResourceDeletor('kubernetes/namespaces');
+
   service.getFeatureFlags = buildSimpleFetcher('feature_flags', 'feature flags');
   service.updateFeatureFlag = buildResourceUpdater('feature_flags');
 
@@ -1153,6 +1159,16 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       .then(handle4xxError)
       .catch(response => {
         logger.error(buildErrorMessageFromResponse('Failed to escalate privilege on Kube token', response));
+        return $q.reject(response);
+      });
+  }
+
+  function getKubernetesNamespaces(params) {
+    return $http
+      .get(`${apiEndpoint}/kubernetes/namespaces`, {params: params})
+      .then(response => response.data)
+      .catch(response => {
+        logger.error('Failed to fetch kubernetes namespaces – the API might be down. Try again later.');
         return $q.reject(response);
       });
   }

--- a/platform-hub-web/src/app/shared/icons.factory.js
+++ b/platform-hub-web/src/app/shared/icons.factory.js
@@ -15,6 +15,7 @@ export const icons = function () {
     internalLink: 'input',
     kubernetesClusters: 'cloud_circle',
     kubernetesGroups: 'groups',
+    kubernetesNamespaces: 'picture_in_picture_alt',
     kubernetesTokens: 'vpn_key',
     markAllRead: 'drafts',
     menu: 'menu',

--- a/platform-hub-web/src/app/shared/model/kubernetes-namespaces.js
+++ b/platform-hub-web/src/app/shared/model/kubernetes-namespaces.js
@@ -1,0 +1,24 @@
+/* eslint camelcase: 0 */
+
+export const KubernetesNamespaces = function (hubApiService) {
+  'ngInject';
+
+  const model = {};
+
+  model.getAllByService = getAllByService;
+  model.getAllByCluster = getAllByCluster;
+  model.get = hubApiService.getKubernetesNamespace;
+  model.create = hubApiService.createKubernetesNamespace;
+  model.update = hubApiService.updateKubernetesNamespace;
+  model.delete = hubApiService.deleteKubernetesNamespace;
+
+  return model;
+
+  function getAllByService(serviceId) {
+    return hubApiService.getKubernetesNamespaces({service_id: serviceId});
+  }
+
+  function getAllByCluster(clusterName) {
+    return hubApiService.getKubernetesNamespaces({cluster_name: clusterName});
+  }
+};

--- a/platform-hub-web/src/app/shared/model/model.module.js
+++ b/platform-hub-web/src/app/shared/model/model.module.js
@@ -10,6 +10,7 @@ import {FeatureFlags} from './feature-flags';
 import {Identities} from './identities';
 import {KubernetesClusters} from './kubernetes-clusters';
 import {KubernetesGroups} from './kubernetes-groups';
+import {KubernetesNamespaces} from './kubernetes-namespaces';
 import {KubernetesTokens} from './kubernetes-tokens';
 import {Me} from './me';
 import {PlatformThemes} from './platform-themes';
@@ -32,6 +33,7 @@ export const ModelModule = angular
   .service('Identities', Identities)
   .service('KubernetesClusters', KubernetesClusters)
   .service('KubernetesGroups', KubernetesGroups)
+  .service('KubernetesNamespaces', KubernetesNamespaces)
   .service('KubernetesTokens', KubernetesTokens)
   .service('Me', Me)
   .service('PlatformThemes', PlatformThemes)


### PR DESCRIPTION
Note: there's currently no relationship/interaction between RBAC groups and namespaces within the hub – we can solve this in a later PR (depending on _if_ and _how_ we might want to do that).