### PR TITLE
Hub admins can pin help entries to the top of the help search page

### DIFF
--- a/platform-hub-api/app/controllers/pinned_help_entries_controller.rb
+++ b/platform-hub-api/app/controllers/pinned_help_entries_controller.rb
@@ -1,0 +1,48 @@
+class PinnedHelpEntriesController < ApiJsonController
+
+  LIST_NAME = 'default'
+
+  before_action :load_pinned_help_entries_hash_record
+
+  # GET /pinned_help_entries
+  def show
+    authorize! :manage, :pinned_help_entries
+
+    render json: entries
+  end
+
+  # PUT /pinned_help_entries
+  def update
+    authorize! :manage, :pinned_help_entries
+
+    data = @pinned_help_entries.data.merge({
+        LIST_NAME => params[:pinned_help_entry][:_json]
+    })
+
+    if @pinned_help_entries.update(data: data)
+      AuditService.log(
+        context: audit_context,
+        action: 'update_pinned_help_entries'
+      )
+
+      render json: entries
+    else
+      render @pinned_help_entries
+    end
+  end
+
+  private
+
+  def load_pinned_help_entries_hash_record
+    @pinned_help_entries = HashRecord.webapp.find_or_create_by!(id: 'pinned_help_entries') do |r|
+      r.data = {
+        LIST_NAME => []
+      }
+    end
+  end
+
+  def entries
+    @pinned_help_entries.data[LIST_NAME]
+  end
+
+end

--- a/platform-hub-api/app/services/help_search_service.rb
+++ b/platform-hub-api/app/services/help_search_service.rb
@@ -104,8 +104,8 @@ class HelpSearchService
 
     Array(results.response.hits.hits).map do |h|
       {
-        'item' => h._source.to_hash,
-        'highlights' => h.highlight.to_hash
+        'item' => h._source.to_hash.reject { |k,v| k == 'content' },
+        'highlights' => h.highlight.respond_to?(:to_hash) ? h.highlight.to_hash : {}
       }
     end
   end

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -159,6 +159,9 @@ Rails.application.routes.draw do
       get :entries, on: :member
     end
 
+    get '/pinned_help_entries', to: 'pinned_help_entries#show'
+    put '/pinned_help_entries', to: 'pinned_help_entries#update'
+
   end
 
 end

--- a/platform-hub-api/spec/controllers/pinned_help_entries_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/pinned_help_entries_controller_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe PinnedHelpEntriesController, type: :controller do
+
+  let(:key) { 'pinned_help_entries' }
+
+  describe 'GET #show' do
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        get :show
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          get :show
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        context 'when no data exists' do
+          it 'creates a new HashRecord with an empty default list and returns it' do
+            expect(HashRecord.webapp.where(id: key).count).to eq 0
+            get :show
+            expect(response).to be_success
+            expect(json_response).to eq([])
+            expect(HashRecord.webapp.where(id: key).count).to eq 1
+          end
+        end
+
+        context 'when data exists' do
+          let :data do
+            {
+              'default' => ['1', '2', '3']
+            }
+          end
+
+          before do
+            @pinned_help_entries = create :hash_record, id: key, scope: 'webapp', data: data
+          end
+
+          it 'returns the default list' do
+            get :show
+            expect(response).to be_success
+            expect(json_response).to eq data['default']
+          end
+        end
+
+      end
+
+    end
+  end
+
+  describe 'PUT #update' do
+    let :put_data do
+      {
+        'pinned_help_entry' => { '_json' => ['1', '5', '4', '7'] }
+      }
+    end
+
+    it_behaves_like 'unauthenticated not allowed'  do
+      before do
+        put :update, params: put_data
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+
+      it_behaves_like 'not a hub admin so forbidden'  do
+        before do
+          put :update, params: put_data
+        end
+      end
+
+      it_behaves_like 'a hub admin' do
+
+        before do
+          @pinned_help_entries = create :hash_record, id: key, scope: 'webapp', data: { 'default'=> ['1', '2', '3'] }
+        end
+
+        it 'updates the default list' do
+          expect(HashRecord.webapp.where(id: key).count).to eq 1
+          put :update, params: put_data
+          expect(response).to be_success
+          expect(json_response).to eq put_data['pinned_help_entry']['_json']
+          expect(HashRecord.webapp.where(id: key).count).to eq 1
+          expect(Audit.count).to eq 1
+          audit = Audit.first
+          expect(audit.action).to eq 'update_pinned_help_entries'
+          expect(audit.user.id).to eq current_user_id
+        end
+
+      end
+
+    end
+  end
+
+end

