### PR TITLE
Add an extra publish step for Costs Reports

### DIFF
--- a/platform-hub-api/app/models/costs_report.rb
+++ b/platform-hub-api/app/models/costs_report.rb
@@ -10,6 +10,7 @@ class CostsReport < ApplicationRecord
   before_validation :set_id
 
   scope :by_year_and_month, -> (year, month) { where(year: year, month: month) }
+  scope :published, -> { where.not(published_at: nil) }
 
   validates :id,
     format: {
@@ -28,9 +29,17 @@ class CostsReport < ApplicationRecord
       message: 'is not a valid abbreviated month name'
     }
 
-  def self.exists_for? year, month
+  def self.exists_for? year, month, filter_scope = nil
     id = CostsReport.generate_id_for year, month
-    CostsReport.exists? id
+    if filter_scope.present?
+      CostsReport.send(filter_scope.to_sym)
+    else
+      CostsReport
+    end.exists?(id)
+  end
+
+  def self.already_published? year, month
+    self.exists_for?(year, month, 'published')
   end
 
   def self.generate_id_for year, month_abbr
@@ -42,6 +51,25 @@ class CostsReport < ApplicationRecord
 
   def self.is_valid_month_abbr? month_abbr
     Date::ABBR_MONTHNAMES.include? month_abbr
+  end
+
+  def publish!
+    self.published_at = DateTime.now.utc
+    self.save!
+  end
+
+  def published?
+    self.published_at.present?
+  end
+
+  protected
+
+  def readonly?
+    if persisted?
+      if published? && self.published_at_was != nil  # Because we may be trying to publish!
+        raise ActiveRecord::ReadOnlyRecord, 'has already been published'
+      end
+    end
   end
 
   private

--- a/platform-hub-api/app/serializers/costs_report_serializer.rb
+++ b/platform-hub-api/app/serializers/costs_report_serializer.rb
@@ -6,7 +6,8 @@ class CostsReportSerializer < BaseSerializer
     :billing_file,
     :metrics_file,
     :notes,
-    :created_at
+    :created_at,
+    :published_at
   )
 
   attribute :config do

--- a/platform-hub-api/app/services/project_bills_query_service.rb
+++ b/platform-hub-api/app/services/project_bills_query_service.rb
@@ -6,6 +6,7 @@ module ProjectBillsQueryService
     raise ArgumentError if project_id.count("}'") > 0
 
     entries = CostsReport
+      .published
       .select("costs_reports.year, costs_reports.month, costs_reports.results #> '{project_bills,#{project_id}}' as project_bill")
       .order(id: :desc)
       .entries

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -141,6 +141,7 @@ Rails.application.routes.draw do
       constraints: { id: CostsReport::ID_REGEX_FOR_ROUTES } do
       get :available_data_files, on: :collection
       post :prepare, on: :collection
+      post :publish, on: :member
     end
 
   end

--- a/platform-hub-api/db/migrate/20171214165427_add_published_at_to_costs_reports.rb
+++ b/platform-hub-api/db/migrate/20171214165427_add_published_at_to_costs_reports.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToCostsReports < ActiveRecord::Migration[5.0]
+  def change
+    add_column :costs_reports, :published_at, :datetime, null: true
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -195,7 +195,8 @@ CREATE TABLE costs_reports (
     config json NOT NULL,
     results json NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    published_at timestamp without time zone
 );
 
 
@@ -1112,6 +1113,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171114100517'),
 ('20171127115843'),
 ('20171130163603'),
-('20171201113437');
+('20171201113437'),
+('20171214165427');
 
 

--- a/platform-hub-api/spec/factories/costs_reports.rb
+++ b/platform-hub-api/spec/factories/costs_reports.rb
@@ -6,5 +6,6 @@ FactoryGirl.define do
     metrics_file 'metrics.csv'
     config { {} }
     results { {} }
+    published_at nil
   end
 end

--- a/platform-hub-api/spec/routing/costs_reports_routing_spec.rb
+++ b/platform-hub-api/spec/routing/costs_reports_routing_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe CostsReportsController, type: :routing do
       expect(:delete => '/costs_reports/2017-01').to route_to('costs_reports#destroy', :id => '2017-01')
     end
 
+    it 'routes to #publish' do
+      expect(:post => '/costs_reports/2017-01/publish').to route_to('costs_reports#publish', :id => '2017-01')
+    end
+
     it 'doesn\'t route an invalid ID' do
       expect(:get => '/costs_reports/1').not_to be_routable
       expect(:get => '/costs_reports/foo').not_to be_routable

