### PR TITLE
Enable strict-transport-security setting for phub

### DIFF
--- a/platform-hub-api/config/environments/production.rb
+++ b/platform-hub-api/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
This pull request enables Strict-Transport-Security for Platform Hub.