### PR TITLE
Help search: count queries and result sizes and show on help search page

### DIFF
--- a/platform-hub-api/app/controllers/help_controller.rb
+++ b/platform-hub-api/app/controllers/help_controller.rb
@@ -1,6 +1,6 @@
 class HelpController < ApiJsonController
 
-  skip_authorization_check only: [ :search ]
+  skip_authorization_check only: [ :search, :search_query_stats ]
 
   # GET /help/search
   def search
@@ -11,12 +11,20 @@ class HelpController < ApiJsonController
     else
       begin
         results = HelpSearchService.instance.search(q)
+
+        HelpSearchStatsService.count_query q, results.size
+
         render json: results
       rescue HelpSearchService::Errors::SearchUnavailable
         logger.error 'Help search service is currently unavailable'
         service_unavailable_error 'Search is currently unavailable'
       end
     end
+  end
+
+  # GET /help/search_query_stats
+  def search_query_stats
+    render json: HelpSearchStatsService.query_stats.first(20)
   end
 
 end

--- a/platform-hub-api/app/services/help_search_service.rb
+++ b/platform-hub-api/app/services/help_search_service.rb
@@ -113,7 +113,8 @@ class HelpSearchService
           title: { number_of_fragments: 0 },
           content: { number_of_fragments: 3 }
         }
-      }
+      },
+      size: 100
     )
 
     Array(results.response.hits.hits).map do |h|

--- a/platform-hub-api/app/services/help_search_stats_service.rb
+++ b/platform-hub-api/app/services/help_search_stats_service.rb
@@ -1,0 +1,62 @@
+module HelpSearchStatsService
+
+  KEY = 'help_search_stats'
+
+  LAST_RESULT_SIZES_TO_KEEP = 3
+
+  def self.count_query(query, results_size)
+    return if query.blank?
+
+    normalised_query = query.strip.downcase
+
+    record = get_hash_record
+
+    record.with_lock do
+      queries = record.data['queries']
+
+      data = if queries.has_key? normalised_query
+        queries[normalised_query]
+      else
+        queries[normalised_query] = {
+          'count' => 0,
+          'last_result_sizes' => []
+        }
+      end
+
+      data['count'] += 1
+      data['last_result_sizes'] << results_size
+      data['last_result_sizes'] = data['last_result_sizes'].last(LAST_RESULT_SIZES_TO_KEEP)
+
+      record.save!
+    end
+  rescue => ex
+    Rails.logger.error "Failed to record help search stats for query: #{query} - error: #{ex.message}"
+  end
+
+  def self.query_stats
+    stats = get_hash_record
+      .data['queries']
+      .each_with_object([]) do |(k,v), acc|
+        acc << {
+          query: k,
+          count: v['count'],
+          last_result_sizes: v['last_result_sizes']
+        }
+      end
+
+    stats.sort do |a, b|
+      c = (b[:count] <=> a[:count])
+      c.zero? ? (a[:query] <=> b[:query]) : c
+    end
+  end
+
+  private_class_method def self.get_hash_record
+    HashRecord.find_or_create_by!(id: KEY, scope: 'general') do |r|
+      r.data = {
+        'queries' => {}
+      }
+    end
+  end
+
+
+end

--- a/platform-hub-api/config/routes.rb
+++ b/platform-hub-api/config/routes.rb
@@ -151,7 +151,10 @@ Rails.application.routes.draw do
       get :last_published_config, on: :collection
     end
 
-    get '/help/search', to: 'help#search', constraints: lambda { |_| FeatureFlagService.is_enabled? :help_search }
+    constraints lambda { |_| FeatureFlagService.is_enabled? :help_search } do
+      get '/help/search', to: 'help#search'
+      get '/help/search_query_stats', to: 'help#search_query_stats'
+    end
 
     resources :docs_sources do
       post '/sync', to: 'docs_sources#sync_all', on: :collection

--- a/platform-hub-api/spec/controllers/help_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/help_controller_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe HelpController, type: :controller do
           expect(help_search_service_instance).to receive(:search)
             .with(query)
             .and_return(results)
+
+          expect(HelpSearchStatsService).to receive(:count_query)
+            .with(query, results.size)
         end
 
         it 'should return the results as expected' do

--- a/platform-hub-api/spec/routing/help_routing_spec.rb
+++ b/platform-hub-api/spec/routing/help_routing_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe HelpController, type: :routing do
         expect(:get => '/help/search').to route_to('help#search')
       end
 
