### PR TITLE
Next iteration of the Docker repos work: handling backend responses

### DIFF
--- a/platform-hub-api/app/models/docker_repo.rb
+++ b/platform-hub-api/app/models/docker_repo.rb
@@ -5,7 +5,8 @@ class DockerRepo < ApplicationRecord
   ACCESS_STATUS = {
     pending: 'pending',
     active: 'active',
-    removing: 'removing'
+    removing: 'removing',
+    failed: 'failed',
   }.freeze
 
   include Audited
@@ -25,6 +26,7 @@ class DockerRepo < ApplicationRecord
     pending: 'pending',
     active: 'active',
     deleting: 'deleting',
+    failed: 'failed',
   }
 
   enum provider: {

--- a/platform-hub-api/app/models/identity.rb
+++ b/platform-hub-api/app/models/identity.rb
@@ -7,7 +7,8 @@ class Identity < ApplicationRecord
   enum provider: {
     keycloak: 'keycloak',
     github: 'github',
-    kubernetes: 'kubernetes'
+    kubernetes: 'kubernetes',
+    ecr: 'ecr',
   }
 
   has_many :tokens, -> { where kind: 'user' }, as: :tokenable, class_name: KubernetesToken

--- a/platform-hub-api/app/models/user.rb
+++ b/platform-hub-api/app/models/user.rb
@@ -59,6 +59,10 @@ class User < ApplicationRecord
     identity :kubernetes
   end
 
+  def ecr_identity
+    identity :ecr
+  end
+
   def identity provider
     identities.find_by provider: provider
   end

--- a/platform-hub-api/app/serializers/identity_serializer.rb
+++ b/platform-hub-api/app/serializers/identity_serializer.rb
@@ -16,4 +16,8 @@ class IdentitySerializer < BaseSerializer
   has_many :kubernetes_tokens, if: -> { object.kubernetes? && FeatureFlagService.is_enabled?(:kubernetes_tokens) } do
     []  # For backwards compatibility; user tokens list has now been moved to a dedicated endpoint
   end
+
+  attribute :credentials, if: -> { object.ecr? && FeatureFlagService.is_enabled?(:docker_repos) } do
+    object.data['credentials']
+  end
 end

--- a/platform-hub-api/app/services/audit_service.rb
+++ b/platform-hub-api/app/services/audit_service.rb
@@ -13,7 +13,7 @@ module AuditService
         request_uuid: context[:request_uuid]
       )
     rescue => e
-      Rails.logger.error "Failed to log audit - exception: type = #{e.class.name}, message = #{e.message}, backtrace = #{e.backtrace.join("\n")}"
+      Rails.logger.error "Failed to log audit - exception: type = #{e.class.name}, message = #{e.message}, backtrace = #{e.backtrace.join(" -- ")}"
     end
   end
 

--- a/platform-hub-api/app/services/docker_repo_access_policy_service.rb
+++ b/platform-hub-api/app/services/docker_repo_access_policy_service.rb
@@ -95,9 +95,10 @@ class DockerRepoAccessPolicyService
           user = User.find_by email: username
           identity = user.ecr_identity || user.identities.build(
             provider: Identity.providers[:ecr],
-            external_id: username
+            external_id: username,
+            external_username: username,
           )
-          identity.data = { credentials: credentials }
+          identity.data = { 'credentials' => credentials }
           identity.save!
         },
         fields_to_update: [ 'writable' ]

--- a/platform-hub-api/app/services/docker_repo_access_policy_service.rb
+++ b/platform-hub-api/app/services/docker_repo_access_policy_service.rb
@@ -42,6 +42,78 @@ class DockerRepoAccessPolicyService
     )
   end
 
