### PR TITLE
Backend: allow passing in of a custom `INTERNAL_SERVICES_CA_FILE`

### DIFF
--- a/platform-hub-api/config/initializers/elasticsearch.rb
+++ b/platform-hub-api/config/initializers/elasticsearch.rb
@@ -1,4 +1,13 @@
-ELASTICSEARCH_CLIENT = Elasticsearch::Client.new(url: ENV.fetch('PHUB_ELASTICSEARCH_URL'))
+transport_options = if ENV.has_key?('INTERNAL_SERVICES_CA_FILE')
+  { ssl: { ca_file: ENV['INTERNAL_SERVICES_CA_FILE'] } }
+else
+  {}
+end
+
+ELASTICSEARCH_CLIENT = Elasticsearch::Client.new(
+  url: ENV.fetch('PHUB_ELASTICSEARCH_URL'),
+  transport_options: transport_options
+)
 
 if Rails.env.development?
   logger           = ActiveSupport::Logger.new(STDERR)


### PR DESCRIPTION
… which is currently only used for the ElasticSearch client.