### PR TITLE
Add `aws_region` to `KubernetesCluster` records

### DIFF
--- a/platform-hub-api/app/controllers/kubernetes/clusters_controller.rb
+++ b/platform-hub-api/app/controllers/kubernetes/clusters_controller.rb
@@ -109,6 +109,7 @@ class Kubernetes::ClustersController < ApiJsonController
       :name,
       :description,
       :aws_account_id,
+      :aws_region,
       :s3_region,
       :s3_bucket_name,
       :s3_access_key_id,

--- a/platform-hub-api/app/serializers/kubernetes_cluster_serializer.rb
+++ b/platform-hub-api/app/serializers/kubernetes_cluster_serializer.rb
@@ -5,6 +5,7 @@ class KubernetesClusterSerializer < BaseSerializer
   attributes :name, :description
 
   attribute :aws_account_id, if: :is_admin?
+  attribute :aws_region, if: :is_admin?
 
   attributes :api_url, :ca_cert_encoded
 

--- a/platform-hub-api/db/migrate/20180216141957_add_aws_region_to_kubernetes_cluster.rb
+++ b/platform-hub-api/db/migrate/20180216141957_add_aws_region_to_kubernetes_cluster.rb
@@ -1,0 +1,5 @@
+class AddAwsRegionToKubernetesCluster < ActiveRecord::Migration[5.0]
+  def change
+    add_column :kubernetes_clusters, :aws_region, :string
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -287,7 +287,8 @@ CREATE TABLE kubernetes_clusters (
     updated_at timestamp without time zone NOT NULL,
     aws_account_id bigint,
     api_url character varying,
-    ca_cert_encoded character varying
+    ca_cert_encoded character varying,
+    aws_region character varying
 );
 
 
@@ -1117,6 +1118,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171130163603'),
 ('20171201113437'),
 ('20171214165427'),
-('20171221143451');
+('20171221143451'),
+('20180216141957');
 
 

--- a/platform-hub-api/spec/controllers/kubernetes/clusters_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/clusters_controller_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
               'name' => @cluster.name,
               'description' => @cluster.description,
               'aws_account_id' => nil,
+              'aws_region' => nil,
               'api_url' => nil,
               'ca_cert_encoded' => nil
             })
@@ -107,6 +108,7 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
         name: 'foobar',
         description: 'foobar desc',
         aws_account_id: '123456789012',
+        aws_region: 'aws_region',
         s3_region: 's3_region',
         s3_bucket_name: 's3_bucket_name',
         s3_access_key_id: 's3_access_key_id',
@@ -147,6 +149,7 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
             'name' => post_data[:name],
             'description' => post_data[:description],
             'aws_account_id' => post_data[:aws_account_id].to_i,
+            'aws_region' => post_data[:aws_region],
             'api_url' => post_data[:api_url],
             'ca_cert_encoded' => post_data[:ca_cert_encoded]
           });

--- a/platform-hub-api/spec/controllers/kubernetes/namespaces_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/namespaces_controller_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Kubernetes::NamespacesController, type: :controller do
                 'name' => @namespace.cluster.name,
                 'description' => @namespace.cluster.description,
                 'aws_account_id' => @namespace.cluster.aws_account_id,
+                'aws_region' => @namespace.cluster.aws_region,
                 'api_url' => @namespace.cluster.api_url,
                 'ca_cert_encoded' => @namespace.cluster.ca_cert_encoded
               },
@@ -179,6 +180,7 @@ RSpec.describe Kubernetes::NamespacesController, type: :controller do
               'name' => post_data[:namespace][:cluster_name],
               'description' => namespace.cluster.description,
               'aws_account_id' => namespace.cluster.aws_account_id,
+              'aws_region' => namespace.cluster.aws_region,
               'api_url' => namespace.cluster.api_url,
               'ca_cert_encoded' => namespace.cluster.ca_cert_encoded
             },

--- a/platform-hub-api/spec/controllers/kubernetes/tokens_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/tokens_controller_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
                 'name' => @token.cluster.name,
                 'description' => @token.cluster.description,
                 'aws_account_id' => @token.cluster.aws_account_id,
