### PR TITLE
Web: allow `per_page` override on certain views

### DIFF
--- a/platform-hub-web/src/app/app.module.js
+++ b/platform-hub-web/src/app/app.module.js
@@ -109,7 +109,6 @@ angular
   .module(name)
   .constant('apiEndpoint', apiEndpoint)
   .constant('apiBackoffTimeMs', 2000)
-  .constant('apiDefaultPerPage', 10)
   .constant('featureFlagKeys', {
     kubernetesTokens: 'kubernetes_tokens',
     kubernetesTokensEscalatePrivilege: 'kubernetes_tokens_escalate_privilege',

--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -195,7 +195,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         template: '<ui-view></ui-view>'
       })
         .state('kubernetes.groups.list', {
-          url: '/list',
+          url: '/list?per_page',
           component: KubernetesGroupsList,
           data: {
             authenticate: true,
@@ -242,7 +242,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         template: '<ui-view></ui-view>'
       })
         .state('kubernetes.namespaces.list', {
-          url: '/list/:cluster',
+          url: '/list/:cluster?per_page',
           component: KubernetesNamespacesList,
           data: {
             authenticate: true,
@@ -344,7 +344,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         template: '<ui-view></ui-view>'
       })
         .state('kubernetes.robot-tokens.list', {
-          url: '/list/:cluster',
+          url: '/list/:cluster?per_page',
           component: KubernetesRobotTokensList,
           data: {
             authenticate: true,
@@ -473,7 +473,7 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           }
         })
     .state('users', {
-      url: '/users',
+      url: '/users?per_page',
       component: UsersList,
       data: {
         authenticate: true,

--- a/platform-hub-web/src/app/app.run.js
+++ b/platform-hub-web/src/app/app.run.js
@@ -1,4 +1,4 @@
-export const appRun = function ($q, $rootScope, $transitions, $state, authService, loginDialogService, roleCheckerService, events, AppSettings, Me, FeatureFlags, logger, _) {
+export const appRun = function ($q, $rootScope, $transitions, $state, authService, loginDialogService, roleCheckerService, events, apiPagination, AppSettings, Me, FeatureFlags, logger, _) {
   'ngInject';
 
   logger.debug('Starting app…');
@@ -116,7 +116,17 @@ export const appRun = function ($q, $rootScope, $transitions, $state, authServic
       .catch(reject);
   }
 
+  function handlePerPageParam(params) {
+    if (_.has(params, 'per_page')) {
+      apiPagination.setPerPage(parseInt(params.per_page, 10));
+    } else {
+      apiPagination.resetPerPage();
+    }
+  }
+
   $transitions.onStart({}, transition => {
+    handlePerPageParam(transition.params());
+
     const config = transition.$to().data;
 
     const shouldAuthenticate = Boolean(config.authenticate);

--- a/platform-hub-web/src/app/shared/hub-api/api-helpers.factory.js
+++ b/platform-hub-web/src/app/shared/hub-api/api-helpers.factory.js
@@ -1,13 +1,9 @@
-/* eslint camelcase: 0, object-shorthand: 0 */
-
-export const apiHelpers = function ($q, apiDefaultPerPage, _) {
+export const apiHelpers = function ($q, _) {
   'ngInject';
 
   return {
     buildErrorMessageFromResponse,
-    handle4xxError,
-    withPaginationParams,
-    handlePaginatedResponse
+    handle4xxError
   };
 
   function buildErrorMessageFromResponse(prefix, response) {
@@ -25,34 +21,5 @@ export const apiHelpers = function ($q, apiDefaultPerPage, _) {
       return $q.reject(response);
     }
     return response;
-  }
-
-  function withPaginationParams(params, page) {
-    if (page) {
-      return _.merge(
-        params,
-        {
-          per_page: apiDefaultPerPage,
-          page: page
-        }
-      );
-    }
-
-    return params;
-  }
-
-  function handlePaginatedResponse(response) {
-    const items = response.data;
-
-    const headers = response.headers();
-
-    if (headers.total && headers['per-page']) {
-      items.pagination = {
-        total: parseInt(headers.total, 10),
-        perPage: parseInt(headers['per-page'], 10)
-      };
-    }
-
-    return items;
   }
 };

--- a/platform-hub-web/src/app/shared/hub-api/api-pagination.factory.js
+++ b/platform-hub-web/src/app/shared/hub-api/api-pagination.factory.js
@@ -1,0 +1,55 @@
+/* eslint camelcase: 0, object-shorthand: 0 */
+
+export const apiPagination = function (_) {
+  'ngInject';
+
+  const DEFAULT_PER_PAGE = 10;
+
+  let perPage;
+
+  resetPerPage();
+
+  return {
+    setPerPage,
+    resetPerPage,
+    withPaginationParams,
+    handlePaginatedResponse
+  };
+
+  function setPerPage(num) {
+    perPage = num;
+  }
+
+  function resetPerPage() {
+    perPage = DEFAULT_PER_PAGE;
+  }
+
+  function withPaginationParams(params, page) {
+    if (page) {
+      return _.merge(
+        params,
+        {
+          per_page: perPage,
+          page: page
+        }
+      );
+    }
+
+    return params;
+  }
+
+  function handlePaginatedResponse(response) {
+    const items = response.data;
+
+    const headers = response.headers();
+
+    if (headers.total && headers['per-page']) {
+      items.pagination = {
+        total: parseInt(headers.total, 10),
+        perPage: parseInt(headers['per-page'], 10)
+      };
+    }
+
+    return items;
+  }
+};

--- a/platform-hub-web/src/app/shared/hub-api/api-request-builders.factory.js
+++ b/platform-hub-web/src/app/shared/hub-api/api-request-builders.factory.js
@@ -1,10 +1,11 @@
-export const apiRequestBuilders = function ($q, $http, apiEndpoint, apiHelpers, logger, _) {
+export const apiRequestBuilders = function ($q, $http, apiEndpoint, apiHelpers, apiPagination, logger, _) {
   'ngInject';
 
   const buildErrorMessageFromResponse = apiHelpers.buildErrorMessageFromResponse;
   const handle4xxError = apiHelpers.handle4xxError;
-  const withPaginationParams = apiHelpers.withPaginationParams;
-  const handlePaginatedResponse = apiHelpers.handlePaginatedResponse;
+
+  const withPaginationParams = apiPagination.withPaginationParams;
+  const handlePaginatedResponse = apiPagination.handlePaginatedResponse;
 
   return {
     buildSimpleFetcher,

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.module.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.module.js
@@ -1,12 +1,14 @@
 import angular from 'angular';
 
 import {apiHelpers} from './api-helpers.factory';
+import {apiPagination} from './api-pagination.factory';
 import {apiRequestBuilders} from './api-request-builders.factory';
 import {hubApiService} from './hub-api.service';
 
 export const HubApiModule = angular
   .module('app.shared.hubApi', [])
   .factory('apiHelpers', apiHelpers)
+  .factory('apiPagination', apiPagination)
   .factory('apiRequestBuilders', apiRequestBuilders)
   .service('hubApiService', hubApiService)
   .name;

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -1,12 +1,13 @@
 /* eslint camelcase: 0, object-shorthand: 0 */
 
-export const hubApiService = function ($rootScope, $http, $q, logger, apiEndpoint, apiHelpers, apiRequestBuilders, _) {
+export const hubApiService = function ($rootScope, $http, $q, logger, apiEndpoint, apiHelpers, apiPagination, apiRequestBuilders, _) {
   'ngInject';
 
   const buildErrorMessageFromResponse = apiHelpers.buildErrorMessageFromResponse;
   const handle4xxError = apiHelpers.handle4xxError;
-  const withPaginationParams = apiHelpers.withPaginationParams;
-  const handlePaginatedResponse = apiHelpers.handlePaginatedResponse;
+
+  const withPaginationParams = apiPagination.withPaginationParams;
+  const handlePaginatedResponse = apiPagination.handlePaginatedResponse;
 
   const buildSimpleFetcher = apiRequestBuilders.buildSimpleFetcher;
   const buildSimplePoster = apiRequestBuilders.buildSimplePoster;


### PR DESCRIPTION
You can now control the number of items returned per page in certain views by adding the `per_page=XX` query parameter to the URL.

The following views support this:
- Users list
- Kube groups list
- Kube namespaces list
- Kube robot tokens list