### PR TITLE
Web: fix namespaces tab visibility

### DIFF
--- a/platform-hub-web/src/app/projects/services/project-services-detail.html
+++ b/platform-hub-web/src/app/projects/services/project-services-detail.html
@@ -145,7 +145,7 @@
 
       <md-tab
         id="kube-namespaces-tab"
-        ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetesTokens)"
+        ng-if="$ctrl.isAdmin && $ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetesTokens)"
         md-on-select="$ctrl.loadKubernetesNamespaces()">
         <md-tab-label>Kube Namespaces</md-tab-label>
         <md-tab-body>


### PR DESCRIPTION
… only hub admins can view and manage these at the moment.

Note: the API was still returning a 403, so this is purely a UI fix.