--- a/platform-hub-api/spec/routing/pinned_help_entries_routing_spec.rb
+++ b/platform-hub-api/spec/routing/pinned_help_entries_routing_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe PinnedHelpEntriesController, type: :routing do
+  describe 'routing' do
+
+    it 'routes to #show' do
+      expect(:get => "/pinned_help_entries").to route_to('pinned_help_entries#show')
+    end
+
+    it 'routes to #update' do
+      expect(:put => "/pinned_help_entries").to route_to('pinned_help_entries#update')
+    end
+
+  end
+end

--- a/platform-hub-web/src/app/app.routes.js
+++ b/platform-hub-web/src/app/app.routes.js
@@ -19,7 +19,8 @@ import {
 import {
   DocsSourcesDetail,
   DocsSourcesForm,
-  DocsSourcesList
+  DocsSourcesList,
+  PinnedHelpEntriesForm
 } from './docs-sources/docs-sources.module';
 import {
   FeatureFlagsForm
@@ -841,5 +842,13 @@ export const appRoutes = function ($stateProvider, $urlRouterProvider, $location
           authenticate: true,
           rolesPermitted: ['admin']
         }
-      });
+      })
+    .state('pinned-help-entries', {
+      url: '/pinned-help-entries/edit',
+      component: PinnedHelpEntriesForm,
+      data: {
+        authenticate: true,
+        rolesPermitted: ['admin']
+      }
+    });
 };

--- a/platform-hub-web/src/app/docs-sources/docs-sources.module.js
+++ b/platform-hub-web/src/app/docs-sources/docs-sources.module.js
@@ -3,15 +3,18 @@ import angular from 'angular';
 import {DocsSourcesDetailComponent} from './docs-sources-detail.component';
 import {DocsSourcesFormComponent} from './docs-sources-form.component';
 import {DocsSourcesListComponent} from './docs-sources-list.component';
+import {PinnedHelpEntriesFormComponent} from './pinned-help-entries-form.component';
 
 // Main section component names
 export const DocsSourcesDetail = 'docsSourcesDetail';
 export const DocsSourcesForm = 'docsSourcesForm';
 export const DocsSourcesList = 'docsSourcesList';
+export const PinnedHelpEntriesForm = 'pinnedHelpEntriesForm';
 
 export const DocsSourcesModule = angular
   .module('app.docs-sources', [])
   .component(DocsSourcesDetail, DocsSourcesDetailComponent)
   .component(DocsSourcesForm, DocsSourcesFormComponent)
   .component(DocsSourcesList, DocsSourcesListComponent)
+  .component(PinnedHelpEntriesForm, PinnedHelpEntriesFormComponent)
   .name;

