### PR TITLE
Revamp the FAQ...

### DIFF
--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -70,6 +70,8 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
   'ngInject';
 
   $locationProvider.html5Mode(true);
+  $locationProvider.hashPrefix('!');
+
   $urlRouterProvider.otherwise('/');
 
   $stateProvider

--- a/platform-hub-web/src/app/help/faq/faq-entries.component.js
+++ b/platform-hub-web/src/app/help/faq/faq-entries.component.js
@@ -3,7 +3,7 @@ export const FaqEntriesComponent = {
   controller: FaqEntriesController
 };
 
-function FaqEntriesController(AppSettings, FeatureFlags, featureFlagKeys) {
+function FaqEntriesController(AppSettings, FeatureFlags, featureFlagKeys, icons) {
   'ngInject';
 
   const ctrl = this;
@@ -11,4 +11,5 @@ function FaqEntriesController(AppSettings, FeatureFlags, featureFlagKeys) {
   ctrl.AppSettings = AppSettings;
   ctrl.FeatureFlags = FeatureFlags;
   ctrl.featureFlagKeys = featureFlagKeys;
+  ctrl.linkIcon = icons.link;
 }

--- a/platform-hub-web/src/app/help/faq/faq-entries.html
+++ b/platform-hub-web/src/app/help/faq/faq-entries.html
@@ -1,35 +1,69 @@
 <div class="faq-entries">
 
-  <md-card>
+  <md-card id="what-is-this-hub">
     <md-card-title>
       <md-card-title-text>
-        <span class="md-title">What is the {{$ctrl.AppSettings.getAppTitle()}}?</span>
+        <span class="md-title" layout="row">
+          What is the {{$ctrl.AppSettings.getAppTitle()}}?
+          <span flex></span>
+          <a class="md-icon-button" ui-sref="{'#':'what-is-this-hub'}" target="_self"><md-icon ng-bind="$ctrl.linkIcon"></md-icon></a>
+        </span>
       </md-card-title-text>
     </md-card-title>
     <md-card-content>
       <p class="md-body-1">
-        A portal for users of the {{$ctrl.AppSettings.getPlatformName()}}, currently providing information about the platform, support request forms, and self-serve tools for onboarding on to services. With plans to provide more self-serve tools, docs, status and updates for the platform in one central place.
+        A portal for users of the {{$ctrl.AppSettings.getPlatformName()}}, currently providing information about the platform, links to docs and resources, support request forms and self-serve tools for onboarding and for managing projects (e.g. self serve of Kubernetes tokens). With plans to provide more tools, docs, status and updates for the platform in one central place.
       </p>
     </md-card-content>
   </md-card>
 
-  <md-card>
+  <md-card id="how-to-create-user-account">
     <md-card-title>
       <md-card-title-text>
-        <span class="md-title">How do I create a user account on the hub?</span>
+        <span class="md-title" layout="row">
+          How do I create a user account on the Hub?
+          <span flex></span>
+          <a class="md-icon-button" ui-sref="{'#':'how-to-create-user-account'}" target="_self"><md-icon ng-bind="$ctrl.linkIcon"></md-icon></a>
+        </span>
       </md-card-title-text>
     </md-card-title>
     <md-card-content>
       <p class="md-body-1">
-        Login <em>(Sidebar > Login)</em> using Keycloak and a new account will be created for you on the hub
+        Login <em>(Sidebar > Login)</em> using your single sign-on account (SSO) through Keycloak and a new account will be created for you on the Hub
       </p>
     </md-card-content>
   </md-card>
 
-  <md-card>
+  <md-card id="how-to-find-stuff-and-request-support">
     <md-card-title>
       <md-card-title-text>
-        <span class="md-title">What can I do on the hub?</span>
+        <span class="md-title" layout="row">
+          How can I find the links to docs and resources, and how do I request support?
+          <span flex></span>
+          <a class="md-icon-button" ui-sref="{'#':'how-to-find-stuff-and-request-support'}" target="_self"><md-icon ng-bind="$ctrl.linkIcon"></md-icon></a>
+        </span>
+      </md-card-title-text>
+    </md-card-title>
+    <md-card-content>
+      <p class="md-body-1">
+        Both the <a ui-sref="home">homepage</a> and the side nav bar contain <em>platform themes</em> – these are related groups of information, and links to docs and resources, that you may find useful when navigating the platform and figuring out how to perform certain tasks.
+      </p>
+
+      <p class="md-body-1">
+        If you can't achieve what you need via these links or self-serve on the Hub (see FAQs below for more on self-serve) then you can request support from the {{$ctrl.AppSettings.getPlatformName()}} team by filling in
+        <a ui-sref="help.support.requests.overview">one of the available support request forms</a>.
+      </p>
+    </md-card-content>
+  </md-card>
+
+  <md-card id="what-can-I-do-on-the-hub">
+    <md-card-title>
+      <md-card-title-text>
+        <span class="md-title" layout="row">
+          What can I do on the Hub?
+          <span flex></span>
+          <a class="md-icon-button" ui-sref="{'#':'what-can-I-do-on-the-hub'}" target="_self"><md-icon ng-bind="$ctrl.linkIcon"></md-icon></a>
+        </span>
       </md-card-title-text>
     </md-card-title>
     <md-card-content>
@@ -45,7 +79,7 @@
                 <a ui-sref="terms-of-service">Agree to the Terms of Service</a>
               </li>
               <li>
-                <a ui-sref="onboarding.hub-setup">Configure your hub setup</a>
+                <a ui-sref="onboarding.hub-setup">Configure your Hub setup</a>
               </li>
               <li>
                 <a ui-sref="onboarding.services">Onboard on to platform services</a>
@@ -53,16 +87,28 @@
             </ul>
           </li>
           <li>
-            You can <a ui-sref="identities">manage your connected identities and any relevant auth info (e.g: GitHub, Kubernetes)</a>
+            You can <a ui-sref="identities">manage your connected identities and view any relevant auth info</a> (e.g: Github, Kubernetes)
+
+            <ul ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetesTokens)">
+              <li>
+                E.g. here you can find Kubernetes tokens you have been granted by your project(s)
+              </li>
+            </ul>
           </li>
           <li>
             You can <a ui-sref="announcements.global">view global announcements about the platform</a>
           </li>
           <li>
-            You can view information and resources about the various platform <em>themes</em> from the sidebar or <a ui-sref="home">homepage</a>
+            You can view information and resources about the various <em>platform themes</em> from the sidebar or <a ui-sref="home">homepage</a>
           </li>
           <li ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.projects)">
