### PR TITLE
Add a `skip_sync` flag to KubernetesCluster records

### DIFF
--- a/platform-hub-api/app/controllers/kubernetes/clusters_controller.rb
+++ b/platform-hub-api/app/controllers/kubernetes/clusters_controller.rb
@@ -111,6 +111,7 @@ class Kubernetes::ClustersController < ApiJsonController
       :aws_account_id,
       :aws_region,
       :costs_bucket,
+      :skip_sync,
       :s3_region,
       :s3_bucket_name,
       :s3_access_key_id,

--- a/platform-hub-api/app/jobs/tokens_sync_job.rb
+++ b/platform-hub-api/app/jobs/tokens_sync_job.rb
@@ -11,7 +11,7 @@ class TokensSyncJob < ApplicationJob
       :kubernetes_tokens
     ])
 
-    KubernetesCluster.names.each do |cluster_name|
+    KubernetesCluster.syncable.names.each do |cluster_name|
       begin
         Kubernetes::TokenSyncService.sync_tokens(cluster_name)
 

--- a/platform-hub-api/app/models/kubernetes_cluster.rb
+++ b/platform-hub-api/app/models/kubernetes_cluster.rb
@@ -25,6 +25,8 @@ class KubernetesCluster < ApplicationRecord
     where(name: value.downcase).or(by_alias(value))
   }
 
+  scope :syncable, -> { where(skip_sync: false) }
+
   validates :name,
     format: {
       with: NAME_REGEX,
@@ -34,7 +36,9 @@ class KubernetesCluster < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   validates :description, :s3_region, :s3_bucket_name, :s3_object_key,
-            :s3_access_key_id, :s3_secret_access_key, presence: true
+            :s3_access_key_id, :s3_secret_access_key,
+            presence: true,
+            unless: :skip_sync
 
   validates :aws_account_id,
     allow_nil: true,

--- a/platform-hub-api/app/serializers/kubernetes_cluster_serializer.rb
+++ b/platform-hub-api/app/serializers/kubernetes_cluster_serializer.rb
@@ -9,6 +9,8 @@ class KubernetesClusterSerializer < BaseSerializer
 
   attribute :costs_bucket, if: :is_admin?
 
+  attribute :skip_sync, if: :is_admin?
+
   attributes :api_url, :ca_cert_encoded
 
 end

--- a/platform-hub-api/app/services/kubernetes/token_sync_service.rb
+++ b/platform-hub-api/app/services/kubernetes/token_sync_service.rb
@@ -12,6 +12,8 @@ module Kubernetes
       begin
         cluster = KubernetesCluster.friendly.find cluster_name
 
+        return if cluster.skip_sync
+
         body = Kubernetes::TokenFileService.generate(cluster_name)
         raise Errors::TokensFileBlank, 'Tokens file empty!' if body.blank?
 

--- a/platform-hub-api/db/migrate/20180406075539_add_skip_sync_to_kubernetes_cluster.rb
+++ b/platform-hub-api/db/migrate/20180406075539_add_skip_sync_to_kubernetes_cluster.rb
@@ -1,0 +1,5 @@
+class AddSkipSyncToKubernetesCluster < ActiveRecord::Migration[5.0]
+  def change
+    add_column :kubernetes_clusters, :skip_sync, :boolean, default: false
+  end
+end

--- a/platform-hub-api/db/migrate/20180406083658_remove_s3_bucket_fields_null_constraints_for_kubernetes_cluster.rb
+++ b/platform-hub-api/db/migrate/20180406083658_remove_s3_bucket_fields_null_constraints_for_kubernetes_cluster.rb
@@ -1,0 +1,9 @@
+class RemoveS3BucketFieldsNullConstraintsForKubernetesCluster < ActiveRecord::Migration[5.0]
+  def change
+    change_column :kubernetes_clusters, :s3_region, :string, null: true
+    change_column :kubernetes_clusters, :s3_bucket_name, :string, null: true
+    change_column :kubernetes_clusters, :s3_access_key_id, :string, null: true
+    change_column :kubernetes_clusters, :s3_secret_access_key, :string, null: true
+    change_column :kubernetes_clusters, :s3_object_key, :string, null: true
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -278,11 +278,11 @@ CREATE TABLE kubernetes_clusters (
     id uuid DEFAULT uuid_generate_v4() NOT NULL,
     name character varying NOT NULL,
     description text NOT NULL,
-    s3_region character varying NOT NULL,
-    s3_bucket_name character varying NOT NULL,
-    s3_access_key_id character varying NOT NULL,
-    s3_secret_access_key character varying NOT NULL,
-    s3_object_key character varying NOT NULL,
+    s3_region character varying,
+    s3_bucket_name character varying,
+    s3_access_key_id character varying,
+    s3_secret_access_key character varying,
+    s3_object_key character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     aws_account_id bigint,
@@ -290,7 +290,8 @@ CREATE TABLE kubernetes_clusters (
     ca_cert_encoded character varying,
     aws_region character varying,
     aliases character varying[] DEFAULT '{}'::character varying[],
-    costs_bucket character varying
+    costs_bucket character varying,
+    skip_sync boolean DEFAULT false
 );
 
 
@@ -1144,6 +1145,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180216141957'),
 ('20180221130735'),
 ('20180221145217'),
-('20180314151141');
+('20180314151141'),
+('20180406075539'),
+('20180406083658');
 
 

--- a/platform-hub-api/spec/controllers/kubernetes/clusters_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/clusters_controller_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
               'aws_account_id' => nil,
               'aws_region' => nil,
               'costs_bucket' => nil,
+              'skip_sync' => false,
               'api_url' => nil,
               'ca_cert_encoded' => nil
             })