--- a/platform-hub-web/src/app/docs-sources/pinned-help-entries-form.component.js
+++ b/platform-hub-web/src/app/docs-sources/pinned-help-entries-form.component.js
@@ -1,0 +1,77 @@
+export const PinnedHelpEntriesFormComponent = {
+  template: require('./pinned-help-entries-form.html'),
+  controller: PinnedHelpEntriesFormController
+};
+
+function PinnedHelpEntriesFormController(PinnedHelpEntries, hubApiService, logger, _) {
+  'ngInject';
+
+  const ctrl = this;
+
+  ctrl.loading = true;
+  ctrl.saving = false;
+  ctrl.entries = [];
+  ctrl.searchSelectedEntry = null;
+  ctrl.searchText = '';
+
+  ctrl.search = search;
+  ctrl.addSelectedToPinned = addSelectedToPinned;
+  ctrl.update = update;
+
+  init();
+
+  function init() {
+    loadEntries();
+  }
+
+  function loadEntries() {
+    ctrl.loading = true;
+
+    return PinnedHelpEntries
+      .get()
+      .then(entries => {
+        // Make sure to store a copy as we may be mutating this!
+        angular.copy(entries, ctrl.entries);
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function search(query) {
+    return hubApiService.helpSearch({q: query});
+  }
+
+  function addSelectedToPinned() {
+    if (ctrl.searchSelectedEntry) {
+      const item = ctrl.searchSelectedEntry.item;
+      addToEntries(item);
+      ctrl.searchText = '';
+      ctrl.searchSelectedEntry = null;
+    }
+  }
+
+  function update() {
+    ctrl.saving = true;
+
+    return PinnedHelpEntries
+      .update(ctrl.entries)
+      .then(() => {
+        logger.success('Updated the list of pinned help entries');
+        return loadEntries();
+      })
+      .finally(() => {
+        ctrl.saving = false;
+      });
+  }
+
+  function addToEntries(item) {
+    const id = item.id;
+
+    const exists = _.some(ctrl.entries, e => e.id === id);
+
+    if (!exists) {
+      ctrl.entries.push(item);
+    }
+  }
+}

--- a/platform-hub-web/src/app/docs-sources/pinned-help-entries-form.html
+++ b/platform-hub-web/src/app/docs-sources/pinned-help-entries-form.html
@@ -1,0 +1,96 @@
+<div class="pinned-help-entries-form">
+  <md-toolbar>
+    <div class="md-toolbar-tools">
+      <h2>
+        Pinned help entries
+      </h2>
+    </div>
+  </md-toolbar>
+
+  <loading-indicator loading="$ctrl.loading || $ctrl.saving"></loading-indicator>
+
+  <md-content layout-padding ng-if="!$ctrl.loading">
+
+    <div flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z1" layout-padding>
+      <p class="md-body-1" md-colors="{background: 'primary-50'}">
+        The list specfied here will be shown by default on the help search page when no search has been carried out yet.
+      </p>
+
+      <div>
+        <h3 class="md-title">
+          Add item:
+        </h3>
+        <div layout="column" layout-margin layout-padding>
+          <md-autocomplete
+            md-no-cache="true"
+            md-selected-item="$ctrl.searchSelectedEntry"
+            md-selected-item-change="$ctrl.addSelectedToPinned()"
+            md-search-text="$ctrl.searchText"
+            md-items="entry in $ctrl.search($ctrl.searchText)"
+            md-item-text="'[' + entry.item.type + '] ' + entry.item.title"
+            md-min-length="2"
+            ng-model-options="{debounce: 500}"
+            placeholder="Search for existing help items to add...">
+            <md-item-template>
+              <span md-highlight-text="$ctrl.searchText" md-highlight-flags="^i">
+                [{{entry.item.type}}]
+                {{entry.item.title}}
+              </span>
+              <span ng-if="entry.item.link">
+                - <small>{{entry.item.link}}</small>
+              </span>
+            </md-item-template>
+            <md-not-found>
+              No items found in the help search matching "{{$ctrl.searchText}}"
+            </md-not-found>
+          </md-autocomplete>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="md-title">
+          Manage the list:
+        </h3>
+        <div
+          sv-root
+          class="multi-sortable"
+          layout="column"
+          layout-margin
+          layout-padding>
+          <div
+            flex
+            class="sortable-container"
+            sv-part="$ctrl.entries"
+            md-colors="{background: 'blue-grey-50'}">
+            <div
+              ng-repeat="e in $ctrl.entries"
+              md-colors="{background: 'blue-grey-100'}"
+              sv-element
+              md-whiteframe="1"
+              class="item">
+              <span>
+                [{{e.type}}]
+                {{e.title}}
+              </span>
+              <br ng-if="e.link" />
+              <small ng-if="e.link">{{e.link}}</small>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <md-button
+          type="button"
+          class="md-primary md-raised"
+          ng-click="$ctrl.update()"
+          ng-disabled="$ctrl.saving"
+          aria-label="Save the list of pinned help entries">
+          Save
+        </md-button>
+        <md-button ui-sref="home" ng-disabled="$ctrl.saving">Cancel</md-button>
+      </div>
+    </div>
+
+  </md-content>
+</div>

--- a/platform-hub-web/src/app/help/search/search.component.js
+++ b/platform-hub-web/src/app/help/search/search.component.js
@@ -6,19 +6,19 @@ export const SearchComponent = {
   controller: SearchController
 };
 
-function SearchController($state, $sce, hubApiService, icons, _) {
+function SearchController($state, $sce, hubApiService, PinnedHelpEntries, icons, _) {
   'ngInject';
 
   const ctrl = this;
 
-  const query = ctrl.transition && ctrl.transition.params().q;
+  ctrl.query = ctrl.transition && ctrl.transition.params().q;
 
   ctrl.supportRequestsIcon = icons.supportRequests;
   ctrl.docsIcon = icons.docs;
 
   ctrl.loading = false;
   ctrl.initialState = true;
-  ctrl.searchText = query;
+  ctrl.searchText = ctrl.query;
   ctrl.results = [];
 
   ctrl.search = search;
@@ -27,8 +27,10 @@ function SearchController($state, $sce, hubApiService, icons, _) {
   init();
 
   function init() {
-    if (query) {
+    if (ctrl.query) {
       fetchResults();
+    } else {
+      fetchPinnedItems();
     }
   }
 
@@ -41,7 +43,6 @@ function SearchController($state, $sce, hubApiService, icons, _) {
   }
 
   function fetchResults() {
-    ctrl.initialState = false;
     ctrl.loading = true;
     ctrl.results = [];
 
@@ -53,6 +54,20 @@ function SearchController($state, $sce, hubApiService, icons, _) {
       .helpSearch(params)
       .then(results => {
         ctrl.results = processResults(results);
+        ctrl.initialState = false;
+      })
+      .finally(() => {
+        ctrl.loading = false;
+      });
+  }
+
+  function fetchPinnedItems() {
+    ctrl.loading = true;
+
+    PinnedHelpEntries
+      .get()
+      .then(items => {
+        angular.copy(items, ctrl.results);
       })
       .finally(() => {
         ctrl.loading = false;

--- a/platform-hub-web/src/app/help/search/search.html
+++ b/platform-hub-web/src/app/help/search/search.html
@@ -50,11 +50,18 @@
     </div>
 
     <p
-      ng-if="!$ctrl.initialState && !$ctrl.results.length"
+      ng-if="$ctrl.query && !$ctrl.initialState && !$ctrl.results.length"
       class="none-text"
       layout="row" layout-align="center center" layout-padding>
       No help items found
     </p>
+
+    <h4
+      ng-if="!$ctrl.query && $ctrl.results.length"
+      layout="row" layout-align="center center" layout-padding
+      style="padding-bottom: 0;">
+      Suggestions
+    </h4>
 
     <div class="search-results">
       <md-list flex>
@@ -65,7 +72,10 @@
           <!-- Support request -->
           <md-list-item
             ng-switch-when="support-request"
-            class="md-3-line md-long-text"
+            ng-class="{
+              'md-2-line': !item.content,
+              'md-3-line md-long-text': item.content
+            }"
             ui-sref="help.support.requests.new({id: item.hub_id})">
             <md-icon class="md-avatar-icon">{{$ctrl.supportRequestsIcon}}</md-icon>
             <div class="md-list-item-text" layout="column">
@@ -75,7 +85,7 @@
                   Support request form
                 </small>
               </h4>
-              <p ng-bind-html='item.content'></p>
+              <p ng-if="item.content" ng-bind-html='item.content'></p>
             </div>
             <md-divider ng-if="!$last"></md-divider>
           </md-list-item>
@@ -83,7 +93,10 @@
           <!-- Doc -->
           <md-list-item
             ng-switch-when="doc"
-            class="md-3-line md-long-text"
+            ng-class="{
+              'md-2-line': !item.content,
+              'md-3-line md-long-text': item.content
+            }"
             ng-href="{{item.link}}"
             target="_blank">
             <md-icon class="md-avatar-icon">{{$ctrl.docsIcon}}</md-icon>
@@ -94,7 +107,7 @@
                   Documentation
                 </small>
               </h4>
-              <p ng-bind-html='item.content'></p>
+              <p ng-if="item.content" ng-bind-html='item.content'></p>
             </div>
             <md-divider ng-if="!$last"></md-divider>
           </md-list-item>

--- a/platform-hub-web/src/app/layout/shell.component.js
+++ b/platform-hub-web/src/app/layout/shell.component.js
@@ -129,6 +129,11 @@ function ShellController($scope, $mdSidenav, authService, roleCheckerService, ev
       icon: icons.docsSources
     },
     {
+      title: 'Pinned Help Entries',
+      state: 'pinned-help-entries',
+      icon: icons.pinnedHelpEntries
+    },
+    {
       title: 'Users',
       state: 'users',
       icon: icons.users

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -189,6 +189,9 @@ export const hubApiService = function ($rootScope, $http, $q, logger, apiEndpoin
   service.syncDocsSource = syncDocsSource;
   service.getDocsSourceEntries = buildSubCollectionFetcher('docs_sources', 'entries');
 
+  service.getPinnedHelpEntries = buildSimpleFetcher('pinned_help_entries', 'pinned help entries');
+  service.updatePinnedHelpEntries = buildSimpleUpdater('pinned_help_entries', 'pinned help entries');
+
   return service;
 
   function getMe() {

--- a/platform-hub-web/src/app/shared/icons.factory.js
+++ b/platform-hub-web/src/app/shared/icons.factory.js
@@ -25,6 +25,7 @@ export const icons = function () {
     link: 'link',
     markAllRead: 'drafts',
     menu: 'menu',
+    pinnedHelpEntries: 'low_priority',
     platformThemes: 'lens',
     projects: 'group_work',
     revokeToken: 'delete_sweep',

--- a/platform-hub-web/src/app/shared/model/model.module.js
+++ b/platform-hub-web/src/app/shared/model/model.module.js
@@ -15,6 +15,7 @@ import {KubernetesGroups} from './kubernetes-groups';
 import {KubernetesNamespaces} from './kubernetes-namespaces';
 import {KubernetesTokens} from './kubernetes-tokens';
 import {Me} from './me';
+import {PinnedHelpEntries} from './pinned-help-entries';
 import {PlatformThemes} from './platform-themes';
 import {PlatformThemesResourceKinds} from './platform-themes-resource-kinds';
 import {Projects} from './projects';
@@ -40,6 +41,7 @@ export const ModelModule = angular
   .service('KubernetesNamespaces', KubernetesNamespaces)
   .service('KubernetesTokens', KubernetesTokens)
   .service('Me', Me)
+  .service('PinnedHelpEntries', PinnedHelpEntries)
   .service('PlatformThemes', PlatformThemes)
   .service('PlatformThemesResourceKinds', PlatformThemesResourceKinds)
   .service('Projects', Projects)

--- a/platform-hub-web/src/app/shared/model/pinned-help-entries.js
+++ b/platform-hub-web/src/app/shared/model/pinned-help-entries.js
@@ -1,0 +1,10 @@
+export const PinnedHelpEntries = function (hubApiService) {
+  'ngInject';
+
+  const model = {};
+
+  model.get = hubApiService.getPinnedHelpEntries;
+  model.update = hubApiService.updatePinnedHelpEntries;
+
+  return model;
+};


### PR DESCRIPTION
This list is managed in a new admin section - 'Pinned Help Entries' in the admin nav section.

This list is ordered.