### PR TITLE
Web: revamped user experience for viewing your own Kubernetes tokens

### DIFF
--- a/platform-hub-web/src/app/app.scss
+++ b/platform-hub-web/src/app/app.scss
@@ -147,3 +147,9 @@ md-card,
     display: none;
   }
 }
+
+.kubernetes-identity-tokens {
+  md-list-item .md-secondary-container {
+    margin: inherit;
+  }
+}

--- a/platform-hub-web/src/app/shared/icons.factory.js
+++ b/platform-hub-web/src/app/shared/icons.factory.js
@@ -8,6 +8,7 @@ export const icons = function () {
     contactList: 'contacts',
     copy: 'content_copy',
     costsReports: 'attach_money',
+    escalateToken: 'security',
     externalLink: 'link',
     faq: 'question_answer',
     featureFlags: 'flag',

--- a/platform-hub-web/src/app/shared/identities/identities-list.component.js
+++ b/platform-hub-web/src/app/shared/identities/identities-list.component.js
@@ -8,7 +8,7 @@ export const IdentitiesListComponent = {
   controller: IdentitiesListController
 };
 
-function IdentitiesListController($mdDialog, Identities, Me, _, logger, hubApiService, FeatureFlags, featureFlagKeys, kubeConfigHelperPopupService) {
+function IdentitiesListController($mdDialog, Identities, Me, _, FeatureFlags, featureFlagKeys, kubernetesIdentityTokensPopupService) {
   'ngInject';
 
   const ctrl = this;
@@ -19,12 +19,10 @@ function IdentitiesListController($mdDialog, Identities, Me, _, logger, hubApiSe
 
   ctrl.currentUserId = null;
   ctrl.userIdentities = {};
-  ctrl.showKubeTokens = false;
-  ctrl.kubernetesTokensByProject = {};
 
   ctrl.connect = connect;
   ctrl.disconnect = disconnect;
-  ctrl.openKubeConfigHelperPopup = openKubeConfigHelperPopup;
+  ctrl.showKubernetesTokens = showKubernetesTokens;
 
   init();
 
@@ -63,11 +61,6 @@ function IdentitiesListController($mdDialog, Identities, Me, _, logger, hubApiSe
               {connected: !_.isEmpty(match)}
             );
           });
-
-          const kubernetesIdentity = _.find(identities, ['provider', 'kubernetes']);
-          if (kubernetesIdentity && !_.isEmpty(kubernetesIdentity.kubernetes_tokens)) {
-            ctrl.kubernetesTokensByProject = _.groupBy(kubernetesIdentity.kubernetes_tokens, t => `Project: ${t.project.name} (${t.project.shortname})`);
-          }
         }
       })
       .finally(() => {
@@ -109,7 +102,7 @@ function IdentitiesListController($mdDialog, Identities, Me, _, logger, hubApiSe
       });
   }
 
-  function openKubeConfigHelperPopup(kubeId, token, targetEvent) {
-    return kubeConfigHelperPopupService.open(kubeId, token, targetEvent);
+  function showKubernetesTokens(identity, targetEvent) {
+    return kubernetesIdentityTokensPopupService.open(identity, targetEvent);
   }
 }

--- a/platform-hub-web/src/app/shared/identities/identities-list.html
+++ b/platform-hub-web/src/app/shared/identities/identities-list.html
@@ -46,7 +46,7 @@
     <md-list-item
       ng-switch-when="kubernetes"
       ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.kubernetesTokens)"
-      class="md-3-line md-long-text">
+      class="md-3-line">
 
       <md-icon ng-if="i.connected" md-colors="{color: 'teal'}">check_circle</md-icon>
 
@@ -57,70 +57,23 @@
           ID: {{i.external_id}}
         </p>
 
-        <p ng-if="i.kubernetes_tokens.length == 0">
-          No tokens currently available for you
+        <p ng-if="i.connected">
+          <ng-pluralize
+            count="i.kubernetes_tokens.length"
+            when="{
+              '0': 'No tokens available yet',
+              '1': '1 token ',
+              'other': '{} tokens'
+            }">
+          </ng-pluralize>
         </p>
