### PR TITLE
Costs reports: finer grained allocation of clusters that host shared services

### DIFF
--- a/platform-hub-api/app/services/costs/project_bills_builder_service.rb
+++ b/platform-hub-api/app/services/costs/project_bills_builder_service.rb
@@ -39,9 +39,6 @@ module Costs
     #                   }
     #                 }
     #               },
-    #               from_shared_clusters: {
-    #                 '<cluster_name>' => <BigDecimal>
-    #               },
     #               from_missing_metrics: {
     #                 '<cluster_name>' => <BigDecimal>
     #               },
@@ -98,11 +95,6 @@ module Costs
     def add_allocated_known_resource_cost_from_shared_project_service_for_service(project_id, service_id, date, shared_project_id, shared_service_id, amount)
       entry = get_service_shared_project_service_entry(project_id, service_id, date, shared_project_id, shared_service_id)
       entry[:known_resources] += amount
-    end
-
-    def add_shared_cluster_allocated_cost_for_service(project_id, service_id, date, cluster_name, amount)
-      entry = get_service_entry(project_id, service_id, date)[:shared][:from_shared_clusters]
-      entry[cluster_name] += amount
     end
 
     def add_shared_missing_metrics_allocated_cost_for_service(project_id, service_id, date, cluster_name, amount)
