### PR TITLE
Hub admins can manage sources for docs to index

### DIFF
--- a/platform-hub-api/app/controllers/docs_sources_controller.rb
+++ b/platform-hub-api/app/controllers/docs_sources_controller.rb
@@ -1,0 +1,86 @@
+class DocsSourcesController < ApiJsonController
+
+  before_action :find_docs_source, only: [ :show, :update, :destroy ]
+
+  authorize_resource
+
+  # GET /docs_sources
+  def index
+    @docs_sources = DocsSource.order(:name)
+
+    render json: @docs_sources
+  end
+
+  # GET /docs_sources/1
+  def show
+    render json: @docs_source
+  end
+
+  # POST /docs_sources
+  def create
+    @docs_source = DocsSource.new(docs_source_params)
+
+    if @docs_source.save
+      AuditService.log(
+        context: audit_context,
+        action: 'create',
+        auditable: @docs_source
+      )
+
+      render json: @docs_source, status: :created
+    else
+      render_model_errors @docs_source.errors
+    end
+  end
+
+  # PATCH/PUT /docs_sources/1
+  def update
+    if @docs_source.update(docs_source_params)
+      AuditService.log(
+        context: audit_context,
+        action: 'update',
+        auditable: @docs_source
+      )
+
+      render json: @docs_source
+    else
+      render_model_errors @docs_source.errors
+    end
+  end
+
+  # DELETE /docs_sources/1
+  def destroy
+    id = @docs_source.id
+    name = @docs_source.name
+
+    @docs_source.destroy
+
+    AuditService.log(
+      context: audit_context,
+      action: 'destroy',
+      auditable: @docs_source,
+      comment: "User '#{current_user.email}' deleted docs source: '#{name}' (ID: #{id})"
+    )
+
+    head :no_content
+  end
+
+  private
+
+  def find_docs_source
+    @docs_source = DocsSource.find params[:id]
+  end
+
+  # Only allow a trusted parameter "white list" through.
+  def docs_source_params
+    allowed_params = params.require(:docs_source).permit(:kind, :name)
+
+    # Below is a workaround until Rails 5.1 lands and we can use the `foo: {}` syntax to permit the whole hash
+    if params[:docs_source][:config]
+      allowed_params[:config] = params[:docs_source][:config]
+    end
+
+    allowed_params.permit!
+  end
+
+end

--- a/platform-hub-api/app/models/docs_source.rb
+++ b/platform-hub-api/app/models/docs_source.rb
@@ -1,0 +1,24 @@
+class DocsSource < ApplicationRecord
+
+  include Audited
+
+  audited descriptor_field: :name
+
+  enum kind: {
+    github_repo: 'github_repo',
+    gitlab_repo: 'gitlab_repo'
+  }
+
+  enum last_fetch_status: {
+    successful: 'successful',
+    failed: 'failed'
+  }
+
+  validates :kind, presence: true
+
+  validates :name, presence: true
+
+  validates :is_fetching,
+    inclusion: { in: [ true, false ] }
+
+end

--- a/platform-hub-api/app/serializers/docs_source_serializer.rb
+++ b/platform-hub-api/app/serializers/docs_source_serializer.rb
@@ -1,0 +1,15 @@
+class DocsSourceSerializer < ActiveModel::Serializer
+  attributes(
+    :id,
+    :kind,
+    :name,
+    :config,
+    :is_fetching,
+    :last_fetch_status,
+    :last_fetch_started_at,
+    :last_fetch_error,
+    :last_successful_fetch_started_at,
+    :created_at,
+    :updated_at
+  )
+end

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -153,6 +153,8 @@ Rails.application.routes.draw do
 
     get '/help/search', to: 'help#search', constraints: lambda { |_| FeatureFlagService.is_enabled? :help_search }
 
+    resources :docs_sources
+
   end
 
 end