--- a/platform-hub-web/src/app/costs-reports/costs-reports-detail.html
+++ b/platform-hub-web/src/app/costs-reports/costs-reports-detail.html
@@ -48,6 +48,19 @@
           {{$ctrl.report.created_at | date:'medium'}}
         </p>
 
+        <p class="md-body-1">
+          <span md-colors="{color: 'blue-grey-700'}">
+            Published at:
+          </span>
+          <span ng-if="!$ctrl.report.published_at" class="none-text">not published yet</span>
+          <span ng-if="$ctrl.report.published_at">
+            <span>
+              {{$ctrl.report.published_at | date:'EEE MMM d y HH:mm UTC':'UTC'}}
+            </span>
+            (<strong><span am-time-ago="$ctrl.report.published_at" md-colors="{color: 'accent'}"></span></strong>)
+          </span>
+        </p>
+
         <p
           class="md-body-1"
           md-colors="{background: 'blue-grey-50'}"

--- a/platform-hub-web/src/app/costs-reports/costs-reports-form.html
+++ b/platform-hub-web/src/app/costs-reports/costs-reports-form.html
@@ -7,7 +7,7 @@
     </div>
   </md-toolbar>
 
-  <loading-indicator loading="$ctrl.loading || $ctrl.saving"></loading-indicator>
+  <loading-indicator loading="$ctrl.loading || $ctrl.preparing || $ctrl.saving"></loading-indicator>
 
   <md-content layout-padding ng-if="!$ctrl.loading">
 
@@ -17,7 +17,10 @@
           <div layout="row">
             <md-input-container>
               <label>Year</label>
-              <md-select ng-model="$ctrl.report.year" required>
+              <md-select
+                ng-model="$ctrl.report.year"
+                required
+                ng-disabled="$ctrl.prepareResults">
                 <md-option ng-repeat="y in $ctrl.years" ng-value="y">
                   {{y}}
                 </md-option>
@@ -26,7 +29,10 @@
 
             <md-input-container>
               <label>Month</label>
-              <md-select ng-model="$ctrl.report.month" required>
+              <md-select
+                ng-model="$ctrl.report.month"
+                required
+                ng-disabled="$ctrl.prepareResults">
                 <md-option ng-repeat="m in $ctrl.months" ng-value="m">
                   {{m}}
                 </md-option>
@@ -39,7 +45,8 @@
             <md-select
               name="billing_file"
               ng-model="$ctrl.report.billing_file"
-              required>
+              required
+              ng-disabled="$ctrl.prepareResults">
               <md-option ng-repeat="f in $ctrl.availableBillingFiles" ng-value="f">
                 {{f}}
               </md-option>
@@ -54,7 +61,8 @@
             <md-select
               name="metrics_file"
               ng-model="$ctrl.report.metrics_file"
-              required>
+              required
+              ng-disabled="$ctrl.prepareResults">
               <md-option ng-repeat="f in $ctrl.availableMetricsFiles" ng-value="f">
                 {{f}}
               </md-option>
@@ -68,8 +76,7 @@
             <md-button
               class="md-primary md-raised"
               ng-click="$ctrl.prepare()"
-              ng-if="!$ctrl.prepareResults"
-              ng-disabled="$ctrl.preparing || !$ctrl.isReadyToPrepare()"
+              ng-disabled="$ctrl.preparing || !$ctrl.isReadyToPrepare() || $ctrl.prepareResults"
               aria-label="Prepare the next step of the report generation based on the data specified">
               Inspect data and prepare next step of report generation
               <md-tooltip md-direction="bottom">
@@ -86,18 +93,32 @@
             </legend>
 
             <p
-              ng-if="!r.exists"
+              ng-if="r.already_published"
+              class="md-body-2"
+              md-colors="{background: 'accent-50', color: 'accent'}"
+              layout-padding>
+              <span>
+                Report has already been published! Cannot overwrite it.
+              </span>
+              <br />
+              <span>
+                (If you <em>really</em> want to recreate it you can delete it from the listings view and then recreate it – but note that projects may have already seen the bill)
+              </span>
+            </p>
+
+            <p
+              ng-if="!r.already_published && r.exists"
+              class="md-body-1"
+              md-colors="{background: 'accent-50', color: 'accent'}"
+              layout-padding>
+              Report already exists for this year and month – by continuing, you will overwrite this report.
+            </p>
+            <p
+              ng-if="!r.already_published && !r.exists"
               class="md-body-1"
               md-colors="{background: 'green-50', color: 'green'}"
               layout-padding>
               Report does not yet exist for this year and month - a new report will be created.