+  def handle_update_result message
+    id = message['resource']['id']
+    name = message['resource']['name']
+
+    begin
+      Audit.create!(
+        action: 'handle_access_update_result',
+        auditable_type: DockerRepo.name,
+        auditable_id: message['resource']['id'],
+        auditable_descriptor: message['resource']['name'],
+        data: { 'message' => message },
+      )
+    rescue => e
+      Rails.logger.error "Failed to log audit - exception: type = #{e.class.name}, message = #{e.message}, backtrace = #{e.backtrace.join("--")}"
+    end
+
+    docker_repo = DockerRepo.find_by id: id
+
+    if docker_repo.nil?
+      Rails.logger.error "[DockerRepoAccessPolicyService] handle_update_result - could not find a DockerRepo with ID: '#{id}' (name: '#{name}')"
+      return
+    end
+
+    # Even if the message has a `Failed` status, it's possible that individual
+    # access items have succeeded. So we need to go through each one and figure
+    # out if our internal state needs updating.
+
+    ActiveRecord::Base.transaction do
+
+      docker_repo.access['robots'] = process_items_from_result(
+        item_type: 'robot',
+        items: message['resource']['robots'],
+        current: docker_repo.access['robots'],
+        check_username: -> (_) { true },
+        set_credentials: -> (item, credentials) { item['credentials'] = credentials }
+      )
+
+      docker_repo.access['users'] = process_items_from_result(
+        item_type: 'user',
+        items: message['resource']['users'],
+        current: docker_repo.access['users'],
+        check_username: -> (email) {
+          user = User.find_by email: email
+          user.present? && ProjectMembershipsService.is_user_a_member_of_project?(
+              docker_repo.service.project_id,
+              user.id
+            )
+        },
+        set_credentials: -> (item, credentials) {
+          username = item['username']
+          user = User.find_by email: username
+          identity = user.ecr_identity || user.identities.build(
+            provider: Identity.providers[:ecr],
+            external_id: username
+          )
+          identity.data = { credentials: credentials }
+          identity.save!
+        },
+        fields_to_update: [ 'writable' ]
+      )
+
+      docker_repo.save!
+
+    end
+
+    AuditService.log(
+      action: 'access_update',
+      auditable: docker_repo,
+      comment: "Backend status was: #{message['result']['status']}"
+    )
+  end
+
   private
 
   def validate_robots robots
@@ -106,6 +178,56 @@ class DockerRepoAccessPolicyService
     end
 
     updated.sort_by { |i| i['username'] }
+  end
+
+  def process_items_from_result item_type:, items:, current:, check_username:, set_credentials:, fields_to_update: []
+    processed = Set.new
+
+    items.each do |r|
+      username = r['username']
+
+      if check_username.call username
+        processed.add username
+
+        existing = current.find { |i| i['username'] == username }
+
+        if existing
+          if existing['status'] == DockerRepo::ACCESS_STATUS[:removing]
+            existing['status'] = DockerRepo::ACCESS_STATUS[:failed]
+          else
+            credentials = r['credentials']
+            if credentials
+              set_credentials.call existing, credentials
+
+              fields_to_update.each do |f|
+                existing[f] = r[f]
+              end
+
+              existing['status'] = DockerRepo::ACCESS_STATUS[:active]
+            elsif existing['status'] == DockerRepo::ACCESS_STATUS[:pending]
+              existing['status'] = DockerRepo::ACCESS_STATUS[:failed]
+            end
+          end
+        else
+          # Unknown item but let's add it anyway
+
+          Rails.logger.warn "[DockerRepoAccessPolicyService] process_items_from_result - unknown #{item_type} was detected - username: '#{username}' - adding anyway"
+
+          new_item = r.merge 'status' => DockerRepo::ACCESS_STATUS[:active]
+          credentials = r['credentials']
+          set_credentials.call new_item, credentials if credentials
+          current << new_item
+        end
+
+      else
+        Rails.logger.error "[DockerRepoAccessPolicyService] process_items_from_result - username for #{item_type} did not pass the check - username: '#{username}' - ignoring this item and removing from access"
+      end
+    end
+
+    # Remove items not processed/seen in the backend response
+    current.select do |r|
+      processed.include? r['username']
+    end
   end
 
 end