--- a/platform-hub-api/db/migrate/20180810102606_create_docs_sources.rb
+++ b/platform-hub-api/db/migrate/20180810102606_create_docs_sources.rb
@@ -1,0 +1,16 @@
+class CreateDocsSources < ActiveRecord::Migration[5.0]
+  def change
+    create_table :docs_sources, id: :uuid do |t|
+      t.string :kind, null: false, index: true
+      t.string :name, null: false
+      t.json :config, null: false
+      t.boolean :is_fetching, null: false, default: false
+      t.string :last_fetch_status
+      t.datetime :last_fetch_started_at
+      t.string :last_fetch_error
+      t.datetime :last_successful_fetch_started_at
+
+      t.timestamps
+    end
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -240,6 +240,25 @@ ALTER SEQUENCE delayed_jobs_id_seq OWNED BY delayed_jobs.id;
 
 
 --
+-- Name: docs_sources; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE docs_sources (
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    kind character varying NOT NULL,
+    name character varying NOT NULL,
+    config json NOT NULL,
+    is_fetching boolean DEFAULT false NOT NULL,
+    last_fetch_status character varying,
+    last_fetch_started_at timestamp without time zone,
+    last_fetch_error character varying,
+    last_successful_fetch_started_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
 -- Name: hash_records; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -359,7 +378,7 @@ CREATE TABLE platform_themes (
     slug character varying NOT NULL,
     description text NOT NULL,
     image_url character varying NOT NULL,
-    colour character varying NOT NULL,
+    colour character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     resources json
@@ -401,9 +420,9 @@ CREATE TABLE projects (
 
 CREATE TABLE read_marks (
     id integer NOT NULL,
-    readable_type character varying,
+    readable_type character varying NOT NULL,
     readable_id uuid,
-    reader_type character varying,
+    reader_type character varying NOT NULL,
     reader_id uuid,
     "timestamp" timestamp without time zone
 );
@@ -585,6 +604,14 @@ ALTER TABLE ONLY costs_reports
 
 ALTER TABLE ONLY delayed_jobs
     ADD CONSTRAINT delayed_jobs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: docs_sources docs_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY docs_sources
+    ADD CONSTRAINT docs_sources_pkey PRIMARY KEY (id);
 
 
 --
@@ -838,6 +865,13 @@ CREATE INDEX index_audits_on_user_name ON audits USING btree (user_name);
 --
 
 CREATE INDEX index_delayed_jobs_on_queue ON delayed_jobs USING btree (queue);
+
+
+--
+-- Name: index_docs_sources_on_kind; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_docs_sources_on_kind ON docs_sources USING btree (kind);
 
 
 --
@@ -1170,6 +1204,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180406075539'),
 ('20180406083658'),
 ('20180711092801'),
-('20180718141143');
+('20180718141143'),
+('20180810102606');
 
 

--- a/platform-hub-api/spec/controllers/docs_sources_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/docs_sources_controller_spec.rb
@@ -1,0 +1,214 @@
+require 'rails_helper'
+
+RSpec.describe DocsSourcesController, type: :controller do
+
+  include_context 'time helpers'
+
+  describe 'GET #index' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        get :index
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          get :index
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        before do
+          @docs_sources = create_list :docs_source, 3
+        end
+
+        let :total_docs_sources do
+          @docs_sources.length
+        end
+
+        let :docs_source_ids do
+          @docs_sources.sort_by(&:name).map(&:id)
+        end
+
+        it 'should return a list of all docs sources' do
+          get :index
+          expect(response).to be_success
+          expect(json_response.length).to eq total_docs_sources
+          expect(pluck_from_json_response('id')).to eq docs_source_ids
+        end
+
+      end
+
+    end
+  end
+
+  describe 'GET #show' do
+    before do
+      @docs_source = create :docs_source
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        get :show, params: { id: @docs_source.id }
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          get :show, params: { id: @docs_source.id }
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        context 'for a non-existent docs source' do
+          it 'should return a 404' do
+            get :show, params: { id: 'unknown' }
+            expect(response).to have_http_status(404)
+          end
+        end
+
+        context 'for a docs source that exists' do
+          it 'should return the specified docs source resource' do
+            get :show, params: { id: @docs_source.id }
+            expect(response).to be_success
+            expect(json_response).to eq({
+              'id' => @docs_source.id,
+              'kind' => @docs_source.kind,
+              'name' => @docs_source.name,
+              'config' => Hashie::Mash.new(@docs_source.config),
+              'is_fetching' => @docs_source.is_fetching,
+              'last_fetch_status' => @docs_source.last_fetch_status,
+              'last_fetch_started_at' => @docs_source.last_fetch_started_at,
+              'last_fetch_error' => @docs_source.last_fetch_error,
+              'last_successful_fetch_started_at' => @docs_source.last_successful_fetch_started_at,
+              'created_at' => now_json_value,
+              'updated_at' => now_json_value,
+            })
+          end
+        end
+
+      end
+
+    end
+  end
+
+  describe 'POST #create' do
+    let :post_data do
+      source_data = build :docs_source
+
+      {
+        docs_source: {
+          kind: source_data.kind,
+          name: source_data.name,
+          config: source_data.config
+        }
+      }
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        post :create, params: post_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          post :create, params: post_data
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        it 'creates a new docs source as expected' do
+          expect(DocsSource.count).to eq 0
+          expect(Audit.count).to eq 0
+          post :create, params: post_data
+          expect(response).to be_success
+          expect(DocsSource.count).to eq 1
+          docs_source = DocsSource.first
+          expect(json_response).to eq({
+            'id' => docs_source.id,
+            'kind' => post_data[:docs_source][:kind],
+            'name' => post_data[:docs_source][:name],
+            'config' => Hashie::Mash.new(post_data[:docs_source][:config]),
+            'is_fetching' => docs_source.is_fetching,
+            'last_fetch_status' => docs_source.last_fetch_status,
+            'last_fetch_started_at' => docs_source.last_fetch_started_at,
+            'last_fetch_error' => docs_source.last_fetch_error,
+            'last_successful_fetch_started_at' => docs_source.last_successful_fetch_started_at,
+            'created_at' => now_json_value,
+            'updated_at' => now_json_value,
+          });
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'create'
+          expect(audit.auditable.id).to eq docs_source.id
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+  describe 'PUT #update' do
+    let :put_data do
+      {
+        id: @docs_source.id,
+        docs_source: {
+          name: 'new name'
+        }
+      }
+    end
+
+    before do
+      @docs_source = create :docs_source
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        put :update, params: put_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          put :update, params: put_data
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        it 'updates the specified docs source' do
+          expect(DocsSource.count).to eq 1
+          expect(Audit.count).to eq 0
+          put :update, params: put_data
+          expect(response).to be_success
+          expect(DocsSource.count).to eq 1
+          updated = DocsSource.first
+          expect(updated.name).to eq put_data[:docs_source][:name]
+          expect(updated.config).to eq Hashie::Mash.new(@docs_source.config)
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'update'
+          expect(audit.auditable.id).to eq @docs_source.id
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+
+end

--- a/platform-hub-api/spec/factories/docs_sources.rb
+++ b/platform-hub-api/spec/factories/docs_sources.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :docs_source do
+    id { SecureRandom.uuid }
+
+    kind :github_repo
+
+    sequence :name do |n|
+      "Source #{n}"
+    end
+
+    config { {} }
+  end
+end

--- a/platform-hub-api/spec/routing/docs_sources_routing_spec.rb
+++ b/platform-hub-api/spec/routing/docs_sources_routing_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe DocsSourcesController, type: :routing do
+  describe "routing" do
+
+    it "routes to #index" do
+      expect(:get => "/docs_sources").to route_to("docs_sources#index")
+    end
+
+    it "routes to #show" do
+      expect(:get => "/docs_sources/1").to route_to("docs_sources#show", :id => "1")
+    end
+
+    it "routes to #create" do
+      expect(:post => "/docs_sources").to route_to("docs_sources#create")
+    end
+
+    it "routes to #update via PUT" do
+      expect(:put => "/docs_sources/1").to route_to("docs_sources#update", :id => "1")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(:patch => "/docs_sources/1").to route_to("docs_sources#update", :id => "1")
+    end
+
+    it "routes to #destroy" do
+      expect(:delete => "/docs_sources/1").to route_to("docs_sources#destroy", :id => "1")
+    end
+
+  end
+end

--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -17,6 +17,11 @@ import {
   CostsReportsList
 } from './costs-reports/costs-reports.module';
 import {
+  DocsSourcesDetail,
+  DocsSourcesForm,
+  DocsSourcesList
+} from './docs-sources/docs-sources.module';
+import {
   FeatureFlagsForm
 } from './feature-flags/feature-flags.module';
 import {
@@ -786,6 +791,49 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
       .state('costs-reports.new', {
         url: '/new',
         component: CostsReportsForm,
+        data: {
+          authenticate: true,
+          rolesPermitted: ['admin']
+        }
+      })
+    .state('docs-sources', {
+      abstract: true,
+      url: '/docs-sources',
+      template: '<ui-view></ui-view>'
+    })
+      .state('docs-sources.list', {
+        url: '/list',
+        component: DocsSourcesList,
+        data: {
+          authenticate: true,
+          rolesPermitted: ['admin']
+        }
+      })
+      .state('docs-sources.detail', {
+        url: '/detail/:id',
+        component: DocsSourcesDetail,
+        resolve: {
+          transition: '$transition$'
+        },
+        data: {
+          authenticate: true,
+          rolesPermitted: ['admin']
+        }
+      })
+      .state('docs-sources.new', {
+        url: '/new',
+        component: DocsSourcesForm,
+        data: {
+          authenticate: true,
+          rolesPermitted: ['admin']
+        }
+      })
+      .state('docs-sources.edit', {
+        url: '/edit/:id',
+        component: DocsSourcesForm,
+        resolve: {
+          transition: '$transition$'
+        },
         data: {
           authenticate: true,
           rolesPermitted: ['admin']

--- a/platform-hub-web/src/app/docs-sources/docs-sources-detail.component.js
+++ b/platform-hub-web/src/app/docs-sources/docs-sources-detail.component.js
@@ -1,0 +1,68 @@
+export const DocsSourcesDetailComponent = {
+  bindings: {
+    transition: '<'
+  },
+  template: require('./docs-sources-detail.html'),
+  controller: DocsSourcesDetailController
+};
+
+function DocsSourcesDetailController($mdDialog, $state, DocsSources, logger) {
+  'ngInject';
+
+  const ctrl = this;
+
+  const id = ctrl.transition.params().id;
+
+  ctrl.DocsSources = DocsSources;
+
+  ctrl.loading = true;
+  ctrl.source = null;
+
+  ctrl.deleteSource = deleteSource;
+
+  init();
+
+  function init() {
+    loadSource();
+  }
+
+  function loadSource() {
+    ctrl.loading = true;
+    ctrl.source = null;
+
+    DocsSources
+      .get(id)
+      .then(source => {
+        ctrl.source = source;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function deleteSource(targetEvent) {
+    const confirm = $mdDialog.confirm()
+      .title('Are you sure?')
+      .textContent('This will delete the docs source permanently from the hub and no longer index it\'s docs.')
+      .ariaLabel('Confirm deletion of docs source')
+      .targetEvent(targetEvent)
+      .ok('Do it')
+      .cancel('Cancel');
+
+    $mdDialog
+      .show(confirm)
+      .then(() => {
+        ctrl.loading = true;
+
+        DocsSources
+          .delete(ctrl.source.id)
+          .then(() => {
+            logger.success('Docs source deleted');
+            $state.go('docs-sources.list');
+          })
+          .finally(() => {
+            ctrl.loading = false;
+          });
+      });
+  }
+}

--- a/platform-hub-web/src/app/docs-sources/docs-sources-detail.html
+++ b/platform-hub-web/src/app/docs-sources/docs-sources-detail.html
@@ -1,0 +1,47 @@
+<div class="docs-sources-detail">
+  <md-toolbar>
+    <div class="md-toolbar-tools">
+      <h3>
+        <span>Docs Source: </span>
+        <span ng-cloak>{{$ctrl.source.shortname}}</span>
+      </h3>
+      <span flex></span>
+      <md-button
+        ng-if="$ctrl.source"
+        aria-label="Edit this docs source"
+        ui-sref="docs-sources.edit({id: $ctrl.source.id})">
+        <md-icon>edit</md-icon>
+        Edit
+      </md-button>
+      <md-button
+        ng-if="$ctrl.source"
+        aria-label="Delete this docs source"
+        ng-click="$ctrl.deleteSource($event)">
+        <md-icon>delete</md-icon>
+        Delete
+      </md-button>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading"></loading-indicator>
+
+  <md-content layout-padding ng-if="!$ctrl.loading && $ctrl.source">
+
+    <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50">
+      <md-content layout-padding>
+
+        <h3 class="md-title" layout="row">
+          {{$ctrl.source.name}}
+
+          <span
+            class="badge float-right"
+            md-colors="{background: 'blue'}">
+            {{$ctrl.DocsSources.kinds[$ctrl.source.kind]}}
+          </span>
+        </h3>
+
+      </md-content>
+    </div>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/docs-sources/docs-sources-form.component.js
+++ b/platform-hub-web/src/app/docs-sources/docs-sources-form.component.js
@@ -1,0 +1,88 @@
+export const DocsSourcesFormComponent = {
+  bindings: {
+    transition: '<'
+  },
+  template: require('./docs-sources-form.html'),
+  controller: DocsSourcesFormController
+};
+
+function DocsSourcesFormController($state, DocsSources, logger) {
+  'ngInject';
+
+  const ctrl = this;
+
+  const id = ctrl.transition && ctrl.transition.params().id;
+
+  ctrl.DocsSources = DocsSources;
+
+  ctrl.loading = true;
+  ctrl.saving = false;
+  ctrl.isNew = true;
+  ctrl.source = null;
+
+  ctrl.createOrUpdate = createOrUpdate;
+
+  init();
+
+  function init() {
+    ctrl.isNew = !id;
+
+    if (ctrl.isNew) {
+      ctrl.source = initEmptySource();
+      ctrl.loading = false;
+    } else {
+      loadSource();
+    }
+  }
+
+  function initEmptySource() {
+    return {
+      config: {}
+    };
+  }
+
+  function loadSource() {
+    ctrl.loading = true;
+    ctrl.source = null;
+
+    DocsSources
+      .get(id)
+      .then(source => {
+        ctrl.source = source;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function createOrUpdate() {
+    if (ctrl.sourceForm.$invalid) {
+      logger.error('Check the form for issues before saving');
+      return;
+    }
+
+    ctrl.saving = true;
+
+    if (ctrl.isNew) {
+      DocsSources
+        .create(ctrl.source)
+        .then(source => {
+          logger.success('New docs source created');
+          $state.go('docs-sources.detail', {id: source.id});
+        })
+        .finally(() => {
+          ctrl.saving = false;
+        });
+    } else {
+      DocsSources
+        .update(ctrl.source.id, ctrl.source)
+        .then(source => {
+          logger.success('Docs source updated');
+          $state.go('docs-sources.detail', {id: source.id});
+        })
+        .finally(() => {
+          ctrl.saving = false;
+        });
+    }
+  }
+}

--- a/platform-hub-web/src/app/docs-sources/docs-sources-form.html
+++ b/platform-hub-web/src/app/docs-sources/docs-sources-form.html
@@ -1,0 +1,63 @@
+<div class="docs-sources-form">
+  <md-toolbar>
+    <div class="md-toolbar-tools">
+      <h3>
+        <span ng-if="$ctrl.isNew">New Docs Source</span>
+        <span ng-if="!$ctrl.isNew">Edit Docs Source</span>
+      </h3>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading || $ctrl.saving"></loading-indicator>
+
+  <md-content layout-padding ng-if="!$ctrl.loading">
+
+    <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z1" layout-padding>
+      <md-content>
+        <form name="$ctrl.sourceForm" role="form" ng-submit="$ctrl.createOrUpdate()">
+
+          <md-input-container class="md-block">
+            <label for="name">Name:</label>
+            <input
+              name="name"
+              ng-model="$ctrl.source.name"
+              required
+              placeholder="Name for this source, e.g. 'Main platform docs'">
+            <div ng-messages="$ctrl.sourceForm.name.$error">
+              <div ng-message="required">This is required.</div>
+            </div>
+          </md-input-container>
+
+          <md-input-container class="md-block">
+            <label for="kind">What kind of source is this:</label>
+            <md-select
+              name="kind"
+              ng-model="$ctrl.source.kind"
+              aria-label="Set what kind of docs source this is">
+              <md-option
+                ng-repeat="(k,v) in $ctrl.DocsSources.kinds"
+                ng-value="k">
+                {{v}}
+              </md-option>
+            </md-select>
+          </md-input-container>
+
+          <div>
+            <md-button
+              type="submit"
+              class="md-primary"
+              ng-disabled="$ctrl.saving || $ctrl.sourceForm.$invalid"
+              ng-class="{'md-raised': ($ctrl.sourceForm.$dirty && $ctrl.sourceForm.$valid) }"
+              aria-label="Save docs source">
+              <span ng-if="$ctrl.isNew">Create</span>
+              <span ng-if="!$ctrl.isNew">Update</span>
+            </md-button>
+            <md-button ui-sref="docs-sources.list" ng-disabled="$ctrl.saving">Cancel</md-button>
+          </div>
+
+        </form>
+      </md-content>
+    </div>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/docs-sources/docs-sources-list.component.js
+++ b/platform-hub-web/src/app/docs-sources/docs-sources-list.component.js
@@ -1,0 +1,31 @@
+export const DocsSourcesListComponent = {
+  template: require('./docs-sources-list.html'),
+  controller: DocsSourcesListController
+};
+
+function DocsSourcesListController(DocsSources) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.DocsSources = DocsSources;
+
+  ctrl.sources = [];
+
+  ctrl.loading = false;
+
+  init();
+
+  function init() {
+    ctrl.loading = true;
+
+    DocsSources
+      .getAll()
+      .then(sources => {
+        ctrl.sources = sources;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+}

--- a/platform-hub-web/src/app/docs-sources/docs-sources-list.html
+++ b/platform-hub-web/src/app/docs-sources/docs-sources-list.html
@@ -1,0 +1,50 @@
+<div class="docs-sources-list">
+  <md-toolbar>
+    <div class="md-toolbar-tools">
+      <h3>
+        <span>All Docs Sources</span>
+      </h3>
+      <span flex></span>
+      <md-button
+        aria-label="Add new docs source"
+        ui-sref="docs-sources.new">
+        <md-icon>add_box</md-icon>
+        New
+      </md-button>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading"></loading-indicator>
+
+  <md-content>
+
+    <md-card ng-repeat="s in $ctrl.sources track by t.id">
+      <md-card-title>
+        <md-card-title-text>
+          <span class="md-headline">
+            {{s.name}}
+
+            <small
+              class="badge float-right"
+              md-colors="{background: 'blue'}">
+              {{$ctrl.DocsSources.kinds[s.kind]}}
+            </small>
+          </span>
+        </md-card-title-text>
+      </md-card-title>
+
+      <md-card-content>
+      </md-card-content>
+
+      <md-card-actions layout="row" layout-align="start center">
+        <md-button
+          class="md-primary"
+          aria-label="View details of this docs source"
+          ui-sref="docs-sources.detail({id: s.id})">
+          Details
+        </md-button>
+      </md-card-actions>
+    </md-card>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/docs-sources/docs-sources.module.js
+++ b/platform-hub-web/src/app/docs-sources/docs-sources.module.js
@@ -1,0 +1,17 @@
+import angular from 'angular';
+
+import {DocsSourcesDetailComponent} from './docs-sources-detail.component';
+import {DocsSourcesFormComponent} from './docs-sources-form.component';
+import {DocsSourcesListComponent} from './docs-sources-list.component';
+
+// Main section component names
+export const DocsSourcesDetail = 'docsSourcesDetail';
+export const DocsSourcesForm = 'docsSourcesForm';
+export const DocsSourcesList = 'docsSourcesList';
+
+export const AnnouncementsModule = angular
+  .module('app.announcements', [])
+  .component(DocsSourcesDetail, DocsSourcesDetailComponent)
+  .component(DocsSourcesForm, DocsSourcesFormComponent)
+  .component(DocsSourcesList, DocsSourcesListComponent)
+  .name;

--- a/platform-hub-web/src/app/layout/shell.component.js
+++ b/platform-hub-web/src/app/layout/shell.component.js
@@ -123,6 +123,12 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
       icon: icons.costsReports
     },
     {
+      title: 'Docs Sources',
+      state: 'docs-sources.list',
+      activeState: 'docs-sources',
+      icon: icons.docsSources
+    },
+    {
       title: 'Users',
       state: 'users',
       icon: icons.users

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -180,6 +180,12 @@ export const hubApiService = function ($rootScope, $http, $q, logger, apiEndpoin
 
   service.helpSearch = buildSimpleFetcher('help/search', 'help search');
 
+  service.getDocsSources = buildCollectionFetcher('docs_sources');
+  service.getDocsSource = buildResourceFetcher('docs_sources');
+  service.createDocsSource = buildResourceCreator('docs_sources');
+  service.updateDocsSource = buildResourceUpdater('docs_sources');
+  service.deleteDocsSource = buildResourceDeletor('docs_sources');
+
   return service;
 
   function getMe() {

--- a/platform-hub-web/src/app/shared/icons.factory.js
+++ b/platform-hub-web/src/app/shared/icons.factory.js
@@ -8,6 +8,7 @@ export const icons = function () {
     contactList: 'contacts',
     copy: 'content_copy',
     costsReports: 'attach_money',
+    docsSources: 'library_books',
     escalateToken: 'security',
     externalLink: 'link',
     faq: 'question_answer',

--- a/platform-hub-web/src/app/shared/model/docs-sources.js
+++ b/platform-hub-web/src/app/shared/model/docs-sources.js
@@ -1,0 +1,20 @@
+/* eslint camelcase: 0 */
+
+export const DocsSources = function (hubApiService) {
+  'ngInject';
+
+  const model = {};
+
+  model.kinds = {
+    github_repo: 'GitHub repo',
+    gitlab_repo: 'Gitlab repo'
+  };
+
+  model.getAll = hubApiService.getDocsSources;
+  model.get = hubApiService.getDocsSource;
+  model.create = hubApiService.createDocsSource;
+  model.update = hubApiService.updateDocsSource;
+  model.delete = hubApiService.deleteDocsSource;
+
+  return model;
+};

--- a/platform-hub-web/src/app/shared/model/model.module.js
+++ b/platform-hub-web/src/app/shared/model/model.module.js
@@ -7,6 +7,7 @@ import {AnnouncementTemplates} from './announcement-templates';
 import {Announcements} from './announcements';
 import {AppSettings} from './app-settings';
 import {CostsReports} from './costs-reports';
+import {DocsSources} from './docs-sources';
 import {FeatureFlags} from './feature-flags';
 import {Identities} from './identities';
 import {KubernetesClusters} from './kubernetes-clusters';
@@ -31,6 +32,7 @@ export const ModelModule = angular
   .service('Announcements', Announcements)
   .service('AppSettings', AppSettings)
   .service('CostsReports', CostsReports)
+  .service('DocsSources', DocsSources)
   .service('FeatureFlags', FeatureFlags)
   .service('Identities', Identities)
   .service('KubernetesClusters', KubernetesClusters)


### PR DESCRIPTION
This just provides the initial model for "docs sources" and the ability to create, update and delete them in the UI, but with empty `config`.

Kind-specific config + actual fetching and indexing of docs from these sources will come in later PRs.