@@ -113,6 +114,7 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
         aws_account_id: '123456789012',
         aws_region: 'aws_region',
         costs_bucket: 'Prod',
+        skip_sync: true,
         s3_region: 's3_region',
         s3_bucket_name: 's3_bucket_name',
         s3_access_key_id: 's3_access_key_id',
@@ -156,6 +158,7 @@ RSpec.describe Kubernetes::ClustersController, type: :controller do
             'aws_account_id' => post_data[:aws_account_id].to_i,
             'aws_region' => post_data[:aws_region],
             'costs_bucket' => post_data[:costs_bucket],
+            'skip_sync' => post_data[:skip_sync],
             'api_url' => post_data[:api_url],
             'ca_cert_encoded' => post_data[:ca_cert_encoded]
           });

--- a/platform-hub-api/spec/controllers/kubernetes/namespaces_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/namespaces_controller_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe Kubernetes::NamespacesController, type: :controller do
                 'aws_account_id' => @namespace.cluster.aws_account_id,
                 'aws_region' => @namespace.cluster.aws_region,
                 'costs_bucket' => @namespace.cluster.costs_bucket,
+                'skip_sync' => @namespace.cluster.skip_sync,
                 'api_url' => @namespace.cluster.api_url,
                 'ca_cert_encoded' => @namespace.cluster.ca_cert_encoded
               },
@@ -185,6 +186,7 @@ RSpec.describe Kubernetes::NamespacesController, type: :controller do
               'aws_account_id' => namespace.cluster.aws_account_id,
               'aws_region' => namespace.cluster.aws_region,
               'costs_bucket' => namespace.cluster.costs_bucket,
+              'skip_sync' => namespace.cluster.skip_sync,
               'api_url' => namespace.cluster.api_url,
               'ca_cert_encoded' => namespace.cluster.ca_cert_encoded
             },

--- a/platform-hub-api/spec/controllers/kubernetes/tokens_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/kubernetes/tokens_controller_spec.rb
@@ -160,6 +160,7 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
                 'aws_account_id' => @token.cluster.aws_account_id,
                 'aws_region' => @token.cluster.aws_region,
                 'costs_bucket' => @token.cluster.costs_bucket,