--- a/platform-hub-api/app/services/docker_repo_lifecycle_service.rb
+++ b/platform-hub-api/app/services/docker_repo_lifecycle_service.rb
@@ -1,0 +1,108 @@
+class DockerRepoLifecycleService
+
+  def request_create service, params, audit_context
+    docker_repo = service.docker_repos.new(params)
+    docker_repo.provider = DockerRepo.providers[:ECR]
+
+    # TODO post to queue
+
+    AuditService.log(
+      context: audit_context,
+      action: 'request_create',
+      auditable: docker_repo
+    )
+
+    docker_repo
+  end
+
+  def request_delete! docker_repo, audit_context
+    id = docker_repo.id
+    name = docker_repo.name
+    service = docker_repo.service
+
+    docker_repo.update! status: :deleting
+
+    # TODO post to queue
+
+    AuditService.log(
+      context: audit_context,
+      action: 'request_delete',
+      auditable: docker_repo,
+      associated: service,
+      comment: "User '#{audit_context[:user].email}' has requested deletion of Docker repo: '#{name}' (ID: #{id}) in project '#{service.project.shortname}'"
+    )
+  end
+
+  def handle_create_result message
+    handle_result message, 'handle_create_result' do |docker_repo|
+      docker_repo.update!(
+        url: message['resource']['url'],
+        status: DockerRepo.statuses[:active]
+      )
+
+      AuditService.log(
+        action: 'create',
+        auditable: docker_repo,
+        comment: "Backend integration service successfully created Docker repo from provider: #{docker_repo.provider}"
+      )
+    end
+  end
+
+  def handle_delete_result message
+    handle_result message, 'handle_delete_result' do |docker_repo|
+      docker_repo.destroy!
+
+      AuditService.log(
+        action: 'destroy',
+        auditable: docker_repo,
+        comment: "Backend integration service successfully deleted Docker repo from provider: #{docker_repo.provider}"
+      )
+    end
+  end
+
+  private
+
+  def handle_result message, action
+    audit_message message, action
+
+    docker_repo = load_docker_repo message['resource'], action
+
+    return if docker_repo.nil?
+
+    status = message['result']['status']
+    case status
+    when 'Complete'
+      yield docker_repo
+    when 'Failed'
+      docker_repo.failed!
+    else
+      raise "Unknown status '#{status}' received from backend integration service"
+    end
+  end
+
+  def audit_message message, action
+    Audit.create!(
+      action: action,
+      auditable_type: DockerRepo.name,
+      auditable_id: message['resource']['id'],
+      auditable_descriptor: message['resource']['name'],
+      data: { 'message' => message },
+    )
+  rescue => e
+    Rails.logger.error "Failed to log audit - exception: type = #{e.class.name}, message = #{e.message}, backtrace = #{e.backtrace.join("--")}"
+  end
+
+  def load_docker_repo resource, action
+    id = resource['id']
+    name = resource['name']
+
+    docker_repo = DockerRepo.find_by id: id
+
+    if docker_repo.nil?
+      Rails.logger.error "[DockerRepoLifecycleService] #{action} - could not find a DockerRepo with ID: '#{id}' (name: '#{name}')"
+    end
+
+    docker_repo
+  end
+
+end

--- a/platform-hub-api/spec/factories/identities.rb
+++ b/platform-hub-api/spec/factories/identities.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     provider 'github'
     user
     sequence :external_id do |n|
-      "github_#{n}"
+      "#{provider}_external_id_#{n}"
     end
 
     factory :github_identity do
@@ -11,6 +11,18 @@ FactoryGirl.define do
 
     factory :kubernetes_identity do
       provider 'kubernetes'
+    end
+
+    factory :ecr_identity do
+      provider 'ecr'
+      data do
+        {
+          'credentials' => {
+            'access_key' => SecureRandom.uuid,
+            'access_secret' => SecureRandom.uuid,
+          }
+        }
+      end
     end
   end
 end

