### PR TITLE
Web: handle 404 responses from the API in a better way

### DIFF
--- a/platform-hub-web/src/app/app.run.js
+++ b/platform-hub-web/src/app/app.run.js
@@ -34,6 +34,12 @@ export const appRun = function ($q, $rootScope, $transitions, $state, authServic
     }
   });
 
+  // Listen for API resource not found event
+  const apiResourceNotFoundHandler = $rootScope.$on(events.api.resourceNotFound, () => {
+    logger.error('Not found');
+    $state.go('home');
+  });
+
   // Listen for auth unauthorized event
   const authUnauthorizedHandler = $rootScope.$on(events.auth.unauthorized, () => {
     logger.error('User unauthorized.');
@@ -56,6 +62,7 @@ export const appRun = function ($q, $rootScope, $transitions, $state, authServic
       });
   });
 
+  $rootScope.$on('$destroy', apiResourceNotFoundHandler);
   $rootScope.$on('$destroy', authDataHandler);
   $rootScope.$on('$destroy', authUnauthorizedHandler);
   $rootScope.$on('$destroy', authForbiddenHandler);

--- a/platform-hub-web/src/app/shared/api-interceptor.service.js
+++ b/platform-hub-web/src/app/shared/api-interceptor.service.js
@@ -14,6 +14,9 @@ export const apiInterceptorService = function ($rootScope, events) {
     if (response.status === 403) {
       $rootScope.$broadcast(events.auth.forbidden, 'Access forbidden');
     }
+    if (response.status === 404) {
+      $rootScope.$broadcast(events.api.resourceNotFound, 'Not found');
+    }
     if (response.status === 418) {
       $rootScope.$broadcast(events.auth.deactivated, 'User deactivated');
     }

--- a/platform-hub-web/src/app/shared/events.factory.js
+++ b/platform-hub-web/src/app/shared/events.factory.js
@@ -2,11 +2,14 @@ export const events = function () {
   'ngInject';
 
   return {
+    api: {
+      resourceNotFound: 'api:resourceNotFound'
+    },
     auth: {
-      updated: 'auth:updated',
-      unauthorized: 'auth:unauthorized',
+      deactivated: 'auth:deactivated',
       forbidden: 'auth:forbidden',
-      deactivated: 'auth:deactivated'
+      unauthorized: 'auth:unauthorized',
+      updated: 'auth:updated'
     }
   };
 };

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -1,6 +1,6 @@
 /* eslint camelcase: 0, object-shorthand: 0 */
 
-export const hubApiService = function ($rootScope, $http, $q, logger, events, apiEndpoint, _) {
+export const hubApiService = function ($rootScope, $http, $q, logger, apiEndpoint, _) {
   'ngInject';
 
   const service = {};


### PR DESCRIPTION
Previously, we would still continue to load up the view/component, whereas now we redirect to the homepage on any 404 response from the API.