+                'skip_sync' => @token.cluster.skip_sync,
                 'api_url' => @token.cluster.api_url,
                 'ca_cert_encoded' => @token.cluster.ca_cert_encoded
               },
@@ -199,6 +200,7 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
                 'aws_account_id' => @token.cluster.aws_account_id,
                 'aws_region' => @token.cluster.aws_region,
                 'costs_bucket' => @token.cluster.costs_bucket,
+                'skip_sync' => @token.cluster.skip_sync,
                 'api_url' => @token.cluster.api_url,
                 'ca_cert_encoded' => @token.cluster.ca_cert_encoded
               },
@@ -244,6 +246,7 @@ RSpec.describe Kubernetes::TokensController, type: :controller do
                 'aws_account_id' => @token.cluster.aws_account_id,
                 'aws_region' => @token.cluster.aws_region,
                 'costs_bucket' => @token.cluster.costs_bucket,
+                'skip_sync' => @token.cluster.skip_sync,
                 'api_url' => @token.cluster.api_url,
                 'ca_cert_encoded' => @token.cluster.ca_cert_encoded
               },

--- a/platform-hub-api/spec/controllers/projects_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/projects_controller_spec.rb
@@ -1111,6 +1111,7 @@ RSpec.describe ProjectsController, type: :controller do
         cluster['aws_account_id'] = token.cluster.aws_account_id if is_admin
         cluster['aws_region'] = token.cluster.aws_region if is_admin
         cluster['costs_bucket'] = token.cluster.costs_bucket if is_admin