--- a/platform-hub-api/spec/services/docker_repo_access_policy_service_spec.rb
+++ b/platform-hub-api/spec/services/docker_repo_access_policy_service_spec.rb
@@ -81,9 +81,8 @@ describe DockerRepoAccessPolicyService, type: :service do
         expect(Audit.count).to eq 1
         audit = Audit.first
         expect(audit.action).to eq 'request_access_update'
-        expect(audit.auditable_type).to eq DockerRepo.name
-        expect(audit.auditable_id).to eq docker_repo.id
-        expect(audit.user.id).to eq user.id
+        expect(audit.auditable).to eq docker_repo
+        expect(audit.user).to eq user
       end
 
       context 'with existing access already set' do
@@ -176,6 +175,163 @@ describe DockerRepoAccessPolicyService, type: :service do
           docker_repo.reload
           expect(docker_repo.access).to eq expected_access
         end
+      end
+
+    end
+
+  end
+
+  context '#handle_update_result' do
+    let :message do
+      {
+        'resource' => {
+          'id' => repo_id,
+          'name' => repo_name,
+          'url' => 'a_url',
+          'robots' => robots,
+          'users' => users,
+        },
+        'result' => {
+          'status' => result_status
+        }
+      }
+    end
+
+    let(:repo_id) { docker_repo.id }
+    let(:repo_name) { docker_repo.name }
+
+    let(:robots) { [] }
+    let(:users) { [] }
+
+    let(:result_status) { 'Complete' }
+
+    it 'should log an audit for the message' do
+      expect(Audit.count).to eq 0
+
+      subject.handle_update_result message
+
+      expect(Audit.count).to be > 1
+      audit = Audit.first
+      expect(audit.action).to eq 'handle_access_update_result'
+      expect(audit.auditable_type).to eq DockerRepo.name
+      expect(audit.auditable_id).to eq repo_id
+      expect(audit.auditable_descriptor).to eq repo_name
+      expect(audit.data['message']).to eq message
+    end
+
+    context 'for a non-existing repo' do
+      let(:repo_id) { 'non-existent' }
+      let(:repo_name) { 'nope' }
+
+      it 'should log an error' do
+        expect(Rails.logger).to receive(:error)
+          .with("[DockerRepoAccessPolicyService] handle_update_result - could not find a DockerRepo with ID: '#{repo_id}' (name: '#{repo_name}')")
+
+        subject.handle_update_result message
+      end
+    end
+
+    context 'for an existing repo' do
+
+      let! :project_member_2_ecr_identity do
+        create :ecr_identity, user: project_member_2
+      end
+
+      let! :project_member_3 do
+        create(:project_membership, project: project).user
+      end
+
+      let! :project_member_4 do
+        create(:project_membership, project: project).user
+      end
+      let! :project_member_4_ecr_identity do
+        create :ecr_identity, user: project_member_4
+      end
+
+      let(:unknown_user_email) { 'whodis?@example.org' }
+      let!(:no_longer_a_project_member) { create :user }
+
+      let :existing_access do
+        {
+          'robots' => [
+            { 'username' => "#{project.slug}_robot_1", 'status' => 'pending' },
+            { 'username' => "#{project.slug}_robot_2", 'status' => 'pending' },
+            { 'username' => "#{project.slug}_robot_3", 'status' => 'active' },
+            { 'username' => "#{project.slug}_robot_4", 'status' => 'removing' },
+            { 'username' => "#{project.slug}_robot_5", 'status' => 'removing' },
+          ],
+          'users' => [
+            { 'username' => project_member_1.email, 'writable' => false, 'status' => 'pending' },
+            { 'username' => project_member_2.email, 'writable' => true, 'status' => 'removing' },
+            { 'username' => project_member_3.email, 'writable' => true, 'status' => 'removing' },
+            { 'username' => project_member_4.email, 'writable' => true, 'status' => 'active' },
+            { 'username' => unknown_user_email, 'writable' => false, 'status' => 'pending' },
+            { 'username' => no_longer_a_project_member.email, 'writable' => false, 'status' => 'active' },
+          ]
+        }
+      end
+
+      let :robots do
+        [
+          { 'username' => "#{project.slug}_robot_1", 'credentials' => { 'robot_1' => 'robot_1' } },
+          { 'username' => "#{project.slug}_robot_2" },
+          { 'username' => "#{project.slug}_robot_3" },
+          { 'username' => "#{project.slug}_robot_5" },
+        ]
+      end
+
+      let :users do
+        [
+          { 'username' => project_member_1.email, 'writable' => true, 'credentials' => { 'project_member_1' => 'project_member_1' } },
+          { 'username' => project_member_3.email, 'writable' => true },
+          { 'username' => unknown_user_email, 'writable' => false },
+          { 'username' => no_longer_a_project_member.email, 'writable' => false },
+        ]
+      end
+
+      before do
+        docker_repo.update! access: existing_access
+      end
+
+      let :expected_access do
+        {
+          'robots' => [
+            { 'username' => "#{project.slug}_robot_1", 'status' => 'active', 'credentials' => { 'robot_1' => 'robot_1' } },
+            { 'username' => "#{project.slug}_robot_2", 'status' => 'failed' },
+            { 'username' => "#{project.slug}_robot_3", 'status' => 'active' },
+            { 'username' => "#{project.slug}_robot_5", 'status' => 'failed' },
+          ],
+          'users' => [
+            { 'username' => project_member_1.email, 'writable' => true, 'status' => 'active' },
+            { 'username' => project_member_3.email, 'writable' => true, 'status' => 'failed' },
+          ]
+        }
+      end
+
+      it 'should update the repo\'s access as expected, create any required ecr identities and log an audit' do
+        expect(project_member_1.reload.ecr_identity).to be nil
+        expect(project_member_2.reload.ecr_identity).to eq project_member_2_ecr_identity
+        expect(project_member_3.reload.ecr_identity).to be nil
+        expect(project_member_4.reload.ecr_identity).to eq project_member_4_ecr_identity
+
+        subject.handle_update_result message
+
+        updated = DockerRepo.find docker_repo.id
+        expect(updated.access).to eq expected_access
+
+        expect(project_member_1.reload.ecr_identity.attributes).to include(
+          'provider' => 'ecr',
+          'external_id' => project_member_1.email,
+          'external_username' => project_member_1.email,
+          'data' => { 'credentials' => { 'project_member_1' => 'project_member_1' } }
+        )
+        expect(project_member_2.reload.ecr_identity).to eq project_member_2_ecr_identity
+        expect(project_member_3.reload.ecr_identity).to be nil
+        expect(project_member_4.reload.ecr_identity).to eq project_member_4_ecr_identity
+
+        audit = Audit.last
+        expect(audit.action).to eq 'access_update'
+        expect(audit.auditable).to eq docker_repo
       end
 
     end

