### PR TITLE
Sync, fetch and index markdown docs from GitHub repos

### DIFF
--- a/platform-hub-api/Gemfile
+++ b/platform-hub-api/Gemfile
@@ -29,6 +29,7 @@ gem 'api-pagination', '~> 4.7'
 gem 'memoist', '~> 0.16.0'
 gem 'has_scope', '~> 0.7.2'
 gem 'elasticsearch-persistence', '~> 5.1'
+gem 'commonmarker', '~> 0.17.11'
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/platform-hub-api/Gemfile.lock
+++ b/platform-hub-api/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
     classy_hash (0.2.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    commonmarker (0.17.11)
+      ruby-enum (~> 0.5)
     composite_primary_keys (9.0.8)
       activerecord (~> 5.0.0)
     concurrent-ruby (1.0.5)
@@ -227,6 +229,8 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
+    ruby-enum (0.7.2)
+      i18n
     ruby_dep (1.5.0)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
@@ -276,6 +280,7 @@ DEPENDENCIES
   byebug
   cancancan (~> 2.1.3)
   classy_hash (~> 0.2.0)
+  commonmarker (~> 0.17.11)
   composite_primary_keys (~> 9.0, >= 9.0.6)
   delayed_job (~> 4.1, >= 4.1.4)
   delayed_job_active_record (~> 4.1, >= 4.1.2)

--- a/platform-hub-api/app/controllers/docs_sources_controller.rb
+++ b/platform-hub-api/app/controllers/docs_sources_controller.rb
@@ -53,6 +53,11 @@ class DocsSourcesController < ApiJsonController
     id = @docs_source.id
     name = @docs_source.name
 
+    # Clean up docs in the help search index
+    @docs_source.entries.each do |entry|
+      HelpSearchService.instance.delete_item entry
+    end
+
     @docs_source.destroy
 
     AuditService.log(

--- a/platform-hub-api/app/jobs/docs_sync_job.rb
+++ b/platform-hub-api/app/jobs/docs_sync_job.rb
@@ -1,0 +1,13 @@
+class DocsSyncJob < ApplicationJob
+  queue_as :docs_sync
+
+  def self.is_already_queued?
+    Delayed::Job.where(queue: :docs_sync).count > 0
+  end
+
+  def perform
+    return unless FeatureFlagService.is_enabled?(:docs_sync)
+
+    Docs::DocsSyncService.new(help_search_service: HelpSearchService.instance).sync_all
+  end
+end

--- a/platform-hub-api/app/models/docs_source.rb
+++ b/platform-hub-api/app/models/docs_source.rb
@@ -4,6 +4,10 @@ class DocsSource < ApplicationRecord
 
   audited descriptor_field: :name
 
+  has_many :entries,
+    class_name: DocsSourceEntry,
+    dependent: :destroy
+
   attr_readonly :kind
 
   enum kind: {

--- a/platform-hub-api/app/models/docs_source_entry.rb
+++ b/platform-hub-api/app/models/docs_source_entry.rb
@@ -1,0 +1,9 @@
+class DocsSourceEntry < ApplicationRecord
+
+  belongs_to :docs_source
+
+  validates :content_id, presence: true
+
+  validates :content_url, presence: true
+
+end

--- a/platform-hub-api/app/serializers/docs_source_serializer.rb
+++ b/platform-hub-api/app/serializers/docs_source_serializer.rb
@@ -9,7 +9,13 @@ class DocsSourceSerializer < ActiveModel::Serializer
     :last_fetch_started_at,
     :last_fetch_error,
     :last_successful_fetch_started_at,
+    :last_successful_fetch_metadata,
     :created_at,
     :updated_at
   )
+
+  attribute :config do
+    # Need to do this because `config` is a reserved word
+    object.config
+  end
 end

--- a/platform-hub-api/app/services/agents/git_hub_agent_service.rb
+++ b/platform-hub-api/app/services/agents/git_hub_agent_service.rb
@@ -25,6 +25,14 @@ module Agents
       resource.html_url
     end
 
+    def repo_tree repo, sha
+      @client.tree repo, sha, recursive: true
+    end
+
+    def blob_content repo, blob_sha
+      @client.blob repo, blob_sha, accept: 'application/vnd.github.v3.raw'
+    end
+
     private
 
     def with_identity user

--- a/platform-hub-api/app/services/docs/doc_processor.rb
+++ b/platform-hub-api/app/services/docs/doc_processor.rb
@@ -1,0 +1,26 @@
+module Docs
+  class DocProcessor
+
+    include Agents::GitHubAgentInstance
+
+    def fetch_and_process docs_source_entry
+      case
+      when docs_source_entry.docs_source.github_repo?
+        git_hub_repo_doc_processor.fetch_and_process docs_source_entry
+      when docs_source_entry.docs_source.gitlab_repo?
+        # NOOP for now
+      else
+        raise "Kind '#{docs_source_entry.docs_source.kind}' (for DocsSourceEntry ID '#{docs_source_entry.id}') not currently supported for doc processing"
+      end
+    end
+
+    private
+
+    def git_hub_repo_doc_processor
+      @git_hub_repo_doc_processor ||= GitHubRepoDocProcessor.new(
+        git_hub_agent: git_hub_agent_service
+      )
+    end
+
+  end
+end

--- a/platform-hub-api/app/services/docs/docs_sync_job_trigger_service.rb
+++ b/platform-hub-api/app/services/docs/docs_sync_job_trigger_service.rb
@@ -1,0 +1,16 @@
+module Docs
+  module DocsSyncJobTriggerService
+    extend self
+
+    def trigger
+      if !FeatureFlagService.is_enabled?(:docs_sync)
+        Rails.logger.info 'Docs sync feature flag is turned off... will not trigger docs_sync sync job'
+      elsif DocsSyncJob.is_already_queued?
+        Rails.logger.info 'Docs sync job already in queue... will not trigger another one'
+      else
+        Rails.logger.info 'Triggering the docs sync job'
+        DocsSyncJob.perform_later
+      end
+    end
+  end
+end

--- a/platform-hub-api/app/services/docs/docs_sync_service.rb
+++ b/platform-hub-api/app/services/docs/docs_sync_service.rb
@@ -1,0 +1,33 @@
+module Docs
+  class DocsSyncService
+
+    include Agents::GitHubAgentInstance
+
+    def initialize help_search_service:
+      @help_search_service = help_search_service
+    end
+
+    def sync_all
+      DocsSource.all.each do |docs_source|
+        case
+        when docs_source.github_repo?
+          git_hub_repo_docs_sync_service.sync docs_source
+        when docs_source.gitlab_repo?
+          # NOOP for now
+        else
+          raise "Kind '#{docs_source.kind}' (for DocsSource ID '#{docs_source.id}') not currently supported for docs syncing"
+        end
+      end
+    end
+
+    private
+
+    def git_hub_repo_docs_sync_service
+      @git_hub_repo_docs_sync_service ||= GitHubRepoDocsSyncService.new(
+        git_hub_agent: git_hub_agent_service,
+        help_search_service: @help_search_service
+      )
+    end
+
+  end
+end

--- a/platform-hub-api/app/services/docs/git_hub_repo_doc_processor.rb
+++ b/platform-hub-api/app/services/docs/git_hub_repo_doc_processor.rb
@@ -1,0 +1,68 @@
+module Docs
+  class GitHubRepoDocProcessor
+
+    def initialize git_hub_agent:
+      @git_hub_agent = git_hub_agent
+    end
+
+    def fetch_and_process docs_source_entry
+      docs_source = docs_source_entry.docs_source
+
+      return false if !docs_source.github_repo?
+
+      repo = docs_source.config['repo']
+      blob_sha = docs_source_entry.metadata['sha']
+
+      content = @git_hub_agent.blob_content repo, blob_sha
+
+      content = content.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
+
+      doc = CommonMarker.render_doc content, :VALIDATE_UTF8
+
+      headings = sanitize_all(get_headings_from(doc))
+
+      content = sanitize_all(doc.to_html)
+
+      {
+        title: headings.first || '<NO TITLE>',
+        content: content,
+        headings: headings
+      }
+    rescue => ex
+      error_serialised = "[#{ex.class.name}] #{ex.message} - #{ex.backtrace}"
+
+      Rails.logger.error "GitHub doc fetch and process failed for docs source entry '#{docs_source_entry.id}' - error: #{error_serialised}"
+
+      {}
+    end
+
+    private
+
+    def sanitize_all strings
+      Array(strings).map do |s|
+        sanitizer.sanitize s
+      end
+    end
+
+    def sanitizer
+      @sanitizer ||= Rails::Html::FullSanitizer.new
+    end
+
+    def get_headings_from doc
+      headings = []
+
+      doc.walk do |node|
+        if node.type == :header
+          node.each do |subnode|
+            if subnode.type == :text
+              headings << subnode.string_content
+            end
+          end
+        end
+      end
+
+      headings
+    end
+
+  end
+end

--- a/platform-hub-api/app/services/docs/git_hub_repo_docs_sync_service.rb
+++ b/platform-hub-api/app/services/docs/git_hub_repo_docs_sync_service.rb
@@ -1,0 +1,136 @@
+module Docs
+  class GitHubRepoDocsSyncService
+
+    MARKDOWN_FILE_EXTS = ['.markdown', '.md', '.mdown', '.mkdn'].freeze
+
+    BASE_HREF = "https://github.com".freeze
+
+    def initialize git_hub_agent:, help_search_service:
+      @git_hub_agent = git_hub_agent
+      @help_search_service = help_search_service
+    end
+
+    def sync docs_source
+      return false if !docs_source.github_repo? || docs_source.is_fetching
+
+      start = Time.current
+
+      docs_source.update!(
+        is_fetching: true,
+        last_fetch_status: nil,
+        last_fetch_started_at: start,
+        last_fetch_error: nil
+      )
+
+      repo = docs_source.config['repo']
+      branch = docs_source.config['branch'] || 'master'
+
+      data = @git_hub_agent.repo_tree repo, branch
+
+      if data[:truncated] == true
+        Rails.logger.warn "GitHub tree listing for repo '#{repo}' (branch: #{branch} was truncated - some docs may be missing)"
+      end
+
+      markdown_items = select_markdown_items data[:tree]
+
+      sync_entries!(
+        docs_source,
+        markdown_items,
+        repo,
+        branch
+      )
+
+      finish = Time.current
+
+      docs_source.update!(
+        is_fetching: false,
+        last_fetch_status: :successful,
+        last_successful_fetch_started_at: start,
+        last_successful_fetch_metadata: {
+          'sha' => data[:sha],
+          'truncated' => data[:truncated],
+          'total_docs_found' => markdown_items.size,
+          'sync_duration_secs' => (finish - start).round
+        }
+      )
+
+      true
+    rescue => ex
+      error_serialised = "[#{ex.class.name}] #{ex.message} - #{ex.backtrace}"
+
+      Rails.logger.error "GitHub docs sync failed for docs source #{docs_source.id} - error: #{error_serialised}"
+
+      docs_source.update!(
+        is_fetching: false,
+        last_fetch_status: :failed,
+        last_fetch_error: error_serialised
+      )
+
+      false
+    end
+
+    private
+
+    def select_markdown_items items
+      items.select do |i|
+        is_blob = i[:type] == 'blob'
+
+        is_markdown = MARKDOWN_FILE_EXTS.any? { |ext| i[:path].end_with?(ext) }
+
+        is_blob && is_markdown
+      end
+    end
+
+    def sync_entries! docs_source, items, repo, branch
+      current_entries_by_path = docs_source
+        .entries
+        .each_with_object({}) do |e, acc|
+          acc[e.content_id] = e
+        end
+
+      processed = []
+
+      items.each do |i|
+        path = i[:path]
+
+        metadata = {
+          'api_url': i[:url],
+          'sha' => i[:sha],
+          'size' => i[:size]
+        }
+
+        content_url = "#{BASE_HREF}/#{repo}/blob/#{branch}/#{path}"
+
+        entry = if current_entries_by_path.has_key? path
+          # Update existing
+          current_entries_by_path[path].tap do |e|
+            e.update!(
+              content_url: content_url,
+              metadata: metadata
+            )
+          end
+        else
+          # Create new
+          docs_source.entries.create!(
+            content_id: path,
+            content_url: content_url,
+            metadata: metadata
+          )
+        end
+
+        @help_search_service.index_item entry
+
+        processed << path
+      end
+
+      # Delete
+      unprocessed = current_entries_by_path.keys - processed
+      unprocessed.each do |path|
+        entry = current_entries_by_path[path]
+        entry.destroy!
+        @help_search_service.delete_item entry
+      end
+    end
+
+  end
+end

--- a/platform-hub-api/db/migrate/20180810102606_create_docs_sources.rb
+++ b/platform-hub-api/db/migrate/20180810102606_create_docs_sources.rb
@@ -7,7 +7,7 @@ class CreateDocsSources < ActiveRecord::Migration[5.0]
       t.boolean :is_fetching, null: false, default: false
       t.string :last_fetch_status
       t.datetime :last_fetch_started_at
-      t.string :last_fetch_error
+      t.text :last_fetch_error
       t.datetime :last_successful_fetch_started_at
 
       t.timestamps

--- a/platform-hub-api/db/migrate/20180822125540_add_last_fetch_metdata_to_docs_source.rb
+++ b/platform-hub-api/db/migrate/20180822125540_add_last_fetch_metdata_to_docs_source.rb
@@ -1,0 +1,5 @@
+class AddLastFetchMetdataToDocsSource < ActiveRecord::Migration[5.0]
+  def change
+    add_column :docs_sources, :last_successful_fetch_metadata, :json
+  end
+end

--- a/platform-hub-api/db/migrate/20180822130915_create_docs_source_entries.rb
+++ b/platform-hub-api/db/migrate/20180822130915_create_docs_source_entries.rb
@@ -1,0 +1,12 @@
+class CreateDocsSourceEntries < ActiveRecord::Migration[5.0]
+  def change
+    create_table :docs_source_entries, id: :uuid do |t|
+      t.references :docs_source, type: :uuid, null: false, index: true
+      t.string :content_id, null: false
+      t.string :content_url, null: false
+      t.json :metadata
+
+      t.timestamps
+    end
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -240,6 +240,21 @@ ALTER SEQUENCE delayed_jobs_id_seq OWNED BY delayed_jobs.id;
 
 
 --
+-- Name: docs_source_entries; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE docs_source_entries (
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    docs_source_id uuid NOT NULL,
+    content_id character varying NOT NULL,
+    content_url character varying NOT NULL,
+    metadata json,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
 -- Name: docs_sources; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -251,10 +266,11 @@ CREATE TABLE docs_sources (
     is_fetching boolean DEFAULT false NOT NULL,
     last_fetch_status character varying,
     last_fetch_started_at timestamp without time zone,
-    last_fetch_error character varying,
+    last_fetch_error text,
     last_successful_fetch_started_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    last_successful_fetch_metadata json
 );
 
 
@@ -607,6 +623,14 @@ ALTER TABLE ONLY delayed_jobs
 
 
 --
+-- Name: docs_source_entries docs_source_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY docs_source_entries
+    ADD CONSTRAINT docs_source_entries_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: docs_sources docs_sources_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -865,6 +889,13 @@ CREATE INDEX index_audits_on_user_name ON audits USING btree (user_name);
 --
 
 CREATE INDEX index_delayed_jobs_on_queue ON delayed_jobs USING btree (queue);
+
+
+--
+-- Name: index_docs_source_entries_on_docs_source_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_docs_source_entries_on_docs_source_id ON docs_source_entries USING btree (docs_source_id);
 
 
 --
@@ -1205,6 +1236,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180406083658'),
 ('20180711092801'),
 ('20180718141143'),
-('20180810102606');
+('20180810102606'),
+('20180822125540'),
+('20180822130915');
 
 

--- a/platform-hub-api/lib/tasks/docs.rake
+++ b/platform-hub-api/lib/tasks/docs.rake
@@ -1,0 +1,8 @@
+namespace :docs do
+
+  desc "Trigger the docs sync job if it's not already in the queue"
+  task trigger_docs_sync: :environment do
+    Docs:DocsSyncJobTriggerService.trigger
+  end
+
+end

--- a/platform-hub-api/spec/factories/docs_source_entries.rb
+++ b/platform-hub-api/spec/factories/docs_source_entries.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :docs_source_entry do
+    docs_source
+
+    sequence :content_id do |n|
+      "#{n}"
+    end
+
+    sequence :content_url do |n|
+      "http://example.com/#{n}"
+    end
+  end
+end

--- a/platform-hub-api/spec/jobs/docs_sync_job_spec.rb
+++ b/platform-hub-api/spec/jobs/docs_sync_job_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe DocsSyncJob, type: :job do
+
+  describe '.is_already_queued?' do
+    it 'should recognise when the job is already queued' do
+      expect(DocsSyncJob.is_already_queued?).to be false
+
+      DocsSyncJob.perform_later
+
+      expect(DocsSyncJob.is_already_queued?).to be true
+    end
+  end
+
+  describe '.perform' do
+
+    let(:help_search_service) { instance_double('HelpSearchService') }
+    let(:docs_sync_service) { instance_double('Docs::DocsSyncService') }
+
+    before do
+      allow(HelpSearchService).to receive(:instance).and_return(help_search_service)
+    end
+
+    context 'with docs_sync feature flag enabled' do
+      before do
+        FeatureFlagService.create_or_update(:docs_sync, true)
+      end
+
+      it 'should call the DocsSyncService' do
+        expect(Docs::DocsSyncService).to receive(:new)
+          .with(help_search_service: help_search_service)
+          .and_return(docs_sync_service)
+        expect(docs_sync_service).to receive(:sync_all)
+
+        DocsSyncJob.new.perform
+      end
+    end
+
+    context 'with docs_sync feature flag disabled' do
+      before do
+        FeatureFlagService.create_or_update(:docs_sync, false)
+      end
+
+      it 'should not do anything' do
+        expect(Docs::DocsSyncService).to receive(:new).never
+
+        DocsSyncJob.new.perform
+      end
+    end
+
+  end
+
+end

--- a/platform-hub-web/src/app/app.module.js
+++ b/platform-hub-web/src/app/app.module.js
@@ -116,6 +116,7 @@ angular
   .constant('apiEndpoint', apiEndpoint)
   .constant('apiBackoffTimeMs', 2000)
   .constant('featureFlagKeys', {
+    docsSync: 'docs_sync',
     helpSearch: 'help_search',
     kubernetesTokens: 'kubernetes_tokens',
     kubernetesTokensEscalatePrivilege: 'kubernetes_tokens_escalate_privilege',

--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -499,8 +499,11 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
         }
       })
       .state('help.search', {
-        url: '/search',
+        url: '/search?q',
         component: Search,
+        resolve: {
+          transition: '$transition$'
+        },
         data: {
           authenticate: true,
           featureFlags: [featureFlagKeys.helpSearch]

--- a/platform-hub-web/src/app/docs-sources/docs-sources-detail.html
+++ b/platform-hub-web/src/app/docs-sources/docs-sources-detail.html
@@ -3,7 +3,7 @@
     <div class="md-toolbar-tools">
       <h3>
         <span>Docs Source: </span>
-        <span ng-cloak>{{$ctrl.source.shortname}}</span>
+        <span ng-cloak>{{$ctrl.source.name}}</span>
       </h3>
       <span flex></span>
       <md-button
@@ -39,6 +39,12 @@
             {{$ctrl.DocsSources.kinds[$ctrl.source.kind]}}
           </span>
         </h3>
+
+        <h4>
+          Source config
+        </h4>
+
+        <pre>{{$ctrl.source.config | json}}</pre>
 
       </md-content>
     </div>

--- a/platform-hub-web/src/app/docs-sources/docs-sources-form.component.js
+++ b/platform-hub-web/src/app/docs-sources/docs-sources-form.component.js
@@ -21,6 +21,7 @@ function DocsSourcesFormController($state, DocsSources, logger) {
   ctrl.source = null;
 
   ctrl.createOrUpdate = createOrUpdate;
+  ctrl.handleKindChange = handleKindChange;
 
   init();
 
@@ -84,5 +85,9 @@ function DocsSourcesFormController($state, DocsSources, logger) {
           ctrl.saving = false;
         });
     }
+  }
+
+  function handleKindChange() {
+    ctrl.source.config = {};
   }
 }

--- a/platform-hub-web/src/app/docs-sources/docs-sources-form.html
+++ b/platform-hub-web/src/app/docs-sources/docs-sources-form.html
@@ -33,7 +33,8 @@
             <md-select
               name="kind"
               ng-model="$ctrl.source.kind"
-              aria-label="Set what kind of docs source this is">
+              ng-change="$ctrl.handleKindChange()"
+              aria-label="Specify what kind of docs source this is">
               <md-option
                 ng-repeat="(k,v) in $ctrl.DocsSources.kinds"
                 ng-value="k">
@@ -41,6 +42,39 @@
               </md-option>
             </md-select>
           </md-input-container>
+
+          <fieldset ng-if="$ctrl.source.kind">
+            <legend>
+              Config
+            </legend>
+
+            <div ng-if="$ctrl.source.kind == 'github_repo'">
+              <md-input-container class="md-block">
+                <label for="configRepo">Repo:</label>
+                <input
+                  name="configRepo"
+                  ng-model="$ctrl.source.config.repo"
+                  required
+                  placeholder="e.g. kubernetes/ingress-nginx"
+                  aria-label="The GitHub repo to fetch docs from">
+                <div ng-messages="$ctrl.sourceForm.configRepo.$error">
+                  <div ng-message="required">This is required.</div>
+                </div>
+              </md-input-container>
+
+              <md-input-container class="md-block">
+                <label for="configBranch">Branch:</label>
+                <input
+                  name="configBranch"
+                  ng-model="$ctrl.source.config.branch"
+                  placeholder="Leave blank to use master branch"
+                  aria-label="The specific branch to fetch docs from in the repo">
+              </md-input-container>
+            </div>
+          </fieldset>
+
+          <br />
+          <br />
 
           <div>
             <md-button

--- a/platform-hub-web/src/app/help/help.module.js
+++ b/platform-hub-web/src/app/help/help.module.js
@@ -9,6 +9,8 @@ import {SupportRequestTemplatesDetailComponent} from './support/request-template
 import {SupportRequestTemplatesFormComponent} from './support/request-templates/support-request-templates-form.component';
 import {SupportRequestTemplatesListComponent} from './support/request-templates/support-request-templates-list.component';
 
+import './search/search.scss';
+
 // Main section component names
 export const Faq = 'faq';
 export const FaqEntries = 'faqEntries';

--- a/platform-hub-web/src/app/help/search/search.component.js
+++ b/platform-hub-web/src/app/help/search/search.component.js
@@ -1,27 +1,46 @@
 export const SearchComponent = {
+  bindings: {
+    transition: '<'
+  },
   template: require('./search.html'),
   controller: SearchController
 };
 
-function SearchController($sce, hubApiService, icons, _) {
+function SearchController($state, $sce, hubApiService, icons, _) {
   'ngInject';
 
   const ctrl = this;
 
+  const query = ctrl.transition && ctrl.transition.params().q;
+
   ctrl.supportRequestsIcon = icons.supportRequests;
+  ctrl.docsIcon = icons.docs;
 
   ctrl.loading = false;
   ctrl.initialState = true;
-  ctrl.searchText = '';
+  ctrl.searchText = query;
   ctrl.results = [];
 
-  ctrl.fetchResults = fetchResults;
+  ctrl.search = search;
+  ctrl.clear = clear;
+
+  init();
+
+  function init() {
+    if (query) {
+      fetchResults();
+    }
+  }
+
+  function search() {
+    $state.go($state.current, {q: ctrl.searchText}, {reload: true});
+  }
+
+  function clear() {
+    $state.go($state.current, {q: undefined}, {reload: true});
+  }
 
   function fetchResults() {
-    if (_.isNull(ctrl.searchText) || _.isEmpty(ctrl.searchText)) {
-      return;
-    }
-
     ctrl.initialState = false;
     ctrl.loading = true;
     ctrl.results = [];

--- a/platform-hub-web/src/app/help/search/search.html
+++ b/platform-hub-web/src/app/help/search/search.html
@@ -17,7 +17,7 @@
         name="$ctrl.searchForm"
         role="form"
         class="compact"
-        ng-submit="$ctrl.fetchResults()"
+        ng-submit="$ctrl.search()"
         layout="row" layout-align="start center" layout-padding>
         <md-input-container
           class="md-icon-float md-block md-title compact hide-error-spacer"
@@ -40,7 +40,7 @@
           <md-button
             class="md-raised"
             aria-label="Clear search"
-            ng-click="$ctrl.searchText = ''; $ctrl.results = [];"
+            ng-click="$ctrl.clear()"
             ng-disabled="!$ctrl.searchText">
             Clear
           </md-button>
@@ -56,29 +56,51 @@
       No help items found
     </p>
 
-    <div>
-      <md-card
-        ng-repeat="item in $ctrl.results track by item.id"
-        ng-if="item.type == 'support-request'"
-        ui-sref="help.support.requests.new({id: item.hub_id})"
-        class="pointer">
-        <md-card-title>
-          <md-card-title-text>
-            <span class="md-headline">
-              <md-icon>{{$ctrl.supportRequestsIcon}}</md-icon>
-              <span ng-bind-html="item.title"></span>
-            </span>
-          </md-card-title-text>
-        </md-card-title>
+    <div class="search-results">
+      <md-list flex>
+        <ng-switch
+          ng-repeat="item in $ctrl.results track by item.id"
+          on="item.type">
 
-        <md-card-content ng-if="item.content" layout-padding>
-          <p
-            class="md-body-1"
-            md-colors="{background: 'blue-grey-50'}"
-            ng-bind-html='item.content'>
-          </p>
-        </md-card-content>
-      </md-card>
+          <!-- Support request -->
+          <md-list-item
+            ng-switch-when="support-request"
+            class="md-3-line md-long-text"
+            ui-sref="help.support.requests.new({id: item.hub_id})">
+            <md-icon class="md-avatar-icon">{{$ctrl.supportRequestsIcon}}</md-icon>
+            <div class="md-list-item-text" layout="column">
+              <h3 ng-bind-html="item.title"></h3>
+              <h4>
+                <small class="badge" md-colors="{background: 'blue-grey-400'}">
+                  Support request form
+                </small>
+              </h4>
+              <p ng-bind-html='item.content'></p>
+            </div>
+            <md-divider ng-if="!$last"></md-divider>
+          </md-list-item>
+
+          <!-- Doc -->
+          <md-list-item
+            ng-switch-when="doc"
+            class="md-3-line md-long-text"
+            ng-href="{{item.link}}"
+            target="_blank">
+            <md-icon class="md-avatar-icon">{{$ctrl.docsIcon}}</md-icon>
+            <div class="md-list-item-text" layout="column">
+              <h3 ng-bind-html="item.title"></h3>
+              <h4>
+                <small class="badge" md-colors="{background: 'blue-grey-400'}">
+                  Documentation
+                </small>
+              </h4>
+              <p ng-bind-html='item.content'></p>
+            </div>
+            <md-divider ng-if="!$last"></md-divider>
+          </md-list-item>
+
+        </ng-switch>
+      </md-list>
     </div>
 
   </md-content>

--- a/platform-hub-web/src/app/help/search/search.scss
+++ b/platform-hub-web/src/app/help/search/search.scss
@@ -1,0 +1,19 @@
+.search-results {
+  .badge {
+    margin-left: 0;
+    margin-right: 0.66em
+  }
+
+  md-list-item.md-3-line.md-long-text {
+    margin-top: 0;
+    margin-bottom: 0;
+
+    .md-list-item-text {
+      margin-bottom: 1em;
+
+      h3 {
+        margin-top: 1em;
+      }
+    }
+  }
+}

--- a/platform-hub-web/src/app/shared/icons.factory.js
+++ b/platform-hub-web/src/app/shared/icons.factory.js
@@ -8,6 +8,7 @@ export const icons = function () {
     contactList: 'contacts',
     copy: 'content_copy',
     costsReports: 'attach_money',
+    docs: 'description',
     docsSources: 'library_books',
     escalateToken: 'security',
     externalLink: 'link',

--- a/platform-hub-web/src/app/shared/model/docs-sources.js
+++ b/platform-hub-web/src/app/shared/model/docs-sources.js
@@ -7,7 +7,7 @@ export const DocsSources = function (hubApiService) {
 
   model.kinds = {
     github_repo: 'GitHub repo',
-    gitlab_repo: 'Gitlab repo'
+    gitlab_repo: 'GitLab repo'
   };
 
   model.getAll = hubApiService.getDocsSources;


### PR DESCRIPTION
This commit introduces the logic / services to:
- sync the markdown file entries from GitHub repos to entries in the db (with support for adding, modifying and deleting entries on subsequent syncs)
- fetching the content of these markdown files, parsing out the headers and overall content, sanitising, and then indexing into the Help Search index
- rake task to trigger the full docs sync whenever needed and on a regular cycle if needed
- UI to configure GitHub repos as sources for docs
- UI to show docs in Help Search results

---

**Note:** there's more to come in separate PRs: GitLab repo support; better admin UI; manual sync option; etc.