-            </p>
-            <p
-              ng-if="r.exists"
-              class="md-body-2"
-              md-colors="{background: 'accent-50', color: 'accent'}"
-              layout-padding>
-              Report already exists for this year and month – by continuing, you will overwrite this report.
             </p>
 
             <p
@@ -224,7 +245,7 @@
           <br ng-if="$ctrl.prepareResults" />
           <br ng-if="$ctrl.prepareResults" />
 
-          <fieldset ng-if="$ctrl.hasSufficientMappingsToContinue()">
+          <fieldset ng-if="!$ctrl.prepareResults.already_published && $ctrl.hasSufficientMappingsToContinue()">
             <legend>
               Config for the report
             </legend>
@@ -315,7 +336,7 @@
             </md-input-container>
           </fieldset>
 
-          <br ng-if="$ctrl.hasSufficientMappingsToContinue()" />
+          <br ng-if="!$ctrl.prepareResults.already_published && $ctrl.hasSufficientMappingsToContinue()" />
 
           <md-input-container class="md-block">
             <label for="notes">Notes for this report (only visible to hub admins):</label>
@@ -334,8 +355,8 @@
             <md-button
               type="submit"
               class="md-primary"
-              ng-disabled="!$ctrl.prepareResults || !$ctrl.hasSufficientMappingsToContinue() || !$ctrl.doMetricWeightsAddUp() || $ctrl.preparing || $ctrl.saving || !$ctrl.costsForm.$valid"
-              ng-class="{'md-raised': ($ctrl.prepareResults && $ctrl.hasSufficientMappingsToContinue() && $ctrl.doMetricWeightsAddUp() && $ctrl.costsForm.$dirty && $ctrl.costsForm.$valid) }"
+              ng-disabled="!$ctrl.prepareResults || $ctrl.prepareResults.already_published || !$ctrl.hasSufficientMappingsToContinue() || !$ctrl.doMetricWeightsAddUp() || $ctrl.preparing || $ctrl.saving || !$ctrl.costsForm.$valid"
+              ng-class="{'md-raised': ($ctrl.prepareResults && !$ctrl.prepareResults.already_published && $ctrl.hasSufficientMappingsToContinue() && $ctrl.doMetricWeightsAddUp() && $ctrl.costsForm.$dirty && $ctrl.costsForm.$valid) }"
               aria-label="Create costs report">
               Create
             </md-button>

--- a/platform-hub-web/src/app/costs-reports/costs-reports-list.component.js
+++ b/platform-hub-web/src/app/costs-reports/costs-reports-list.component.js
@@ -3,13 +3,16 @@ export const CostsReportsListComponent = {
   controller: CostsReportsListController
 };
 
-function CostsReportsListController(CostsReports) {
+function CostsReportsListController($mdDialog, CostsReports, logger) {
   'ngInject';
 
   const ctrl = this;
 
   ctrl.loading = true;
+  ctrl.processing = false;
   ctrl.reports = [];
+
+  ctrl.publish = publish;
 
   init();
 
@@ -27,6 +30,32 @@ function CostsReportsListController(CostsReports) {
       })
       .finally(() => {
         ctrl.loading = false;
+      });
+  }
+
+  function publish(report, targetEvent) {
+    const confirm = $mdDialog.confirm()
+      .title('Are you sure?')
+      .textContent(`This will publish the costs report '${report.id}' to projects and allow them see their bill for that month. It's still possible to delete and recreate this report afterwards, but it is highly advised to not do this.`)
+      .ariaLabel('Confirm publishing of costs report')
+      .targetEvent(targetEvent)
+      .ok('Do it')
+      .cancel('Cancel');
+
+    $mdDialog
+      .show(confirm)
+      .then(() => {
+        ctrl.processing = true;
+
+        CostsReports
+          .publish(report.id)
+          .then(() => {
+            logger.success('Costs report published');
+            return fetchReports();
+          })
+          .finally(() => {
+            ctrl.processing = false;
+          });
       });
   }
 }

--- a/platform-hub-web/src/app/costs-reports/costs-reports-list.html
+++ b/platform-hub-web/src/app/costs-reports/costs-reports-list.html
@@ -19,11 +19,18 @@
   <md-content ng-if="!$ctrl.loading && $ctrl.reports.length > 0" layout-padding>
 
     <md-card