--- a/platform-hub-api/spec/services/docker_repo_lifecycle_service_spec.rb
+++ b/platform-hub-api/spec/services/docker_repo_lifecycle_service_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+describe DockerRepoLifecycleService, type: :service do
+
+  subject do
+    DockerRepoLifecycleService.new
+  end
+
+  let(:user) { create :user }
+  let(:audit_context) { { user: user } }
+
+  describe '#request_create' do
+
+    let(:service) { create :service }
+
+    let :params do
+      {
+        name: 'foo',
+        description: 'so much fooooo'
+      }
+    end
+
+    it 'should create a new repo, post a request message to the queue and log an audit' do
+      expect(DockerRepo.count).to eq 0
+      expect(Audit.count).to eq 0
+
+      docker_repo = subject.request_create service, params, audit_context
+
+      expect(DockerRepo.count).to eq 1
+      expect(docker_repo.service).to eq service
+      expect(docker_repo.name).to end_with params[:name]
+      expect(docker_repo.description).to eq params[:description]
+      expect(docker_repo.provider).to eq DockerRepo.providers[:ECR]
+      expect(docker_repo.url).to be nil
+      expect(docker_repo.status).to eq DockerRepo.statuses[:pending]
+
+      expect(Audit.count).to be 1
+      audit = Audit.first
+      expect(audit.action).to eq 'request_create'
+      expect(audit.associated).to eq service
+      expect(audit.auditable).to eq docker_repo
+      expect(audit.user).to eq user
+    end
+  end
+
+  describe '#request_delete!' do
+
+    let(:docker_repo) { create :docker_repo }
+
+    it 'should mark the repo for deletion, post a request message to the queue and log an audit' do
+      expect(Audit.count).to eq 0
+
+      subject.request_delete! docker_repo, audit_context
+
+      expect(DockerRepo.exists?(docker_repo.id)).to be true
+      expect(DockerRepo.find(docker_repo.id)).to be_deleting
+
+      expect(Audit.count).to eq 1
+      audit = Audit.first
+      expect(audit.action).to eq 'request_delete'
+      expect(audit.auditable).to eq docker_repo
+      expect(audit.user).to eq user
+    end
+  end
+
+  shared_examples 'common message handling' do |action|
+    let :message do
+      {
+        'resource' => {
+          'id' => repo_id,
+          'name' => repo_name,
+          'url' => 'a_url'
+        },
+        'result' => {
+          'status' => result_status
+        }
+      }
+    end
+
+    let!(:docker_repo) { create :docker_repo }
+
+    let(:repo_id) { docker_repo.id }
+    let(:repo_name) { docker_repo.name }
+
+    let(:result_status) { 'Complete' }
+
+    it 'should log an audit for the message' do
+      expect(Audit.count).to eq 0
+
+      subject.send action, message
+
+      expect(Audit.count).to be > 1
+      audit = Audit.first
+      expect(audit.action).to eq action
+      expect(audit.auditable_type).to eq DockerRepo.name
+      expect(audit.auditable_id).to eq repo_id
+      expect(audit.auditable_descriptor).to eq repo_name
+      expect(audit.data['message']).to eq message
+    end
+
+    context 'for a non-existing repo' do
+      let(:repo_id) { 'non-existent' }
+      let(:repo_name) { 'nope' }
+
+      it 'should log an error' do
+        expect(Rails.logger).to receive(:error)
+          .with("[DockerRepoLifecycleService] #{action} - could not find a DockerRepo with ID: '#{repo_id}' (name: '#{repo_name}')")
+
+        subject.send action, message
+      end
+    end
+
+    context 'when the result is \'Failed\'' do
+      let(:result_status) { 'Failed' }
+
+      it 'should mark the repo as failed' do
+        subject.send action, message
+
+        expect(docker_repo.reload.failed?).to be true
+      end
+    end
+  end
+
+  describe '#handle_create_result' do
+    it_behaves_like 'common message handling', 'handle_create_result' do
+      it 'should update the status of the repo and any metadata' do
+        subject.handle_create_result message
+
+        updated = DockerRepo.find docker_repo.id
+        expect(updated.url).to eq message['resource']['url']
+        expect(updated).to be_active
+      end
+    end
+  end
+
+  describe '#handle_delete_result' do
+    it_behaves_like 'common message handling', 'handle_delete_result' do
+      it 'should destroy the record and log an audit' do
+        expect(DockerRepo.exists?(docker_repo.id)).to be true
+
+        subject.handle_delete_result message
+
+        expect(DockerRepo.exists?(docker_repo.id)).to be false
+
+        audit = Audit.last
+        expect(audit.action).to eq 'destroy'
+        expect(audit.auditable_type).to eq DockerRepo.name
+        expect(audit.auditable_id).to eq docker_repo.id
+      end
+    end
+  end
+
+end

