### PR TITLE
Costs reports: account for missing metrics

### DIFF
--- a/platform-hub-api/app/services/costs/project_bills_builder_service.rb
+++ b/platform-hub-api/app/services/costs/project_bills_builder_service.rb
@@ -42,6 +42,9 @@ module Costs
     #               from_shared_clusters: {
     #                 '<cluster_name>' => 0.0
     #               },
+    #               from_missing_metrics: {
+    #                 '<cluster_name>' => 0.0
+    #               },
     #               from_unmapped: 0.0,
     #               from_unknown: 0.0
     #             }
@@ -99,6 +102,11 @@ module Costs
 
     def add_shared_cluster_allocated_cost_for_service(project_id, service_id, date, cluster_name, amount)
       entry = get_service_entry(project_id, service_id, date)[:shared][:from_shared_clusters]
+      entry[cluster_name] += amount
+    end
+
+    def add_shared_missing_metrics_allocated_cost_for_service(project_id, service_id, date, cluster_name, amount)
+      entry = get_service_entry(project_id, service_id, date)[:shared][:from_missing_metrics]
       entry[cluster_name] += amount
     end
 
@@ -178,6 +186,7 @@ module Costs
         shared: {
           from_shared_projects: HashInitializer[:hash, :hash, 0.0],
           from_shared_clusters: HashInitializer[0.0],
+          from_missing_metrics: HashInitializer[0.0],
           from_unmapped: 0.0,
           from_unknown: 0.0
         }

--- a/platform-hub-api/app/services/costs/shared_costs_breakdown_builder_service.rb
+++ b/platform-hub-api/app/services/costs/shared_costs_breakdown_builder_service.rb
@@ -8,6 +8,7 @@ module Costs
         {
           from_shared_projects: HashInitializer[:hash, :hash, 0.0],
           from_shared_clusters: HashInitializer[0.0],
+          from_missing_metrics: HashInitializer[0.0],
           from_unmapped: 0.0,
           from_unknown: 0.0
         }
@@ -29,6 +30,10 @@ module Costs
 
     def add_cluster_cost(cluster_name, date, amount)
       @data[date][:from_shared_clusters][cluster_name] += amount
+    end
+
+    def add_missing_metrics_cost(cluster_name, date, amount)
+      @data[date][:from_missing_metrics][cluster_name] += amount
     end
 
     def add_unmapped_cost(date, amount)

--- a/platform-hub-web/src/app/shared/project-bill-breakdown-table.component.js
+++ b/platform-hub-web/src/app/shared/project-bill-breakdown-table.component.js
@@ -85,6 +85,12 @@ function ProjectBillBreakdownTableController(_) {
       summary.total += fromSharedClustersAmount;
       totals.total += fromSharedClustersAmount;
 
+      const fromMissingMetricsAmount = _.sum(_.values(s.shared.from_missing_metrics));
+      summary.shared += fromMissingMetricsAmount;
+      totals.shared += fromMissingMetricsAmount;
+      summary.total += fromMissingMetricsAmount;
+      totals.total += fromMissingMetricsAmount;
+
       _.each(s.shared.from_shared_projects, sharedProject => {
         const topLevelKnownResourcesAmount = _.get(sharedProject, 'top_level.known_resources') || 0.0;
         summary.shared += topLevelKnownResourcesAmount;


### PR DESCRIPTION
This accounts for missing metrics for an entire day and entire cluster - it will now allocate this previously missed cost into a new shared pot and distribute it out in the same way we distribute unknown and unmapped costs.