-
-      ng-repeat="r in $ctrl.reports track by r.id">
+      ng-repeat="r in $ctrl.reports track by r.id"
+      md-colors="r.published_at ? {background: 'blue-grey-50'} : {}">
       <md-card-title>
         <md-card-title-text>
           <span class="md-headline">
+            <small
+              class="badge float-right"
+              ng-if="r.published_at"
+              md-colors="{background: 'blue-grey'}">
+              Published
+            </small>
+
             {{r.year}}
             {{r.month}}
           </span>
@@ -31,6 +38,13 @@
       </md-card-title>
 
       <md-card-content>
+        <p
+          class="md-body-2"
+          md-colors="{color: 'accent'}"
+          ng-if="!r.published_at">
+          Not yet published - projects can't currently see their costs from this report
+        </p>
+
         <p class="md-body-1">
           <span md-colors="{color: 'blue-grey-700'}">
             Billing data file:
@@ -51,6 +65,14 @@
           {{r.created_at | date:'medium'}}
         </p>
 
+        <p class="md-body-1" ng-if="r.published_at">
+          <span md-colors="{color: 'blue-grey-700'}">
+            Published at:
+          </span>
+          <span>{{r.published_at | date:'EEE MMM d y HH:mm UTC':'UTC'}}</span>
+          (<strong><span am-time-ago="r.published_at" md-colors="{color: 'accent'}"></span></strong>)
+        </p>
+
         <p
           class="md-body-1"
           md-colors="{background: 'blue-grey-50'}"
@@ -66,6 +88,13 @@
           aria-label="View details for this report"
           ui-sref="costs-reports.detail({id: r.id})">
           Details
+        </md-button>
+        <md-button
+          ng-disabled="$ctrl.processing"
+          ng-if="!r.published_at"
+          aria-label="Publish this report now to projects"
+          ng-click="$ctrl.publish(r, $event)">
+          Publish
         </md-button>
       </md-card-actions>
     </md-card>

--- a/platform-hub-web/src/app/projects/projects-detail.html
+++ b/platform-hub-web/src/app/projects/projects-detail.html
@@ -357,6 +357,13 @@
         <md-tab-body>
           <loading-indicator loading="$ctrl.loadingBills"></loading-indicator>
 
+          <div
+            ng-if="!$ctrl.loadingBills && !$ctrl.bills.length"
+            class="text-center none-text md-body-1">
+            <br />
+            No bills are currently available
+          </div>
+
           <md-card
             ng-if="$ctrl.bills.length"
             ng-repeat="b in $ctrl.bills track by b.year+b.month">

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -147,6 +147,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
   service.prepareCostsReport = buildSimplePoster('costs_reports/prepare', 'prepare costs report');
   service.createCostsReport = buildResourceCreator('costs_reports');
   service.deleteCostsReport = buildResourceDeletor('costs_reports');
+  service.publishCostsReport = publishCostsReport;
 
   return service;
 
@@ -1198,6 +1199,20 @@ export const hubApiService = function ($rootScope, $http, $q, logger, events, ap
       .then(response => response.data)
       .catch(response => {
         logger.error('Failed to fetch kubernetes namespaces – the API might be down. Try again later.');
+        return $q.reject(response);
+      });
+  }
+
+  function publishCostsReport(id) {
+    if (_.isNull(id) || _.isEmpty(id)) {
+      throw new Error('"id" argument not specified or empty');
+    }
+
+    return $http
+      .post(`${apiEndpoint}/costs_reports/${id}/publish`, {})
+      .then(handle4xxError)
+      .catch(response => {
+        logger.error(buildErrorMessageFromResponse('Failed to publish report', response));
         return $q.reject(response);
       });
   }

--- a/platform-hub-web/src/app/shared/model/costs-reports.js
+++ b/platform-hub-web/src/app/shared/model/costs-reports.js
@@ -9,6 +9,7 @@ export const CostsReports = function (hubApiService) {
   model.prepare = hubApiService.prepareCostsReport;
   model.create = hubApiService.createCostsReport;
   model.delete = hubApiService.deleteCostsReport;
+  model.publish = hubApiService.publishCostsReport;
 
   return model;
 };


### PR DESCRIPTION
… before they get shown to projects.

Note: once published, a report cannot be edited, nor recreated via the reports form (though you can still explicitly delete it and recreate it in two separate steps, as a special case capability).