+        cluster['skip_sync'] = token.cluster.skip_sync if is_admin
 
         expect(json_response).to eq({
           'id' => token.id,

--- a/platform-hub-api/spec/controllers/services_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/services_controller_spec.rb
@@ -917,6 +917,7 @@ RSpec.describe ServicesController, type: :controller do
         cluster['aws_account_id'] = token.cluster.aws_account_id if is_admin
         cluster['aws_region'] = token.cluster.aws_region if is_admin
         cluster['costs_bucket'] = token.cluster.costs_bucket if is_admin
+        cluster['skip_sync'] = token.cluster.skip_sync if is_admin
 
         expect(json_response).to eq({
           'id' => token.id,
@@ -1271,6 +1272,7 @@ RSpec.describe ServicesController, type: :controller do
         cluster['aws_account_id'] = token.cluster.aws_account_id if is_admin
         cluster['aws_region'] = token.cluster.aws_region if is_admin
         cluster['costs_bucket'] = token.cluster.costs_bucket if is_admin
+        cluster['skip_sync'] = token.cluster.skip_sync if is_admin
 
         expect(json_response).to include({
           'id' => token.id,

--- a/platform-hub-api/spec/services/kubernetes/token_sync_service_spec.rb
+++ b/platform-hub-api/spec/services/kubernetes/token_sync_service_spec.rb
@@ -4,7 +4,7 @@ describe Kubernetes::TokenSyncService, type: :service do
 
   describe '.sync_tokens' do
     let(:cluster_name) { 'development' }
-    let(:cluster) { create(:kubernetes_cluster, name: cluster_name) }
+    let!(:cluster) { create(:kubernetes_cluster, name: cluster_name) }
     let(:s3_bucket) { double(:s3_bucket) }
     let(:tokens_file_content) { 'tokens file contenet in csv format' }
 
@@ -12,51 +12,70 @@ describe Kubernetes::TokenSyncService, type: :service do
       allow(subject).to receive(:s3_bucket).with(cluster) { s3_bucket }
     end
 
-    context 'when generated tokens file is blank' do
-      before do
-        expect(Kubernetes::TokenFileService).to receive(:generate).with(cluster_name) { '' }
+    context 'for a cluster with skip_sync set to false' do
+
+      context 'when generated tokens file is blank' do
+        before do
+          expect(Kubernetes::TokenFileService).to receive(:generate).with(cluster_name) { '' }
+        end
+
+        it 'raises an exception and does not perform sync' do
+          expect { subject.sync_tokens(cluster_name) }
+            .to raise_error(Kubernetes::TokenSyncService::Errors::TokensFileBlank, 'Tokens file empty!')
+        end
       end
 
-      it 'raises an exception and does not perform sync' do
-        expect { subject.sync_tokens(cluster_name) }
-          .to raise_error(Kubernetes::TokenSyncService::Errors::TokensFileBlank, 'Tokens file empty!')
+      context 'tokens file s3 object key not passed as option' do
+        before do
+          expect(Kubernetes::TokenFileService).to receive(:generate).with(cluster_name) { tokens_file_content }
+        end
+
+        it 'uploads tokens file to S3 using s3_object_key from cluster configuration' do
+          expect(s3_bucket).to receive(:put_object).with(
+            key: cluster.s3_object_key,
+            body: tokens_file_content,
+            server_side_encryption: 'aws:kms',
+            acl: 'private',
+          )
+
+          subject.sync_tokens(cluster_name)
+        end
       end
+
+      context 'token file s3 object key passed as option' do
+        let(:custom_object_key) { 'some/path/tokens.csv' }
+
+        before do
+          expect(Kubernetes::TokenFileService).to receive(:generate).with(cluster_name) { tokens_file_content }
+        end
+
+        it 'uploads tokens file to S3 using s3_object_key passed in options' do
+          expect(s3_bucket).to receive(:put_object).with(
+            key: custom_object_key,
+            body: tokens_file_content,
+            server_side_encryption: 'aws:kms',
+            acl: 'private',
+          )
+
+          subject.sync_tokens(cluster_name, s3_object_key: custom_object_key)
+        end
+      end
+
     end
 
-    context 'tokens file s3 object key not passed as option' do
+    context 'for a cluster with skip_sync set to true' do
+
       before do
-        expect(Kubernetes::TokenFileService).to receive(:generate).with(cluster_name) { tokens_file_content }
+        cluster.update! skip_sync: true
       end
 
-      it 'uploads tokens file to S3 using s3_object_key from cluster configuration' do
-        expect(s3_bucket).to receive(:put_object).with(
-          key: cluster.s3_object_key,
-          body: tokens_file_content,
-          server_side_encryption: 'aws:kms',
-          acl: 'private',
-        )
+      it 'should not do anything' do
+        expect(Kubernetes::TokenFileService).not_to receive(:generate)
+        expect(s3_bucket).not_to receive(:put_object)
 
         subject.sync_tokens(cluster_name)
       end
-    end
 
-    context 'token file s3 object key passed as option' do
-      let(:custom_object_key) { 'some/path/tokens.csv' }
-
-      before do
-        expect(Kubernetes::TokenFileService).to receive(:generate).with(cluster_name) { tokens_file_content }
-      end
-
-      it 'uploads tokens file to S3 using s3_object_key passed in options' do
-        expect(s3_bucket).to receive(:put_object).with(
-          key: custom_object_key,
-          body: tokens_file_content,
-          server_side_encryption: 'aws:kms',
-          acl: 'private',
-        )
-
-        subject.sync_tokens(cluster_name, s3_object_key: custom_object_key)
-      end
     end
   end
 

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-detail.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-detail.html
@@ -67,10 +67,17 @@
 
                 <p class="md-body-1">
                   <span md-colors="{color: 'blue-grey-700'}">
-                    Costs bucket::
+                    Costs bucket:
                   </span>
                   <span ng-if="$ctrl.cluster.costs_bucket">{{$ctrl.cluster.costs_bucket}}</span>
                   <span ng-if="!$ctrl.cluster.costs_bucket" class="none-text">not set yet</span>
+                </p>
+
+                <p class="md-body-1">
+                  <span md-colors="{color: 'blue-grey-700'}">
+                    Skip tokens sync?
+                  </span>
+                  <span>{{$ctrl.cluster.skip_sync}}</span>
                 </p>
 
                 <md-divider></md-divider>

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-form.html
@@ -76,7 +76,7 @@
           </md-input-container>
 
           <md-input-container class="md-block">
-            <label for="costs_bucket">Costs bucket::</label>
+            <label for="costs_bucket">Costs bucket:</label>
             <input
               name="costs_bucket"
               ng-model="$ctrl.cluster.costs_bucket">
@@ -108,7 +108,16 @@
           <br />
           <br />
 
-          <fieldset>
+          <md-input-container class="md-block">
+            <md-checkbox
+              name="skip_sync"
+              ng-model="$ctrl.cluster.skip_sync"
+              aria-label="Should we skip the tokens sync for this particular cluster?">
+              Skip tokens sync? (and potentially any other future syncing for this cluster)
+            </md-checkbox>
+          </md-input-container>
+
+          <fieldset ng-disabled="$ctrl.cluster.skip_sync">
             <legend>S3 bucket config for tokens sync</legend>
 
             <p
@@ -127,7 +136,7 @@
                 name="s3_region"
                 ng-model="$ctrl.cluster.s3_region"
                 placeholder="e.g.: eu-west-2"
-                ng-required="$ctrl.isNew">
+                ng-required="$ctrl.isNew && !$ctrl.cluster.skip_sync">
               <div ng-messages="$ctrl.clusterForm.s3_region.$error">
                 <div ng-message="required">This is required.</div>
               </div>
@@ -138,7 +147,7 @@
               <input
                 name="s3_bucket_name"
                 ng-model="$ctrl.cluster.s3_bucket_name"
-                ng-required="$ctrl.isNew">
+                ng-required="$ctrl.isNew && !$ctrl.cluster.skip_sync">
               <div ng-messages="$ctrl.clusterForm.s3_bucket_name.$error">
                 <div ng-message="required">This is required.</div>
               </div>
@@ -149,7 +158,7 @@
               <input
                 name="s3_access_key_id"
                 ng-model="$ctrl.cluster.s3_access_key_id"
-                ng-required="$ctrl.isNew">
+                ng-required="$ctrl.isNew && !$ctrl.cluster.skip_sync">
               <div ng-messages="$ctrl.clusterForm.s3_access_key_id.$error">
                 <div ng-message="required">This is required.</div>
               </div>
@@ -160,7 +169,7 @@
               <input
                 name="s3_secret_access_key"
                 ng-model="$ctrl.cluster.s3_secret_access_key"
-                ng-required="$ctrl.isNew">
+                ng-required="$ctrl.isNew && !$ctrl.cluster.skip_sync">
               <div ng-messages="$ctrl.clusterForm.s3_secret_access_key.$error">
                 <div ng-message="required">This is required.</div>
               </div>
@@ -172,7 +181,7 @@
                 name="s3_object_key"
                 ng-model="$ctrl.cluster.s3_object_key"
                 placeholder="path/to/tokens-file.csv"
-                ng-required="$ctrl.isNew">
+                ng-required="$ctrl.isNew && !$ctrl.cluster.skip_sync">
               <div ng-messages="$ctrl.clusterForm.s3_object_key.$error">
                 <div ng-message="required">This is required.</div>
               </div>

--- a/platform-hub-web/src/app/kubernetes/kubernetes-clusters-list.html
+++ b/platform-hub-web/src/app/kubernetes/kubernetes-clusters-list.html
@@ -54,10 +54,16 @@
         </p>
         <p class="md-body-1">
           <span md-colors="{color: 'blue-grey-700'}">
-            Costs bucket::
+            Costs bucket:
           </span>
           <span ng-if="c.costs_bucket">{{c.costs_bucket}}</span>
           <span ng-if="!c.costs_bucket" class="none-text">not set yet</span>
+        </p>
+        <p class="md-body-1">
+          <span md-colors="{color: 'blue-grey-700'}">
+            Skip tokens sync?
+          </span>
+          <span>{{c.skip_sync}}</span>
         </p>
         <p class="md-body-1">
           <span md-colors="{color: 'blue-grey-700'}">


### PR DESCRIPTION
This allows us to register clusters that we don't want to do tokens management for in the hub.