### PR TITLE
Project shortname is now readonly

### DIFF
--- a/platform-hub-api/app/models/project.rb
+++ b/platform-hub-api/app/models/project.rb
@@ -11,9 +11,7 @@ class Project < ApplicationRecord
 
   allocation_receivable
 
-  def should_generate_new_friendly_id?
-    shortname_changed? || super
-  end
+  attr_readonly :shortname
 
   scope :by_shortname, -> (value) {
     # Important: the shortname query needs to be case insensitive
@@ -57,6 +55,17 @@ class Project < ApplicationRecord
     memberships
       .includes(:user)  # Eager load users for performance
       .joins(:user).order("users.name")  # Order by user name
+  end
+
+  private
+
+  def readonly?
+    if persisted?
+      read_only_attrs = self.class.readonly_attributes.to_a
+      if read_only_attrs.any? {|f| send(:"#{f}_changed?")}
+        raise ActiveRecord::ReadOnlyRecord, "#{read_only_attrs.join(', ')} can't be modified"
+      end
+    end
   end
 
 end

--- a/platform-hub-api/spec/controllers/projects_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/projects_controller_spec.rb
@@ -197,7 +197,6 @@ RSpec.describe ProjectsController, type: :controller do
       {
         id: @project.friendly_id,
         project: {
-          shortname: 'foo',
           name: 'foobar',
           cost_centre_code: 'NOTSOEXPENSIVENOW'
         }
@@ -235,7 +234,7 @@ RSpec.describe ProjectsController, type: :controller do
           expect(response).to be_success
           expect(Project.count).to eq 1
           updated = Project.first
-          expect(updated.shortname).to eq put_data[:project][:shortname]
+          expect(updated.shortname).to eq @project.shortname
           expect(updated.name).to eq put_data[:project][:name]
           expect(updated.description).to eq existing_description
           expect(updated.cost_centre_code).to eq put_data[:project][:cost_centre_code]

--- a/platform-hub-api/spec/models/announcement_spec.rb
+++ b/platform-hub-api/spec/models/announcement_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Announcement, type: :model do
       expect {
         a.update! title: 'baz'
       }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      expect(a.reload.title).to eq 'bar'
 
       a2 = Announcement.find(a.id)
       a2.update! status: :delivered
@@ -36,6 +37,7 @@ RSpec.describe Announcement, type: :model do
       expect {
         a.update! title: 'baz'
       }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      expect(a.reload.title).to eq 'bar'
 
       a2 = Announcement.find(a.id)
       a2.update! status: :delivered
@@ -50,14 +52,15 @@ RSpec.describe Announcement, type: :model do
     end
 
     it 'should allow status change from \'awaiting_resend\' to another status' do
-      a = create :published_announcement
+      a = create :published_announcement, title: 'foo'
 
       a.mark_for_resend!
       expect(a.status).to eq 'awaiting_resend'
 
       expect {
-        a.update! title: 'baz'
+        a.update! title: 'bar'
       }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      expect(a.reload.title).to eq 'foo'
 
       a2 = Announcement.find(a.id)
       a2.update! status: :delivering

--- a/platform-hub-api/spec/models/docs_source_spec.rb
+++ b/platform-hub-api/spec/models/docs_source_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe DocsSource, type: :model do
           ActiveRecord::ReadOnlyRecord,
           "kind can't be modified"
         )
+
+        expect(@docs_source.reload.github_repo?).to be true
       end
     end
   end

--- a/platform-hub-api/spec/models/kubernetes_token_spec.rb
+++ b/platform-hub-api/spec/models/kubernetes_token_spec.rb
@@ -255,25 +255,31 @@ RSpec.describe KubernetesToken, type: :model do
 
     describe '#token' do
       it 'does not allow to update token' do
+        previous_token = @t.token
         expect { @t.update_attributes(token: SecureRandom.uuid) }.to raise_error(
           ActiveRecord::ReadOnlyRecord, "token, name, uid, kind, cluster_id, project_id can't be modified"
         )
+        expect(@t.reload.token).to eq previous_token
       end
     end
 
     describe '#uid' do
       it 'does not allow to update uid' do
+        previous_uid = @t.uid
         expect { @t.update_attributes(uid: SecureRandom.uuid) }.to raise_error(
           ActiveRecord::ReadOnlyRecord, "token, name, uid, kind, cluster_id, project_id can't be modified"
         )
+        expect(@t.reload.uid).to eq previous_uid
       end
     end
 
     describe '#name' do
       it 'does not allow to update name' do
+        previous_name = @t.name
         expect { @t.update_attributes(name: 'new_name') }.to raise_error(
           ActiveRecord::ReadOnlyRecord, "token, name, uid, kind, cluster_id, project_id can't be modified"
         )
+        expect(@t.reload.name).to eq previous_name
       end
     end
 
@@ -282,9 +288,11 @@ RSpec.describe KubernetesToken, type: :model do
       let(:cluster) { create :kubernetes_cluster, allocate_to: service.project }
 
       it 'does not allow to update kind' do
+        previous_kind = @t.kind
         expect { @t.update_attributes(kind: 'robot', tokenable: service, cluster: cluster, description: 'blah', groups: []) }.to raise_error(
           ActiveRecord::ReadOnlyRecord, "token, name, uid, kind, cluster_id, project_id can't be modified"
         )
+        expect(@t.reload.kind).to eq previous_kind
       end
     end
 
@@ -297,9 +305,11 @@ RSpec.describe KubernetesToken, type: :model do
       end
 
       it 'does not allow to update project' do
+        previous_project_id = @t.project_id
         expect { @t.update_attributes(project: new_project) }.to raise_error(
           ActiveRecord::ReadOnlyRecord, "token, name, uid, kind, cluster_id, project_id can't be modified"
         )
+        expect(@t.reload.project_id).to eq previous_project_id
       end
     end
 
@@ -307,9 +317,11 @@ RSpec.describe KubernetesToken, type: :model do
       let(:new_cluster) { create :kubernetes_cluster, allocate_to: @t.project }
 
       it 'does not allow to update cluster' do
+        previous_cluster = @t.cluster
         expect { @t.update_attributes(cluster: new_cluster) }.to raise_error(
           ActiveRecord::ReadOnlyRecord, "token, name, uid, kind, cluster_id, project_id can't be modified"
         )
+        expect(@t.reload.cluster).to eq previous_cluster
       end
     end
   end

--- a/platform-hub-api/spec/models/project_spec.rb
+++ b/platform-hub-api/spec/models/project_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Project, type: :model do
+
+  describe '#shortname' do
+    before do
+      @project = create :project, shortname: 'Foo'
+    end
+
+    it 'is readonly' do
+      expect {
+        @project.update! shortname: 'Bar'
+      }.to raise_error(
+        ActiveRecord::ReadOnlyRecord,
+        "shortname can't be modified"
+      )
+
+      expect(@project.reload.shortname).to eq 'Foo'
+    end
+  end
+
+end

--- a/platform-hub-web/src/app/projects/projects-form.html
+++ b/platform-hub-web/src/app/projects/projects-form.html
@@ -21,6 +21,7 @@
             <input
               name="shortname"
               ng-model="$ctrl.project.shortname"
+              ng-disabled="!$ctrl.isNew"
               required
               placeholder="A short and memorable name or acronym for this project"
               autofocus>


### PR DESCRIPTION
… since we use this as a first class identifier in billing, etc.

As part of this change I've also added some extra checks in the various specs that check for readonly attribute behaviour.