+                'aws_region' => @token.cluster.aws_region,
                 'api_url' => @token.cluster.api_url,
                 'ca_cert_encoded' => @token.cluster.ca_cert_encoded
               },
@@ -193,6 +194,7 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
                 'name' => @token.cluster.name,
                 'description' => @token.cluster.description,
                 'aws_account_id' => @token.cluster.aws_account_id,
+                'aws_region' => @token.cluster.aws_region,
                 'api_url' => @token.cluster.api_url,
                 'ca_cert_encoded' => @token.cluster.ca_cert_encoded
               },
@@ -235,6 +237,7 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
                 'name' => @token.cluster.name,
                 'description' => @token.cluster.description,
                 'aws_account_id' => @token.cluster.aws_account_id,
+                'aws_region' => @token.cluster.aws_region,
                 'api_url' => @token.cluster.api_url,
                 'ca_cert_encoded' => @token.cluster.ca_cert_encoded
               },

--- a/platform-hub-api/spec/controllers/projects_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/projects_controller_spec.rb
@@ -1108,6 +1108,7 @@ RSpec.describe ProjectsController, type: :controller do
           'ca_cert_encoded' => token.cluster.ca_cert_encoded
         }
         cluster['aws_account_id'] = token.cluster.aws_account_id if is_admin
+        cluster['aws_region'] = token.cluster.aws_region if is_admin
 
         expect(json_response).to eq({
           'id' => token.id,

--- a/platform-hub-api/spec/controllers/services_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/services_controller_spec.rb
@@ -914,6 +914,7 @@ RSpec.describe ServicesController, type: :controller do
           'ca_cert_encoded' => token.cluster.ca_cert_encoded
         }
         cluster['aws_account_id'] = token.cluster.aws_account_id if is_admin
+        cluster['aws_region'] = token.cluster.aws_region if is_admin
 
         expect(json_response).to eq({
           'id' => token.id,
@@ -1265,6 +1266,7 @@ RSpec.describe ServicesController, type: :controller do
           'ca_cert_encoded' => token.cluster.ca_cert_encoded
         }
         cluster['aws_account_id'] = token.cluster.aws_account_id if is_admin
+        cluster['aws_region'] = token.cluster.aws_region if is_admin
 
         expect(json_response).to include({
           'id' => token.id,

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-detail.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-detail.html
@@ -50,6 +50,14 @@
                   <span ng-if="!$ctrl.cluster.aws_account_id" class="none-text">not set yet</span>
                 </p>
 
+                <p class="md-body-1">
+                  <span md-colors="{color: 'blue-grey-700'}">
+                    AWS region:
+                  </span>
+                  <span ng-if="$ctrl.cluster.aws_region">{{$ctrl.cluster.aws_region}}</span>
+                  <span ng-if="!$ctrl.cluster.aws_region" class="none-text">not set yet</span>
+                </p>
+
                 <md-divider></md-divider>
 
                 <p class="md-body-1">

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
@@ -53,6 +53,13 @@
             </div>
           </md-input-container>
 
+          <md-input-container class="md-block">
+            <label for="aws_region">AWS region:</label>
+            <input
+              name="aws_region"
+              ng-model="$ctrl.cluster.aws_region">
+          </md-input-container>
+
           <fieldset>
             <legend>For Kube config</legend>
 

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-list.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-list.html
@@ -41,6 +41,13 @@
         </p>
         <p class="md-body-1">
           <span md-colors="{color: 'blue-grey-700'}">
+            AWS region:
+          </span>
+          <span ng-if="c.aws_region">{{c.aws_region}}</span>
+          <span ng-if="!c.aws_region" class="none-text">not set yet</span>
+        </p>
+        <p class="md-body-1">
+          <span md-colors="{color: 'blue-grey-700'}">
             Kube API URL:
           </span>
           <span ng-if="c.api_url">{{c.api_url}}</span>


### PR DESCRIPTION
This allows us to support multiple Kubernetes clusters within the same AWS account ID, since we can now differentiate them by region. We'll be using this capability in upcoming costs reports work.