### PR TITLE
Web: refactor the huge `hubApiService`

### DIFF
--- a/platform-hub-web/src/app/app.module.js
+++ b/platform-hub-web/src/app/app.module.js
@@ -109,6 +109,7 @@ angular
   .module(name)
   .constant('apiEndpoint', apiEndpoint)
   .constant('apiBackoffTimeMs', 2000)
+  .constant('apiDefaultPerPage', 10)
   .constant('featureFlagKeys', {
     kubernetesTokens: 'kubernetes_tokens',
     kubernetesTokensEscalatePrivilege: 'kubernetes_tokens_escalate_privilege',

--- a/platform-hub-web/src/app/shared/hub-api/api-helpers.factory.js
+++ b/platform-hub-web/src/app/shared/hub-api/api-helpers.factory.js
@@ -1,0 +1,54 @@
+/* eslint camelcase: 0, object-shorthand: 0 */
+
+export const apiHelpers = function ($q, apiDefaultPerPage, _) {
+  'ngInject';
+
+  return {
+    buildErrorMessageFromResponse,
+    handle4xxError,
+    withPaginationParams,
+    handlePaginatedResponse
+  };
+
+  function buildErrorMessageFromResponse(prefix, response) {
+    const errorDetails = _.get(response.data, 'error.message');
+    let msg = prefix;
+    if (errorDetails) {
+      msg += `: ${errorDetails}`;
+    }
+    return msg;
+  }
+
+  function handle4xxError(response) {
+    // handle 4xx errors which are not handled by $http.post
+    if (response.status.toString().match(/4../)) {
+      return $q.reject(response);
+    }
+    return response;
+  }
+
+  function withPaginationParams(params, page) {
+    return _.merge(
+      params,
+      {
+        per_page: apiDefaultPerPage,
+        page: page
+      }
+    );
+  }
+
+  function handlePaginatedResponse(response) {
+    const items = response.data;
+
+    const headers = response.headers();
+
+    if (headers.total && headers['per-page']) {
+      items.pagination = {
+        total: parseInt(headers.total, 10),
+        perPage: parseInt(headers['per-page'], 10)
+      };
+    }
+
+    return items;
+  }
+};

--- a/platform-hub-web/src/app/shared/hub-api/api-request-builders.factory.js
+++ b/platform-hub-web/src/app/shared/hub-api/api-request-builders.factory.js
@@ -1,0 +1,314 @@
+export const apiRequestBuilders = function ($q, $http, apiEndpoint, apiHelpers, logger, _) {
+  'ngInject';
+
+  const buildErrorMessageFromResponse = apiHelpers.buildErrorMessageFromResponse;
+  const handle4xxError = apiHelpers.handle4xxError;
+  const withPaginationParams = apiHelpers.withPaginationParams;
+  const handlePaginatedResponse = apiHelpers.handlePaginatedResponse;
+
+  return {
+    buildSimpleFetcher,
+    buildSimplePoster,
+    buildSimpleUpdater,
+    buildCollectionFetcher,
+    buildSubCollectionFetcher,
+    buildSubSubCollectionFetcher,
+    buildResourceFetcher,
+    buildSubResourceFetcher,
+    buildSubSubResourceFetcher,
+    buildResourceCreator,
+    buildSubResourceCreator,
+    buildResourceUpdater,
+    buildSubResourceUpdater,
+    buildResourceDeletor,
+    buildSubResourceDeletor
+  };
+
+  function buildSimpleFetcher(path, errorDescriptor) {
+    return function () {
+      return $http
+        .get(`${apiEndpoint}/${path}`)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse(`Failed to fetch ${errorDescriptor}`, response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildSimplePoster(path, errorDescriptor) {
+    return function (data) {
+      if (_.isNull(data) || _.isEmpty(data)) {
+        throw new Error('"data" argument not specified or empty');
+      }
+
+      return $http
+        .post(`${apiEndpoint}/${path}`, data)
+        .then(handle4xxError)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse(`Failed to ${errorDescriptor}`, response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildSimpleUpdater(path, errorDescriptor) {
+    return function (data) {
+      if (_.isNull(data) || _.isEmpty(data)) {
+        throw new Error('"data" argument not specified or empty');
+      }
+
+      return $http
+        .put(`${apiEndpoint}/${path}`, data)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse(`Failed to update ${errorDescriptor}`, response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildCollectionFetcher(name) {
+    return function (page = 1) {
+      return $http
+        .get(`${apiEndpoint}/${name}`, {
+          params: withPaginationParams({}, page)
+        })
+        .then(handlePaginatedResponse)
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse('Failed to fetch items', response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildSubCollectionFetcher(parent, name) {
+    return function (parentId, page = 1) {
+      if (_.isNull(parentId) || _.isEmpty(parentId)) {
+        throw new Error('"parentId" argument not specified or empty');
+      }
+
+      return $http
+        .get(`${apiEndpoint}/${parent}/${parentId}/${name}`, {
+          params: withPaginationParams({}, page)
+        })
+        .then(handlePaginatedResponse)
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse(`Failed to fetch items`, response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildSubSubCollectionFetcher(parent, sub, subSub) {
+    return function (parentId, subId, page = 1) {
+      if (_.isNull(parentId) || _.isEmpty(parentId)) {
+        throw new Error('"parentId" argument not specified or empty');
+      }
+      if (_.isNull(subId) || _.isEmpty(subId)) {
+        throw new Error('"subId" argument not specified or empty');
+      }
+
+      return $http
+        .get(
+          `${apiEndpoint}/${parent}/${parentId}/${sub}/${subId}/${subSub}`, {
+            params: withPaginationParams({}, page)
+          }
+        )
+        .then(handlePaginatedResponse)
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse(`Failed to fetch items`, response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildResourceFetcher(resource) {
+    return function (id) {
+      if (_.isNull(id) || _.isEmpty(id)) {
+        throw new Error('"id" argument not specified or empty');
+      }
+
+      return $http
+        .get(`${apiEndpoint}/${resource}/${id}`)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse('Failed to fetch item', response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildSubResourceFetcher(parent, resource) {
+    return function (parentId, id) {
+      if (_.isNull(parentId) || _.isEmpty(parentId)) {
+        throw new Error('"parentId" argument not specified or empty');
+      }
+      if (_.isNull(id) || _.isEmpty(id)) {
+        throw new Error('"id" argument not specified or empty');
+      }
+
+      return $http
+        .get(`${apiEndpoint}/${parent}/${parentId}/${resource}/${id}`)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse('Failed to fetch item', response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildSubSubResourceFetcher(parent, sub, subSub) {
+    return function (parentId, subId, subSubId) {
+      if (_.isNull(parentId) || _.isEmpty(parentId)) {
+        throw new Error('"parentId" argument not specified or empty');
+      }
+      if (_.isNull(subId) || _.isEmpty(subId)) {
+        throw new Error('"subId" argument not specified or empty');
+      }
+      if (_.isNull(subSubId) || _.isEmpty(subSubId)) {
+        throw new Error('"subSubId" argument not specified or empty');
+      }
+
+      return $http
+        .get(`${apiEndpoint}/${parent}/${parentId}/${sub}/${subId}/${subSub}/${subSubId}`)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse(`Failed to fetch item`, response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildResourceCreator(resource) {
+    return function (data) {
+      if (_.isNull(data) || _.isEmpty(data)) {
+        throw new Error('"data" argument not specified or empty');
+      }
+
+      return $http
+        .post(`${apiEndpoint}/${resource}`, data)
+        .then(handle4xxError)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse('Failed to create item', response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildSubResourceCreator(parent, resource) {
+    return function (parentId, data) {
+      if (_.isNull(parentId) || _.isEmpty(parentId)) {
+        throw new Error('"parentId" argument not specified or empty');
+      }
+      if (_.isNull(data) || _.isEmpty(data)) {
+        throw new Error('"data" argument not specified or empty');
+      }
+
+      return $http
+        .post(`${apiEndpoint}/${parent}/${parentId}/${resource}`, data)
+        .then(handle4xxError)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse('Failed to create item', response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildResourceUpdater(resource) {
+    return function (id, data) {
+      if (_.isNull(id) || _.isEmpty(id)) {
+        throw new Error('"id" argument not specified or empty');
+      }
+      if (_.isNull(data) || _.isEmpty(data)) {
+        throw new Error('"data" argument not specified or empty');
+      }
+
+      return $http
+        .put(`${apiEndpoint}/${resource}/${id}`, data)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse('Failed to update item', response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildSubResourceUpdater(parent, resource) {
+    return function (parentId, id, data) {
+      if (_.isNull(parentId) || _.isEmpty(parentId)) {
+        throw new Error('"parentId" argument not specified or empty');
+      }
+      if (_.isNull(id) || _.isEmpty(id)) {
+        throw new Error('"id" argument not specified or empty');
+      }
+      if (_.isNull(data) || _.isEmpty(data)) {
+        throw new Error('"data" argument not specified or empty');
+      }
+
+      return $http
+        .put(`${apiEndpoint}/${parent}/${parentId}/${resource}/${id}`, data)
+        .then(response => {
+          return response.data;
+        })
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse('Failed to update item', response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildResourceDeletor(resource) {
+    return function (id) {
+      if (_.isNull(id) || _.isEmpty(id)) {
+        throw new Error('"id" argument not specified or empty');
+      }
+
+      return $http
+        .delete(`${apiEndpoint}/${resource}/${id}`)
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse('Failed to delete item', response));
+          return $q.reject(response);
+        });
+    };
+  }
+
+  function buildSubResourceDeletor(parent, resource) {
+    return function (parentId, id) {
+      if (_.isNull(parentId) || _.isEmpty(parentId)) {
+        throw new Error('"parentId" argument not specified or empty');
+      }
+      if (_.isNull(id) || _.isEmpty(id)) {
+        throw new Error('"id" argument not specified or empty');
+      }
+
+      return $http
+        .delete(`${apiEndpoint}/${parent}/${parentId}/${resource}/${id}`)
+        .catch(response => {
+          logger.error(buildErrorMessageFromResponse('Failed to delete item', response));
+          return $q.reject(response);
+        });
+    };
+  }
+};

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.module.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.module.js
@@ -1,8 +1,12 @@
 import angular from 'angular';
 
+import {apiHelpers} from './api-helpers.factory';
+import {apiRequestBuilders} from './api-request-builders.factory';
 import {hubApiService} from './hub-api.service';
 
 export const HubApiModule = angular
   .module('app.shared.hubApi', [])
+  .factory('apiHelpers', apiHelpers)
+  .factory('apiRequestBuilders', apiRequestBuilders)
   .service('hubApiService', hubApiService)
   .name;


### PR DESCRIPTION
- Moved all general API helpers into a separate `apiHelpers` service.
- Added a new `withPaginationParams` helper as part of this, to DRY up how pagination params are provided to API calls.
- Made the default "per page" value an app global constant.
- Moved all the request builders into a separate `apiRequestBuilders` service.