### PR TITLE
Web: fix object rollup

### DIFF
--- a/platform-hub-web/package.json
+++ b/platform-hub-web/package.json
@@ -34,7 +34,7 @@
     "angular-ui-router": "^1.0.3",
     "angular-url-encode": "^1.0.0",
     "bourbon": "^4.3.4",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "medium-editor": "^5.23.2",
     "moment": "^2.18.1",
     "ng-material-datetimepicker": "^1.6.3",

--- a/platform-hub-web/src/app/shared/util/object-rollup.service.js
+++ b/platform-hub-web/src/app/shared/util/object-rollup.service.js
@@ -8,15 +8,51 @@ export const objectRollupService = function (_) {
   return service;
 
   function rollup(obj, into) {
-    return _.mergeWith(_.cloneDeep(obj), _.cloneDeep(into), (objValue, srcValue) => {
-      if (_.isObject(objValue)) {
-        return rollup(srcValue, objValue);
-      } else if (_.isArray(objValue)) {
-        return objValue.concat(srcValue);
-      } else if (_.isString(objValue)) {
-        return objValue;
+    return _rollup(_.cloneDeep(obj), _.cloneDeep(into));
+  }
+
+  function _rollup(obj, into) {
+    return _.mergeWith(into, obj, (objValue, srcValue) => {
+      const [v1, v2] = reconcile(objValue, srcValue);
+
+      if (_.isPlainObject(v1)) {
+        return _rollup(v2, v1);
+      } else if (_.isArray(v1)) {
+        return v1.concat(v2);
+      } else if (_.isString(v1)) {
+        return v2;
       }
-      return objValue + srcValue;
+      return v1 + v2;
     });
+  }
+
+  function reconcile(objValue, srcValue) {
+    if (
+      (_.isUndefined(objValue) || _.isNull(objValue)) &&
+      (!_.isUndefined(srcValue) || !_.isNull(srcValue))
+    ) {
+      return [defaultValue(srcValue), srcValue];
+    } else if (
+      (!_.isUndefined(objValue) || !_.isNull(objValue)) &&
+      (_.isUndefined(srcValue) || _.isNull(srcValue))
+    ) {
+      return [objValue, defaultValue(objValue)];
+    }
+    return [objValue, srcValue];
+  }
+
+  function defaultValue(source) {
+    if (_.isPlainObject(source)) {
+      return {};
+    } else if (_.isArray(source)) {
+      return [];
+    } else if (_.isString(source)) {
+      return '';
+    } else if (_.isInteger(source)) {
+      return 0;
+    } else if (_.isNumber(source)) {
+      return 0.0;
+    }
+    return null;
   }
 };

--- a/platform-hub-web/src/app/shared/util/object-rollup.service.spec.js
+++ b/platform-hub-web/src/app/shared/util/object-rollup.service.spec.js
@@ -1,0 +1,108 @@
+import angular from 'angular';
+
+import 'angular-mocks';
+
+import {UtilModule} from './util.module';
+
+describe('objectRollupService', () => {
+  let service = null;
+
+  beforeEach(() => {
+    const moduleName = `${UtilModule}.objectRollupService.spec`;
+    angular.module(moduleName, ['app']);
+    angular.mock.module(moduleName);
+  });
+
+  beforeEach(angular.mock.inject(objectRollupService => {
+    service = objectRollupService;
+  }));
+
+  describe('rollup', () => {
+    describe('given two deep objects', () => {
+      const obj = {
+        a: 'a',
+        b: 5,
+        c: 0.5,
+        d: [1, 2],
+        e: {
+          ea: 'ea',
+          eb: 2,
+          ec: 1.2,
+          ed: [3],
+          ee: {
+            eea: 10,
+            eeb: {
+              eeba: {
+                eebaa: 4,
+                eebab: 'foo'
+              },
+              eebb: 0.6
+            }
+          }
+        },
+        f: 10,
+        g: [
+          {g0a: 1},
+          {g1a: 2}
+        ]
+      };
+
+      const into = {
+        a: '10',
+        b: 10,
+        c: 2.6,
+        d: [4],
+        e: {
+          ea: 'ea',
+          eb: 4,
+          ec: 2.1,
+          ed: ['ed'],
+          ee: {
+            eea: 2,
+            eeb: {
+              eeba: {
+                eebaa: 5
+              }
+            }
+          }
+        },
+        g: [
+          {g1a: 3}
+        ]
+      };
+
+      const expected = {
+        a: 'a',
+        b: 15,
+        c: 3.1,
+        d: [4, 1, 2],
+        e: {
+          ea: 'ea',
+          eb: 6,
+          ec: 3.3,
+          ed: ['ed', 3],
+          ee: {
+            eea: 12,
+            eeb: {
+              eeba: {
+                eebaa: 9,
+                eebab: 'foo'
+              },
+              eebb: 0.6
+            }
+          }
+        },
+        f: 10,
+        g: [
+          {g1a: 3},
+          {g0a: 1},
+          {g1a: 2}
+        ]
+      };
+
+      it('should return the expected rolled up object', () => {
+        expect(service.rollup(obj, into)).toEqual(expected);
+      });
+    });
+  });
+});

--- a/platform-hub-web/yarn.lock
+++ b/platform-hub-web/yarn.lock
@@ -4726,9 +4726,13 @@ lodash@^3.0.1, lodash@^3.10.1, lodash@^3.5.0, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 lodash@~0.9.1:
   version "0.9.2"


### PR DESCRIPTION
- Upgrade to latest lodash
- Avoid deep clones on every object branch (just do it once at the very beginning)
- Handle missing values
- Fix ordering of which object gets merged into which
- Fix String cases