-
-        <div ng-if="$ctrl.showKubeTokens">
-          <br />
-
-          <div ng-repeat="(label, tokens) in $ctrl.kubernetesTokensByProject track by label" class="separated-top">
-            <h5>{{label}}</h5>
-            <ul class="md-body-1">
-              <li ng-repeat="t in tokens">
-                <p>
-                  <span class="badge" md-colors="{background: 'accent-100'}" style="margin-left: 0">{{t.cluster.name}} cluster</span>
-                  <br />
-                  <kubernetes-token-value item="t"></kubernetes-token-value>
-                </p>
-
-                <ul>
-                  <li>
-                    <p>
-                      Groups:
-                      <span ng-if="!t.groups.length" class="none-text">
-                        no RBAC groups assigned to this token
-                      </span>
-                    </p>
-
-                    <ul ng-if="t.groups.length > 0">
-                      <li ng-repeat="g in t.groups" style="margin-bottom: 0.33em">
-                        <span class="inline-block badge" md-colors="{background: 'green-100'}" style="margin-left: 0">{{g}}</span>
-                      </li>
-                    </ul>
-                  </li>
-                  <li ng-if="t.expire_privileged_at">
-                    <p
-                      md-colors="{color: 'accent'}">
-                      <strong>Escalated privilege ends at:</strong>
-                      <br />
-                      {{t.expire_privileged_at | date:'EEE MMM d y HH:mm UTC':'UTC'}}
-                      (<span am-time-ago="t.expire_privileged_at"></span>)
-                    </p>
-                  </li>
-                  <li ng-if="t.cluster.api_url && t.cluster.ca_cert_encoded">
-                    <md-button
-                      class="md-raised"
-                      ng-click="$ctrl.openKubeConfigHelperPopup(i.external_id, t, $event)"
-                      aria-label="Help me set up my kube config to use this token">
-                      Set up Kube Config
-                    </md-button>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </div>
-
-        </div>
 
         <md-button class="md-secondary md-raised"
           ng-if="i.kubernetes_tokens.length > 0"
-          ng-click="$ctrl.showKubeTokens = !$ctrl.showKubeTokens"
-          aria-label="Show/Hide tokens">
-          <span ng-if="!$ctrl.showKubeTokens">Show tokens</span>
-          <span ng-if="$ctrl.showKubeTokens">Hide tokens</span>
+          ng-click="$ctrl.showKubernetesTokens(i, $event)"
+          aria-label="Show tokens for this Kubernetes identity">
+          Show tokens
         </md-button>
-
       </div>
 
     </md-list-item>

--- a/platform-hub-web/src/app/shared/kubernetes-identity-tokens-popup.controller.js
+++ b/platform-hub-web/src/app/shared/kubernetes-identity-tokens-popup.controller.js
@@ -1,0 +1,25 @@
+export const KubernetesIdentityTokensPopupController = function ($mdDialog, icons, kubeConfigHelperPopupService, identity, _) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.escalatedIcon = icons.escalateToken;
+  ctrl.identity = identity;
+
+  ctrl.tokensByProject = {};
+
+  ctrl.close = $mdDialog.hide;
+  ctrl.openKubeConfigHelperPopup = openKubeConfigHelperPopup;
+
+  init();
+
+  function init() {
+    if (!_.isEmpty(identity.kubernetes_tokens)) {
+      ctrl.tokensByProject = _.groupBy(identity.kubernetes_tokens, t => `Project: ${t.project.name} (${t.project.shortname})`);
+    }
+  }
+
+  function openKubeConfigHelperPopup(kubeId, token, targetEvent) {
+    return kubeConfigHelperPopupService.open(kubeId, token, targetEvent);
+  }
+};

