### PR TITLE
Docker repos: set a `provider` on the repo record / resource

### DIFF
--- a/platform-hub-api/app/controllers/docker_repos_controller.rb
+++ b/platform-hub-api/app/controllers/docker_repos_controller.rb
@@ -19,6 +19,7 @@ class DockerReposController < ApiJsonController
     service = @project.services.find params[:service_id]
 
     docker_repo = service.docker_repos.new(docker_repo_params)
+    docker_repo.provider = :ECR
 
     if docker_repo.save
       # TODO post to queue

--- a/platform-hub-api/app/models/docker_repo.rb
+++ b/platform-hub-api/app/models/docker_repo.rb
@@ -6,7 +6,7 @@ class DockerRepo < ApplicationRecord
 
   audited descriptor_field: :name, associated_field: :service
 
-  attr_readonly :name, :service_id
+  attr_readonly :name, :service_id, :provider
 
   before_validation :build_repo_name
 
@@ -18,6 +18,10 @@ class DockerRepo < ApplicationRecord
     pending: 'pending',
     ready: 'ready',
     deleting: 'deleting',
+  }
+
+  enum provider: {
+    ECR: 'ECR'
   }
 
   validates :name,

--- a/platform-hub-api/app/serializers/docker_repo_serializer.rb
+++ b/platform-hub-api/app/serializers/docker_repo_serializer.rb
@@ -1,5 +1,5 @@
 class DockerRepoSerializer < ActiveModel::Serializer
-  attributes :id, :name, :url, :description, :status
+  attributes :id, :name, :url, :description, :status, :provider
 
   belongs_to :service
 

--- a/platform-hub-api/db/migrate/20181109123528_add_provider_to_docker_repos.rb
+++ b/platform-hub-api/db/migrate/20181109123528_add_provider_to_docker_repos.rb
@@ -1,0 +1,5 @@
+class AddProviderToDockerRepos < ActiveRecord::Migration[5.0]
+  def change
+    add_column :docker_repos, :provider, :string, null: false
+  end
+end

--- a/platform-hub-api/db/structure.sql
+++ b/platform-hub-api/db/structure.sql
@@ -251,7 +251,8 @@ CREATE TABLE docker_repos (
     status character varying NOT NULL,
     url character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    provider character varying NOT NULL
 );
 
 
@@ -1300,6 +1301,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180822125540'),
 ('20180822130915'),
 ('20180927152425'),
-('20181101135115');
+('20181101135115'),
+('20181109123528');
 
 

--- a/platform-hub-api/spec/controllers/docker_repos_controller_spec.rb
+++ b/platform-hub-api/spec/controllers/docker_repos_controller_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe DockerReposController, type: :controller do
           'url' => docker_repo.url,
           'description' => docker_repo.description,
           'status' => docker_repo.status,
+          'provider'=> docker_repo.provider,
           'created_at' => docker_repo.created_at.iso8601,
           'updated_at' => docker_repo.updated_at.iso8601
         )

--- a/platform-hub-api/spec/factories/docker_repos.rb
+++ b/platform-hub-api/spec/factories/docker_repos.rb
@@ -6,5 +6,6 @@ FactoryGirl.define do
     end
     service
     status :pending
+    provider :ECR
   end
 end

--- a/platform-hub-api/spec/models/docker_repo_spec.rb
+++ b/platform-hub-api/spec/models/docker_repo_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe DockerRepo, type: :model do
           @docker_repo.update! name: 'bar'
         }.to raise_error(
           ActiveRecord::ReadOnlyRecord,
-          "name, service_id can't be modified"
+          "name, service_id, provider can't be modified"
         )
         expect(@docker_repo.reload.name).to eq previous_name
       end
@@ -73,7 +73,7 @@ RSpec.describe DockerRepo, type: :model do
           @docker_repo.update! service: create(:service)
         }.to raise_error(
           ActiveRecord::ReadOnlyRecord,
-          "name, service_id can't be modified"
+          "name, service_id, provider can't be modified"
         )
         expect(@docker_repo.reload.service_id).to eq previous_service_id
       end

--- a/platform-hub-web/src/app/projects/docker-repos/project-docker-repos-form.html
+++ b/platform-hub-web/src/app/projects/docker-repos/project-docker-repos-form.html
@@ -28,6 +28,15 @@
 
     <div ng-if="$ctrl.services.length" flex-sm="100" flex-gt-sm="90" flex-gt-md="70" flex-gt-lg="50" class="md-whiteframe-z1" layout-padding>
       <md-content>
+        <p
+          class="md-body-1"
+          md-colors="{background: 'blue-grey-50', color: 'blue-grey'}"
+          layout-padding>
+          Fill in the form below to request a new Docker repository on AWS ECR
+        </p>
+
+        <br />
+
         <form
           name="$ctrl.repoForm"
           role="form"

--- a/platform-hub-web/src/app/projects/projects-detail.html
+++ b/platform-hub-web/src/app/projects/projects-detail.html
@@ -266,6 +266,12 @@
                 <span class="md-headline">
                   <small
                     class="badge float-right"
+                    md-colors="{background: 'blue-grey'}">
+                    {{d.provider}}
+                  </small>
+
+                  <small
+                    class="badge float-right"
                     ng-if="d.status == 'pending'"
                     md-colors="{background: 'blue'}">
                     Pending


### PR DESCRIPTION
Currently only 'ECR', but this allows us to potentially support others.