### PR TITLE
Add some uniqueness constraints for AWS account ID and region in Kubernetes clusters

### DIFF
--- a/platform-hub-api/app/models/kubernetes_cluster.rb
+++ b/platform-hub-api/app/models/kubernetes_cluster.rb
@@ -32,6 +32,25 @@ class KubernetesCluster < ApplicationRecord
     format: {
       with: AWS_ACCOUNT_ID_REGEX,
       message: "should be a number with 12 digits (ref: http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html)"
+    },
+    uniqueness: {
+      allow_nil: true,
+      scope: :aws_region,
+      message: "already has a cluster within the same region"
+    }
+
+  validates :aws_account_id,
+    presence: {
+      message: "can't be blank if AWS region is set"
+    },
+    if: ->(c) { c.aws_region.present? }
+
+  validates :aws_region,
+    allow_nil: true,
+    uniqueness: {
+      allow_nil: true,
+      scope: :aws_account_id,
+      message: "already has a cluster in the same AWS account"
     }
 
   has_many :tokens,

--- a/platform-hub-api/db/migrate/20180220175700_add_aws_account_and_region_unique_constraint_to_kubernetes_clusters.rb
+++ b/platform-hub-api/db/migrate/20180220175700_add_aws_account_and_region_unique_constraint_to_kubernetes_clusters.rb
@@ -1,0 +1,5 @@
+class AddAwsAccountAndRegionUniqueConstraintToKubernetesClusters < ActiveRecord::Migration[5.0]
+  def change
+    add_index :kubernetes_clusters, [ :aws_account_id, :aws_region ], unique: true
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -852,6 +852,13 @@ CREATE INDEX index_identities_on_user_id ON identities USING btree (user_id);
 
 
 --
+-- Name: index_kubernetes_clusters_on_aws_account_id_and_aws_region; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_kubernetes_clusters_on_aws_account_id_and_aws_region ON kubernetes_clusters USING btree (aws_account_id, aws_region);
+
+
+--
 -- Name: index_kubernetes_clusters_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1119,6 +1126,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171201113437'),
 ('20171214165427'),
 ('20171221143451'),
-('20180216141957');
+('20180216141957'),
+('20180220175700');
 
 

--- a/platform-hub-api/spec/models/kubernetes_cluster_spec.rb
+++ b/platform-hub-api/spec/models/kubernetes_cluster_spec.rb
@@ -28,6 +28,55 @@ RSpec.describe KubernetesCluster, type: :model do
     it { is_expected.not_to allow_value('1234567890123').for(:aws_account_id) }
     it { is_expected.not_to allow_value('A12345678901').for(:aws_account_id) }
     it { is_expected.not_to allow_value('A').for(:aws_account_id) }
+
+    it 'should be set if aws_region is set' do
+      c = build :kubernetes_cluster, aws_account_id: nil, aws_region: nil
+      expect(c.valid?).to be true
+
+      c = build :kubernetes_cluster, aws_account_id: 123456789012, aws_region: nil
+      expect(c.valid?).to be true
+
+      c = build :kubernetes_cluster, aws_account_id: nil, aws_region: 'foo'
+      expect(c.valid?).to be false
+      expect(c.errors[:aws_account_id]).to include("can't be blank if AWS region is set")
+    end
+  end
+
+  describe '#aws_account_id and #aws_region uniqueness' do
+    before do
+      create :kubernetes_cluster, aws_account_id: nil, aws_region: nil
+      create :kubernetes_cluster, aws_account_id: 123456789012, aws_region: nil
+      create :kubernetes_cluster, aws_account_id: 234567890123, aws_region: 'foo'
+      create :kubernetes_cluster, aws_account_id: 234567890123, aws_region: 'bar'
+    end
+
+    it 'should still allow multiple clusters with nil for these attributes' do
+      c = build :kubernetes_cluster, aws_account_id: nil, aws_region:  nil
+      expect(c.valid?).to be true
+      expect(c.save).to be true
+    end
+
+    it 'should only allow unique pairs of these attributes' do
+      c = build :kubernetes_cluster, aws_account_id: 123456789012, aws_region: nil
+      expect(c.valid?).to be false
+      expect(c.errors[:aws_account_id]).to include("already has a cluster within the same region")
+
+      c = build :kubernetes_cluster, aws_account_id: 123456789012, aws_region: 'foo'
+      expect(c.valid?).to be true
+      expect(c.save).to be true
+
+      c = build :kubernetes_cluster, aws_account_id: 234567890123, aws_region: nil
+      expect(c.valid?).to be true
+      expect(c.save).to be true
+
+      c = build :kubernetes_cluster, aws_account_id: 234567890123, aws_region: 'bar'
+      expect(c.valid?).to be false
+      expect(c.errors[:aws_account_id]).to include("already has a cluster within the same region")
+
+      c = build :kubernetes_cluster, aws_account_id: 234567890123, aws_region: 'new'
+      expect(c.valid?).to be true
+      expect(c.save).to be true
+    end
   end
 
 end

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
@@ -54,9 +54,10 @@
           </md-input-container>
 
           <md-input-container class="md-block">
-            <label for="aws_region">AWS region:</label>
+            <label for="aws_region">AWS region (can only be set if AWS account ID above is set):</label>
             <input
               name="aws_region"
+              ng-disabled="!$ctrl.cluster.aws_account_id"
               ng-model="$ctrl.cluster.aws_region">
           </md-input-container>
 


### PR DESCRIPTION
This ensures we only ever have one KubernetesCluster record per AWS account + region pair.