### PR TITLE
Backend: background job to ensure the help search index is ready

### DIFF
--- a/platform-hub-api/app/jobs/help_search_index_ensurer_job.rb
+++ b/platform-hub-api/app/jobs/help_search_index_ensurer_job.rb
@@ -1,0 +1,23 @@
+class HelpSearchIndexEnsurerJob < ApplicationJob
+  queue_as :help_search_index_ensurer
+
+  def self.is_already_queued?
+    Delayed::Job.where(queue: :help_search_index_ensurer).count > 0
+  end
+
+  def perform
+    if !index_exists || index_is_empty
+      HelpSearchService.instance.reindex_all force: true
+    end
+  end
+
+  private
+
+  def index_exists
+    HelpSearchService.instance.repository.index_exists?
+  end
+
+  def index_is_empty
+    HelpSearchService.instance.repository.count == 0
+  end
+end

--- a/platform-hub-api/app/services/help_search_index_ensurer_job_trigger_service.rb
+++ b/platform-hub-api/app/services/help_search_index_ensurer_job_trigger_service.rb
@@ -1,0 +1,12 @@
+module HelpSearchIndexEnsurerJobTriggerService
+  extend self
+
+  def trigger
+    if HelpSearchIndexEnsurerJob.is_already_queued?
+      Rails.logger.info 'Help search index ensurer job already in queue... will not trigger another one'
+    else
+      Rails.logger.info 'Triggering the help search index ensurer job'
+      HelpSearchIndexEnsurerJob.perform_later
+    end
+  end
+end

--- a/platform-hub-api/lib/tasks/help_search.rake
+++ b/platform-hub-api/lib/tasks/help_search.rake
@@ -1,0 +1,8 @@
+namespace :help_search do
+
+  desc "Trigger the help search index ensurer job if it's not already in the queue"
+  task trigger_index_ensurer_job: :environment do
+    HelpSearchIndexEnsurerJobTriggerService.trigger
+  end
+
+end


### PR DESCRIPTION
The provided trigger can be run continuously to add the job to the queue, which checks to see if either the index doesn't yet exist or it's empty, at which point it performs a full reindex.