+      it 'routes to #search_query_stats' do
+        expect(:get => '/help/search_query_stats').to route_to('help#search_query_stats')
+      end
+
     end
   end
 
@@ -24,6 +28,10 @@ RSpec.describe HelpController, type: :routing do
 
     it 'route to #search is not routable' do
       expect(:get => '/help/search').to_not be_routable
+    end
+
+    it 'route to #search_query_stats is not routable' do
+      expect(:get => '/help/search_query_stats').to_not be_routable
     end
 
   end

--- a/platform-hub-api/spec/services/help_search_stats_service_spec.rb
+++ b/platform-hub-api/spec/services/help_search_stats_service_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe HelpSearchStatsService, type: :service do
+
+  let(:key) { HelpSearchStatsService::KEY }
+
+  describe 'counting queries and getting query stats' do
+    it 'should keep a record of query counts as well as last n result sizes per queries' do
+      expect(subject.query_stats).to be_empty
+
+      subject.count_query 'foo', 21
+
+      expect(subject.query_stats).to eq([
+        { query: 'foo', count: 1, last_result_sizes: [21]}
+      ])
+
+      subject.count_query 'Foo ', 23
+
+      expect(subject.query_stats).to eq([
+        { query: 'foo', count: 2, last_result_sizes: [21, 23]}
+      ])
+
+      subject.count_query 'bar bar', 0
+
+      expect(subject.query_stats).to eq([
+        { query: 'foo', count: 2, last_result_sizes: [21, 23]},
+        { query: 'bar bar', count: 1, last_result_sizes: [0]}
+      ])
+
+      subject.count_query 'moo', 4
+
+      expect(subject.query_stats).to eq([
+        { query: 'foo', count: 2, last_result_sizes: [21, 23]},
+        { query: 'bar bar', count: 1, last_result_sizes: [0]},
+        { query: 'moo', count: 1, last_result_sizes: [4]}
+      ])
+
+      subject.count_query 'moo', 3
+      subject.count_query 'moo', 7
+      subject.count_query 'moo', 10
+
+      expect(subject.query_stats).to eq([
+        { query: 'moo', count: 4, last_result_sizes: [3, 7, 10]},
+        { query: 'foo', count: 2, last_result_sizes: [21, 23]},
+        { query: 'bar bar', count: 1, last_result_sizes: [0]}
+      ])
+    end
+  end
+
+end

--- a/platform-hub-web/src/app/help/search/search.html
+++ b/platform-hub-web/src/app/help/search/search.html
@@ -139,5 +139,41 @@
       </md-list>
     </div>
 
+    <!-- Stats -->
+    <section ng-if="!$ctrl.query && $ctrl.stats.length" layout="column" layout-align="center center" layout-padding style="margin-top: 1em;">
+      <h4>
+        Popular search queries
+      </h4>
+
+      <table class="simple-table">
+        <thead>
+          <th></th>
+          <th>
+            Count
+          </th>
+          <th>
+            Last result size(s)
+          </th>
+        </thead>
+        <tbody>
+          <tr ng-repeat="s in $ctrl.stats track by s.query">
+            <td class="centred">
+              <a ui-sref="help.search({q: s.query, reload: true})">
+                {{s.query}}
+              </a>
+            </td>
+            <td class="centred">
+              {{s.count}}
+            </td>
+            <td class="centred">
+              {{s.last_result_sizes.join(', ')}}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <br />
+
   </md-content>
 </div>

--- a/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
+++ b/platform-hub-web/src/app/shared/hub-api/hub-api.service.js
@@ -179,6 +179,7 @@ export const hubApiService = function ($rootScope, $http, $q, logger, apiEndpoin
   service.lastPublishedConfigCostsReports = buildSimpleFetcher('costs_reports/last_published_config');
 
   service.helpSearch = buildSimpleFetcher('help/search', 'help search');
+  service.helpSearchQueryStats = buildSimpleFetcher('help/search_query_stats', 'help search query stats');
 
   service.getDocsSources = buildCollectionFetcher('docs_sources');
   service.getDocsSource = buildResourceFetcher('docs_sources');


### PR DESCRIPTION
The top 20 popular searches are shown on the help search page when no query has been made. (It will be shown under the suggestions (aka pinned items).

Example:

![screenshot 2018-10-04 15 46 33](https://user-images.githubusercontent.com/31973/46482164-f9165600-c7ec-11e8-8965-cb90cb5ab4fa.png)