-            You can <a ui-sref="projects.list">view projects and team members</a>
+            You can <a ui-sref="projects.list">view projects and their team members</a>
+
+            <ul>
+              <li>
+                If you are a member of a project, you can also view all of its services and associated resources (e.g. Kubernetes robot tokens for a particular service within that project)
+              </li>
+            </ul>
           </li>
           <li>
             You can <a ui-sref="help.support.requests.overview">make a support request</a>
@@ -70,65 +116,76 @@
         </ul>
 
         <p ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.projects)">
-          If you are made a project admin, you can:
+          If you have been made a <strong>project admin</strong> you can:
         </p>
         <ul ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.projects)">
           <li>
-            Add someone to your project team (on the project page)
+            Add someone to your project team (on the main project page).
           </li>
           <li>
-            Remove a team member from your project (using the <em>Actions</em> button next to a team member, on the project page)
+            Remove a team member from your project (using the <em>Actions</em> button next to a team member, on the project page).
           </li>
           <li>
-            Onboard and offboard team members on GitHub (using the <em>Actions</em> button next to a team member, on the project page). <strong>Note:</strong> you can only do this for users that have connected up their GitHub identity within the hub.
+            Onboard and offboard team members on Github (using the <em>Actions</em> button next to a team member, on the project page). <strong>Note:</strong> you can only do this for users that have connected up their Github identity within the Hub.
+          </li>
+          <li>
+            Manage the <em>services</em> that are being developed in your project (via the Services tab on your project page).
+
+            <ul>
+              <li>
+                Project services are a way of grouping and breaking up your project into smaller sub-projects / deliverables / components / apps etc. Most resources provided by the platform are scoped to, and associated with, a particular service in your project (e.g. Kubernetes robot tokens).
+              </li>
+            </ul>
+          </li>
+          <li>
+            Manage Kubernetes user tokens for team members.
+          </li>
+          <li>
+            Manage Kubernetes robot tokens for CI builds and deploys (on the project service page that you can drill down to from the services list of your project).
+          </li>
+          <li>
+            View the monthly costs for your project (via the "Bills" tab on the project page).
           </li>
         </ul>
       </div>
     </md-card-content>
   </md-card>
 
-  <md-card ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.projects)">
+  <md-card id="why-cant-I-create-projects-etc" ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.projects)">
     <md-card-title>
       <md-card-title-text>
-        <span class="md-title">Why can't I create new projects or perform certain actions?</span>
+        <span class="md-title" layout="row">
+          Why can't I create new projects or perform certain actions on the Hub?
+          <span flex></span>
+          <a class="md-icon-button" ui-sref="{'#':'why-cant-I-create-projects-etc'}" target="_self"><md-icon ng-bind="$ctrl.linkIcon"></md-icon></a>
+        </span>
       </md-card-title-text>
     </md-card-title>
     <md-card-content>
       <div class="md-body-1">
         <p>
-          You need to be granted specific permissions to be able to do certain things on the hub
+          You need to be granted specific permissions to be able to do certain things on the Hub:
         </p>
         <ul>
           <li>
-            <strong>Project admins</strong> can manage a project's team and onboard/offboard team members
+            <strong>Project admins</strong> can manage a project's team, onboard/offboard its team members and manage its services and Kubernetes user and robot tokens
           </li>
           <li>