--- a/platform-hub-web/src/app/shared/kubernetes-identity-tokens-popup.html
+++ b/platform-hub-web/src/app/shared/kubernetes-identity-tokens-popup.html
@@ -1,0 +1,81 @@
+<md-dialog aria-label="Kubernetes tokens" class="kubernetes-identity-tokens">
+  <md-toolbar class="md-toolbar-tools md-accent">
+    <h2>Kubernetes tokens for {{$ctrl.identity.external_id}}</h2>
+    <span flex></span>
+    <md-button
+      class="close-button md-icon-button"
+      ng-click="$ctrl.close()"
+      aria-label="Close dialog">
+      <md-icon>clear</md-icon>
+    </md-button>
+  </md-toolbar>
+
+  <md-dialog-content>
+    <md-list flex ng-repeat="(label, tokens) in $ctrl.tokensByProject track by label">
+      <md-subheader class="md-sticky">
+        {{label}}
+      </md-subheader>
+
+      <md-list-item
+        class="md-3-line md-long-text"
+        ng-repeat="t in tokens track by $index">
+        <md-icon
+          ng-if="t.expire_privileged_at"
+          md-colors="{color: 'default-accent'}"
+          ng-bind="$ctrl.escalatedIcon"
+          aria-label="This token has escalated privileges for a certain period of time">
+        </md-icon>
+
+        <div
+          class="md-list-item-text"
+          ng-class="{'md-offset': !t.expire_privileged_at}">
+
+          <h3
+            class="badge"
+            md-colors="{background: 'default-accent-100'}"
+            style="display: inline-block; margin-left: 0; margin-top: 1em;">
+            {{t.cluster.name}} cluster
+          </h3>
+
+          <h4>
+            <kubernetes-token-value item="t"></kubernetes-token-value>
+          </h4>
+
+          <p style="margin-bottom: 2em">
+            <span ng-if="t.expire_privileged_at" md-colors="{color: 'default-accent'}">
+              <strong>Escalated privilege ends at:</strong>
+              {{t.expire_privileged_at | date:'EEE MMM d y HH:mm UTC':'UTC'}}
+              (<span am-time-ago="t.expire_privileged_at"></span>)
+            </span>
+            <br ng-if="t.expire_privileged_at" />
+
+            <span ng-if="!t.groups.length" class="none-text">
+              No RBAC groups assigned to this token yet
+            </span>
+            <span class="md-body-1" ng-if="t.groups.length">
+              RBAC groups:
+              <br />
+              <span class="indented" ng-repeat="g in t.groups track by g">
+                {{g}}
+                <br ng-if="!$last"/>
+              </span>
+            </span>
+          </p>
+
+          <md-button
+            class="md-raised md-secondary"
+            ng-if="t.cluster.api_url && t.cluster.ca_cert_encoded"
+            ng-click="$ctrl.openKubeConfigHelperPopup($ctrl.identity.external_id, t, $event)"
+            aria-label="Help me set up my kube config to use this token">
+            Set up Kube Config
+          </md-button>
+
+          <md-divider></md-divider>
+
+        </div>
+      </md-list-item>
+
+      <br />
+    </md-list>
+  </md-dialog-content>
+</md-dialog>

--- a/platform-hub-web/src/app/shared/kubernetes-identity-tokens-popup.service.js
+++ b/platform-hub-web/src/app/shared/kubernetes-identity-tokens-popup.service.js
@@ -1,0 +1,24 @@
+export const kubernetesIdentityTokensPopupService = function ($document, $mdDialog) {
+  'ngInject';
+
+  const service = {};
+
+  service.open = open;
+
+  return service;
+
+  function open(identity, targetEvent) {
+    return $mdDialog.show({
+      template: require('./kubernetes-identity-tokens-popup.html'),
+      controller: 'KubernetesIdentityTokensPopupController',
+      controllerAs: '$ctrl',
+      parent: angular.element($document.body),
+      targetEvent: targetEvent,  // eslint-disable-line object-shorthand
+      clickOutsideToClose: false,
+      escapeToClose: false,
+      locals: {
+        identity
+      }
+    });
+  }
+};

--- a/platform-hub-web/src/app/shared/shared.module.js
+++ b/platform-hub-web/src/app/shared/shared.module.js
@@ -11,9 +11,11 @@ import {AllocationsListingComponent} from './allocations-listing.component';
 import {apiInterceptorService} from './api-interceptor.service';
 import {events} from './events.factory';
 import {homeEndpoints} from './home-endpoints.factory';
+import {icons} from './icons.factory';
 import {KubeConfigHelperPopupController} from './kube-config-helper-popup.controller';
 import {kubeConfigHelperPopupService} from './kube-config-helper-popup.service';
-import {icons} from './icons.factory';
+import {KubernetesIdentityTokensPopupController} from './kubernetes-identity-tokens-popup.controller';
+import {kubernetesIdentityTokensPopupService} from './kubernetes-identity-tokens-popup.service';
 import {KubernetesTokenValueComponent} from './kubernetes-token-value.component';
 import {onboardingTrigger} from './onboarding-trigger.factory';
 import {roleCheckerService} from './role-checker.service';
@@ -35,6 +37,8 @@ export const SharedModule = angular
   .factory('icons', icons)
   .controller('KubeConfigHelperPopupController', KubeConfigHelperPopupController)
   .service('kubeConfigHelperPopupService', kubeConfigHelperPopupService)
+  .controller('KubernetesIdentityTokensPopupController', KubernetesIdentityTokensPopupController)
+  .service('kubernetesIdentityTokensPopupService', kubernetesIdentityTokensPopupService)
   .factory('onboardingTrigger', onboardingTrigger)
   .service('roleCheckerService', roleCheckerService)
   .name;


### PR DESCRIPTION
The "Show tokens" button the Connected Identities page now pops open a dialogue, where you can view all your tokens, in a better and more user friendly layout.