### PR TITLE
Backend: onboard/offboard to Github when deactivating a user

### DIFF
--- a/platform-hub-api/app/models/user.rb
+++ b/platform-hub-api/app/models/user.rb
@@ -45,6 +45,10 @@ class User < ApplicationRecord
     identity :keycloak
   end
 
+  def github_identity
+    identity :github
+  end
+
   def kubernetes_identity
     identity :kubernetes
   end

--- a/platform-hub-api/app/services/agents/git_hub_agent_service.rb
+++ b/platform-hub-api/app/services/agents/git_hub_agent_service.rb
@@ -28,7 +28,7 @@ module Agents
     private
 
     def with_identity user
-      identity = user.identity 'github'
+      identity = user.github_identity
 
       if identity.blank?
         raise Errors::IdentityMissing

--- a/platform-hub-api/app/services/support_request_formatter_service.rb
+++ b/platform-hub-api/app/services/support_request_formatter_service.rb
@@ -1,7 +1,7 @@
 module SupportRequestFormatterService
 
   def self.format template, data, user
-    identity = user.identity 'github'
+    identity = user.github_identity
 
     submitter_text = if identity
       "@#{identity.external_username}"

--- a/platform-hub-api/app/services/user_activation_service.rb
+++ b/platform-hub-api/app/services/user_activation_service.rb
@@ -1,14 +1,33 @@
 module UserActivationService
   extend Agents::KeycloakAgentInstance
+  extend Agents::GitHubAgentInstance
   extend self
 
   def activate! user
     keycloak_agent_service.activate_user(user)
+
+    if user.github_identity
+      begin
+        git_hub_agent_service.onboard_user user
+      rescue => e
+        logger.error "Failed to onboard to Github whilst activating user. Still continuing with activation. Exception type: #{e.class.name}. Message: #{e.message}"
+      end
+    end
+
     user.activate!
   end
 
   def deactivate! user
     keycloak_agent_service.deactivate_user(user)
+
+    if user.github_identity
+      begin
+        git_hub_agent_service.offboard_user user
+      rescue => e
+        logger.error "Failed to offboard from Github whilst deactivating user. Still continuing with deactivation. Exception type: #{e.class.name}. Message: #{e.message}"
+      end
+    end
+
     user.deactivate!
   end
 

--- a/platform-hub-api/spec/factories/identities.rb
+++ b/platform-hub-api/spec/factories/identities.rb
@@ -6,6 +6,9 @@ FactoryGirl.define do
       "github_#{n}"
     end
 
+    factory :github_identity do
+    end
+
     factory :kubernetes_identity do
       provider 'kubernetes'
     end

--- a/platform-hub-api/spec/services/agents/git_hub_agent_service_spec.rb
+++ b/platform-hub-api/spec/services/agents/git_hub_agent_service_spec.rb
@@ -28,7 +28,7 @@ describe Agents::GitHubAgentService, type: :service do
   describe '#onboard_user' do
     context 'when user does not have a connected GitHub identity' do
       before do
-        expect(user).to receive(:identity).with('github').and_return(nil)
+        expect(user).to receive(:github_identity).and_return(nil)
       end
 
       it 'should throw an IdentityMissing error' do
@@ -40,7 +40,7 @@ describe Agents::GitHubAgentService, type: :service do
 
     context 'when user has a connected GitHub identity' do
       before do
-        expect(user).to receive(:identity).with('github').and_return(github_identity)
+        expect(user).to receive(:github_identity).and_return(github_identity)
       end
 
       it 'should make the appropriate API client call' do
@@ -53,7 +53,7 @@ describe Agents::GitHubAgentService, type: :service do
   describe '#offboard_user' do
     context 'when user does not have a connected GitHub identity' do
       before do
-        expect(user).to receive(:identity).with('github').and_return(nil)
+        expect(user).to receive(:github_identity).and_return(nil)
       end
 
       it 'should throw an IdentityMissing error' do
@@ -65,7 +65,7 @@ describe Agents::GitHubAgentService, type: :service do
 
     context 'when user has a connected GitHub identity' do
       before do
-        expect(user).to receive(:identity).with('github').and_return(github_identity)
+        expect(user).to receive(:github_identity).and_return(github_identity)
       end
 
       it 'should make the appropriate API client call' do

--- a/platform-hub-api/spec/services/user_activation_service_spec.rb
+++ b/platform-hub-api/spec/services/user_activation_service_spec.rb
@@ -1,25 +1,72 @@
 require 'rails_helper'
 
 describe UserActivationService, type: :service do
-  let(:user) { double }
-  let(:keycloak_agent_service) { double }
+  let(:user) { create :user }
+  let(:keycloak_agent_service) { instance_double('Agents::KeycloakAgentService') }
+  let(:git_hub_agent_service) { instance_double('Agents::GitHubAgentService') }
 
   describe '.activate!' do
-    it 'activates user locally and in keycloak' do
+
+    before do
       expect(subject).to receive(:keycloak_agent_service) { keycloak_agent_service }
       expect(keycloak_agent_service).to receive(:activate_user).with(user)
-      expect(user).to receive(:activate!)
-      subject.activate! user
     end
+
+    context 'when user does not have a Github identity connected' do
+      it 'activates user locally and in keycloak' do
+        expect(subject).to receive(:git_hub_agent_service).never
+
+        expect(user).to receive(:activate!)
+        subject.activate! user
+      end
+    end
+
+    context 'when user has a Github identity connected' do
+      before do
+        create :github_identity, user: user
+      end
+
+      it 'activates the user locally and in keycloak, and attempts to onboard to Github' do
+        expect(subject).to receive(:git_hub_agent_service) { git_hub_agent_service }
+        expect(git_hub_agent_service).to receive(:onboard_user).with(user)
+
+        expect(user).to receive(:activate!)
+        subject.activate! user
+      end
+    end
+
   end
 
   describe '.deactivate!' do
-    it 'deactivates user locally and in keycloak' do
+
+    before do
       expect(subject).to receive(:keycloak_agent_service) { keycloak_agent_service }
       expect(keycloak_agent_service).to receive(:deactivate_user).with(user)
-      expect(user).to receive(:deactivate!)
-      subject.deactivate! user
     end
+
+    context 'when user does not have a Github identity connected' do
+      it 'deactivates user locally and in keycloak' do
+        expect(subject).to receive(:git_hub_agent_service).never
+
+        expect(user).to receive(:deactivate!)
+        subject.deactivate! user
+      end
+    end
+
+    context 'when user has a Github identity connected' do
+      before do
+        create :github_identity, user: user
+      end
+
+      it 'deactivates the user locally and in keycloak, and attempts to offboard from Github' do
+        expect(subject).to receive(:git_hub_agent_service) { git_hub_agent_service }
+        expect(git_hub_agent_service).to receive(:offboard_user).with(user)
+
+        expect(user).to receive(:deactivate!)
+        subject.deactivate! user
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
Note: this is a "non blocking" operation, in that if onboard/offboard fails for whatever reason then the activation/deactivation of the user still continues.