-            <strong>Admins</strong> manage announcements, users, projects and much more on the hub and grant special permissions to others
+            <strong>Hub admins</strong> manage announcements, users, projects and much more on the Hub and grant special permissions to others
           </li>
         </ul>
       </div>
     </md-card-content>
   </md-card>
 
-  <md-card>
+  <md-card id="tips-n-tricks">
     <md-card-title>
       <md-card-title-text>
-        <span class="md-title">How do I request support?</span>
-      </md-card-title-text>
-    </md-card-title>
-    <md-card-content>
-      <p class="md-body-1">
-        If you can't achieve what you need via self-serve in the hub (see FAQs above) then you can
-        <a ui-sref="help.support.requests.overview">request support</a>
-        by filling in one of the available support request forms.
-      </p>
-    </md-card-content>
-  </md-card>
-
-  <md-card>
-    <md-card-title>
-      <md-card-title-text>
-        <span class="md-title">Tips &amp; Tricks</span>
+        <span class="md-title" layout="row">
+          Tips &amp; Tricks
+          <span flex></span>
+          <a class="md-icon-button" ui-sref="{'#':'tips-n-tricks'}" target="_self"><md-icon ng-bind="$ctrl.linkIcon"></md-icon></a>
+        </span>
       </md-card-title-text>
     </md-card-title>
     <md-card-content>

--- a/platform-hub-web/src/app/home/home.html
+++ b/platform-hub-web/src/app/home/home.html
@@ -23,34 +23,46 @@
       <br />
     </div>
 
-    <div
-      layout="row" layout-wrap layout-align="center center"
-      ng-if="$ctrl.isAuthenticated() && $ctrl.PlatformThemes.visible.length > 0">
-      <md-card
-        ng-repeat="t in $ctrl.PlatformThemes.visible track by t.id"
-        ui-sref="platform-themes.page({id: t.id})"
-        style="width: 250px; cursor: pointer;">
-        <div class="tinted-bar" md-colors="{background: '{{t.colour}}'}"></div>
-        <img
-          ng-src="{{t.image_url}}"
-          class="md-card-image"
-          alt="{{t.title}} icon" />
-        <md-card-title>
-          <md-card-title-text>
-            <span class="md-headline">{{t.title}}</span>
-          </md-card-title-text>
-        </md-card-title>
-        <md-card-content>
-          <p
-            class="md-body-1"
-            ng-bind-html='t.description | simpleFormat'>
-          </p>
-        </md-card-content>
-      </md-card>
-    </div>
+    <div ng-if="$ctrl.isAuthenticated()">
+      <div layout="row" layout-align="center center">
+        <md-button ui-sref="help.faq" class="md-primary md-raised">
+          View Frequently Asked Questions
+        </md-button>
+      </div>
 
-    <div ng-if="$ctrl.isAuthenticated()" layout="row" layout-align="center center">
-      <md-button ui-sref="help.faq" class="md-primary md-raised">View Frequently Asked Questions</md-button>
+      <br />
+      <md-divider></md-divider>
+      <br />
+
+      <div ng-if="$ctrl.PlatformThemes.visible.length > 0">
+
+        <h2 class="md-title text-center">Platform Themes</h2>
+
+        <div layout-wrap layout="row" layout-align="center center">
+          <md-card
+            ng-repeat="t in $ctrl.PlatformThemes.visible track by t.id"
+            ui-sref="platform-themes.page({id: t.id})"
+            style="width: 250px; cursor: pointer;">
+            <div class="tinted-bar" md-colors="{background: '{{t.colour}}'}"></div>
+            <img
+              ng-src="{{t.image_url}}"
+              class="md-card-image"
+              alt="{{t.title}} icon" />
+            <md-card-title>
+              <md-card-title-text>
+                <span class="md-headline">{{t.title}}</span>
+              </md-card-title-text>
+            </md-card-title>
+            <md-card-content>
+              <p
+                class="md-body-1"
+                ng-bind-html='t.description | simpleFormat'>
+              </p>
+            </md-card-content>
+          </md-card>
+        </div>
+
+      </div>
     </div>
 
   </md-content>

--- a/platform-hub-web/src/app/shared/icons.factory.js
+++ b/platform-hub-web/src/app/shared/icons.factory.js
@@ -19,6 +19,7 @@ export const icons = function () {
     kubernetesGroups: 'groups',
     kubernetesNamespaces: 'picture_in_picture_alt',
     kubernetesTokens: 'vpn_key',
+    link: 'link',
     markAllRead: 'drafts',
     menu: 'menu',
     platformThemes: 'lens',


### PR DESCRIPTION
- Added a new section on how to find links to docs and resources, and merged the support request section into this, making it more prominent towards the top.
- Added in new information on projects, services and self-serve of tokens.
- Reworded a few entries.
- Made each section linkable and added links to each.
- Moved the FAQ link on the homepage before the platform themes as it's likely to be more useful to first time users.
- BONUS: Improved layout + added title for platform themes on the homepage.