--- a/platform-hub-web/src/app/app.module.js
+++ b/platform-hub-web/src/app/app.module.js
@@ -59,8 +59,8 @@ import 'medium-editor/dist/css/themes/beagle.css';
 import 'ng-material-datetimepicker/dist/material-datetimepicker.min.css';
 import 'angular-ivh-treeview/dist/ivh-treeview.css';
 import 'angular-ivh-treeview/dist/ivh-treeview-theme-basic.css';
-import './app.scss';
 import 'angular-material-expansion-panel/dist/md-expansion-panel.css';
+import './app.scss';
 
 const name = 'app';
 

--- a/platform-hub-web/src/app/app.scss
+++ b/platform-hub-web/src/app/app.scss
@@ -179,11 +179,15 @@ form.compact {
   padding: 0;
 }
 
-md-card-content {
-  md-expansion-panel {
-    box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.2);
-  }
+md-expansion-panel {
+  box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.2);
 
+  .md-title {
+    font-size: 14px;
+  }
+}
+
+md-card-content {
   md-expansion-panel,
   md-expansion-panel.md-open,
   md-expansion-panel.md-open:first-of-type {

--- a/platform-hub-web/src/app/projects/projects-detail.html
+++ b/platform-hub-web/src/app/projects/projects-detail.html
@@ -400,6 +400,12 @@
 
                     <h3 class="md-subhead">Project team members</h3>
                     <p
+                      class="md-body-1"
+                      md-colors="{background: 'blue-grey-50'}"
+                      layout-padding>
+                      Note: users can get their access credentials from their Connected Identities page
+                    </p>
+                    <p
                       ng-if="!d.access.users.length"
                       class="md-body-1 none-text">
                       None

--- a/platform-hub-web/src/app/shared/identities/identities-list.html
+++ b/platform-hub-web/src/app/shared/identities/identities-list.html
@@ -76,6 +76,52 @@
         </md-button>
       </div>
 
+      <md-divider></md-divider>
+
+    </md-list-item>
+
+    <md-list-item
+      ng-switch-when="ecr"
+      ng-if="$ctrl.FeatureFlags.isEnabled($ctrl.featureFlagKeys.dockerRepos)"
+      class="md-3-line md-long-text">
+
+      <md-icon ng-if="i.connected" md-colors="{color: 'teal'}">check_circle</md-icon>
+
+      <div class="md-list-item-text" ng-class="{'md-offset': !i.connected}">
+        <h3>{{i.title}}</h3>
+
+        <p ng-if="i.connected">
+          Username: {{i.external_username}}
+        </p>
+
+        <md-expansion-panel
+          md-component-id="ecr-credentials"
+          ng-if="i.credentials"
+          style="margin: 10px 2px;">
+          <md-expansion-panel-collapsed>
+            <div class="md-title">Credentials</div>
+            <span flex></span>
+            <md-expansion-panel-icon></md-expansion-panel-icon>
+          </md-expansion-panel-collapsed>
+
+          <md-expansion-panel-expanded>
+            <md-expansion-panel-header>
+              <div class="md-title">Credentials</div>
+              <span flex></span>
+              <md-expansion-panel-icon></md-expansion-panel-icon>
+            </md-expansion-panel-header>
+            <md-expansion-panel-content>
+              <p class="md-body-1" ng-repeat="(k, v) in i.credentials">
+                <span>{{k}}:</span>
+                <span>{{v}}</span>
+              </p>
+            </md-expansion-panel-content>
+          </md-expansion-panel-expanded>
+        </md-expansion-panel>
+      </div>
+
+      <md-divider></md-divider>
+
     </md-list-item>
 
   </md-list>

--- a/platform-hub-web/src/app/shared/model/identities.js
+++ b/platform-hub-web/src/app/shared/model/identities.js
@@ -18,6 +18,11 @@ export const Identities = function (AppSettings, hubApiService) {
       provider: 'kubernetes',
       title: 'Kubernetes',
       selfservice: false
+    },
+    {
+      provider: 'ecr',
+      title: 'Amazon ECR',
+      selfservice: false
     }
   ];
 


### PR DESCRIPTION
Handle backend integration service responses:
- Create repo – makes sure to update the status of the Docker repo entry in the hub and mark as 'active'.
- Delete repo – deletes the repo entry from the hub.
- Update repo access policy – handles various cases for robots and users access entries in the hub.

Also, shows the Amazon ECR identity on the Connected Identities page.

---

This is the next iteration of the Docker repos work. More to come!