### PR TITLE
Help search: Q&As and support requests will show up higher if more relevant

### DIFF
--- a/platform-hub-api/app/services/help_search_service.rb
+++ b/platform-hub-api/app/services/help_search_service.rb
@@ -118,11 +118,27 @@ class HelpSearchService
 
     results = @repository.search(
       query: {
-        multi_match: {
-          query: query,
-          fields: ['title^10', 'content', 'headings^7'],
-          type: 'phrase',
-          slop: 10
+        function_score: {
+          query: {
+            multi_match: {
+              query: query,
+              fields: ['title^10', 'content', 'headings^7'],
+              type: 'phrase',
+              slop: 10
+            }
+          },
+          functions: [
+            {
+              filter: { match: { type: Types::SUPPORT_REQUEST } },
+              weight: 30
+            },
+            {
+              filter: { match: { type: Types::QA_ENTRY } },
+              weight: 20
+            }
+          ],
+          score_mode: 'multiply',
+          boost_mode: 'multiply'
         }
       },
       highlight: {


### PR DESCRIPTION
Rationale: a Q&A entry or support request form will likely be more relevant to a user of the hub. So this change ensures that these two types of results show up higher, as long as the initial relevance (based on title and content matches) is high also.