@@ -185,7 +177,6 @@ module Costs
         cluster_groups: HashInitializer[:hash, BigDecimal('0')],
         shared: {
           from_shared_projects: HashInitializer[:hash, :hash, BigDecimal('0')],
-          from_shared_clusters: HashInitializer[BigDecimal('0')],
           from_missing_metrics: HashInitializer[BigDecimal('0')],
           from_unmapped: BigDecimal('0'),
           from_unknown: BigDecimal('0')

--- a/platform-hub-api/app/services/costs/shared_costs_breakdown_builder_service.rb
+++ b/platform-hub-api/app/services/costs/shared_costs_breakdown_builder_service.rb
@@ -7,7 +7,6 @@ module Costs
       @data = HashUtils.initialize_hash_with_keys_with_defaults(dates) do
         {
           from_shared_projects: HashInitializer[:hash, :hash, BigDecimal('0')],
-          from_shared_clusters: HashInitializer[BigDecimal('0')],
           from_missing_metrics: HashInitializer[BigDecimal('0')],
           from_unmapped: BigDecimal('0'),
           from_unknown: BigDecimal('0')
@@ -26,10 +25,6 @@ module Costs
     def add_project_known_resource_cost_for_service(project_id, service_id, date, amount)
       entry = get_service_entry(project_id, service_id, date)
       entry[:known_resources] += amount
-    end
-
-    def add_cluster_cost(cluster_name, date, amount)
-      @data[date][:from_shared_clusters][cluster_name] += amount
     end
 
     def add_missing_metrics_cost(cluster_name, date, amount)

--- a/platform-hub-web/src/app/costs-reports/costs-reports-form.component.js
+++ b/platform-hub-web/src/app/costs-reports/costs-reports-form.component.js
@@ -15,8 +15,6 @@ function CostsReportsFormController($state, CostsReports, treeDataHelper, logger
     'metrics_file'
   ];
 
-  const SHARED_BUCKET = 'Shared';
-
   const ctrl = this;
 
   ctrl.months = generateMonthsList();
@@ -87,10 +85,8 @@ function CostsReportsFormController($state, CostsReports, treeDataHelper, logger
   function initReportConfig() {
     ctrl.report.config = {
       metric_weights: {},
-      shared_costs: {
-        clusters: [],
-        projects: []
-      },
+      shared_projects: [],
+      cluster_groups_for_shared_services: [],
       cluster_groups: {},
       ui: {
         main_shared_services: []
@@ -143,7 +139,7 @@ function CostsReportsFormController($state, CostsReports, treeDataHelper, logger
         setAvailableServices();
         setMappedMetricsNamespacesCount();
         setAllClustersGrouped();
-        setConfigSharedClustersAndGroupedClusters();
+        setGroupedClusters();
       })
       .finally(() => {
         ctrl.preparing = false;
@@ -235,7 +231,7 @@ function CostsReportsFormController($state, CostsReports, treeDataHelper, logger
 
   function setAvailableSharedServices() {
     ctrl.availableSharedServices = _.filter(ctrl.availableServices, s => {
-      return _.includes(ctrl.report.config.shared_costs.projects, s.project_shortname);
+      return _.includes(ctrl.report.config.shared_projects, s.project_shortname);
     });
   }
 
@@ -254,19 +250,15 @@ function CostsReportsFormController($state, CostsReports, treeDataHelper, logger
     );
   }
 
-  function setConfigSharedClustersAndGroupedClusters() {
+  function setGroupedClusters() {
     if (ctrl.allMappedClustersGrouped) {
       const config = ctrl.report.config;
       _.values(ctrl.prepareResults.billing.clusters_and_namespaces.mapped).forEach(c => {
-        if (c.costs_bucket.toLowerCase() === SHARED_BUCKET.toLowerCase()) {
-          config.shared_costs.clusters.push(c.cluster_name);
-        } else {
-          if (!_.has(config.cluster_groups, c.costs_bucket)) {
-            config.cluster_groups[c.costs_bucket] = [];
-          }
-          if (!_.includes(config.cluster_groups[c.costs_bucket], c.cluster_name)) {
-            config.cluster_groups[c.costs_bucket].push(c.cluster_name);
-          }
+        if (!_.has(config.cluster_groups, c.costs_bucket)) {
+          config.cluster_groups[c.costs_bucket] = [];
+        }
+        if (!_.includes(config.cluster_groups[c.costs_bucket], c.cluster_name)) {
+          config.cluster_groups[c.costs_bucket].push(c.cluster_name);
         }
       });
     }

--- a/platform-hub-web/src/app/costs-reports/costs-reports-form.html
+++ b/platform-hub-web/src/app/costs-reports/costs-reports-form.html
@@ -239,7 +239,7 @@
 
                       <md-input-container class="md-block">
                         <md-select
-                          ng-model="$ctrl.report.config.shared_costs.projects"
+                          ng-model="$ctrl.report.config.shared_projects"
                           name="shared_projects"
                           multiple
                           ng-change="$ctrl.handleSharedProjectsChange()"
@@ -247,7 +247,7 @@
                           aria-label="Select mapped projects to consider as shared costs to other projects">
                           <md-option
                             ng-repeat="p in $ctrl.availableProjects track by p.project_shortname"
-                            value="{{p.project_shortname}}">
+                            ng-value="p.project_shortname">
                             {{p.project_shortname}}
                           </md-option>
                         </md-select>
@@ -257,7 +257,33 @@
                     <br />
 
                     <div>
-                      <h4>Step 3: configure UI / display</h4>
+                      <h4>Step 3: configure where shared services are hosted</h4>
+
+                      <br />
+
+                      <h5>Which cluster groups are used to actually <em>host</em> shared services?</h5>
+                      <small>The costs from these cluster groups will be shared across all projects.</small>
+
+                      <md-input-container class="md-block">
+                        <md-select
+                          ng-model="$ctrl.report.config.cluster_groups_for_shared_services"
+                          name="cluster_groups_for_shared_services"
+                          multiple
+                          ng-disabled="$ctrl.report.config.cluster_groups.length == 0"
+                          aria-label="Select the cluster groups that host shared services and thus have their costs split across all projects">
+                          <md-option
+                            ng-repeat="(group, clusters) in $ctrl.report.config.cluster_groups track by group"
+                            ng-value="group">
+                            {{group}} (clusters: {{clusters.join(', ')}})
+                          </md-option>
+                        </md-select>
+                      </md-input-container>
+                    </div>
+
+                    <br />
+
+                    <div>
+                      <h4>Step 4: configure UI / display</h4>
 
                       <br />
 
@@ -273,7 +299,7 @@
                           aria-label="Select the important shared project services that will be shown separately in the project bills">
                           <md-option
                             ng-repeat="s in $ctrl.availableSharedServices track by s.service_id"
-                            value="{{s.service_id}}">
+                            ng-value="s.service_id">
                             {{s.project_shortname}}: {{s.service_name}}
                           </md-option>
                         </md-select>
@@ -283,7 +309,7 @@
                     <br />
 
                     <div>
-                      <h4>Step 4: check projects with specific billing items</h4>
+                      <h4>Step 5: check projects with specific billing items</h4>
 
                       <br />
 
@@ -299,27 +325,15 @@
                     <br />
 
                     <div>
-                      <h4>Step 5: check the shared clusters and non-shared cluster groups</h4>
+                      <h4>Step 6: check the cluster groups</h4>
 
                       <p class="md-body-1">
                         Note: these were worked out using the 'costs bucket' value from each cluster in the hub.
-                        <br />
-                        Clusters with a costs bucket value of 'Shared' are treated specially here.
                       </p>
 
                       <br />
 
-                      <h5>The following clusters will be shared across projects:</h5>
-
-                      <div>
-                        <p class="indented" ng-repeat="c in $ctrl.report.config.shared_costs.clusters track by c">
-                          {{c}}
-                        </p>
-                      </div>
-
-                      <br />
-
-                      <h5>Of the remaining non-shared clusters these are the cluster groupings that will be used when distributing costs:</h5>
+                      <h5>These are the cluster groupings that will be used when distributing costs:</h5>
 
                       <div ng-repeat="(group, clusters) in $ctrl.report.config.cluster_groups track by group">
                         <p class="md-body-2">Cluster group: {{group}}</p>

--- a/platform-hub-web/src/app/shared/project-bill-breakdown.component.js
+++ b/platform-hub-web/src/app/shared/project-bill-breakdown.component.js
@@ -96,17 +96,6 @@ function ProjectBillBreakdownController(AppSettings, _) {
 
       // Shared
 
-      const fromSharedClustersAmount = _.sum(_.values(s.shared.from_shared_clusters));
-      summary.shared += fromSharedClustersAmount;
-      totals.shared += fromSharedClustersAmount;
-      summary.total += fromSharedClustersAmount;
-      totals.total += fromSharedClustersAmount;
-      // For shared table:
-      if (ix === 0) {
-        ctrl.sharedHeaders.push('Shared Clusters');
-      }
-      sharedAllocation.items.push(fromSharedClustersAmount);
-
       let allMiscSharedServicesTotal = 0;
 
       _.each(s.shared.from_shared_projects, sharedProject => {


### PR DESCRIPTION
With this change we no longer count "shared clusters" as a single "black box" cost – instead, we now share out the costs to the project services running within that cluster (mapped via namespaces) based on metrics usage and then distribute these across all projects _per_ shared service.

This gives a much more useful and accurate breakdown of the costs of shared services.