### PR TITLE
Feature/flag flags setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,23 @@ docker compose up -d
 Visit http://host.docker.internal:3000/ to use the app.
 - http://localhost:3000 will not work.
 
-### Using all feature
+### Enabling all feature
 
-Run the following in the database to get the all the features in the app:
+To try of the roles in the platform hub:
+- admin
+- limited_admin
+
+admin have access ot the feature flag page, which allows them to determine what features are avialable for use in the app.
+- this feature is required to test all feature in the app on the frontend.
+
+Run the following in the database (platform-hub-db) to get the all the features in the app:
+Access database:
+
+```sh
+psql -U $POSTGRES_USER -d $POSTGRES_DB
+```
+
+For admin users:
 ```sql
 UPDATE users SET role = 'admin';
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Follow these confluence pages for setting the environments for:
 * [Keycloak proxy](https://collaboration.homeoffice.gov.uk/display/DSASS/ACP+Platform+Hub+-+keycloak+auth+proxy+local+setup).
 * [Backend API](https://collaboration.homeoffice.gov.uk/display/DSASS/ACP+Platform+Hub+-+How+to+setup+API+backend+locally)
 
-### How to
+### How To
 
 Run the below:
 ```sh
@@ -22,14 +22,14 @@ docker compose up -d
 Visit http://host.docker.internal:3000/ to use the app.
 - http://localhost:3000 will not work.
 
-### Enabling all feature
+### Enabling All Feature
 
 To try of the roles in the platform hub:
 - admin
 - limited_admin
 
-admin have access ot the feature flag page, which allows them to determine what features are avialable for use in the app.
-- this feature is required to test all feature in the app on the frontend.
+Admin have access to the feature flag page, which allows them to determine what features are available for use in the app.
+- This feature is required to test all feature in the app on the frontend.
 
 Run the following in the database (platform-hub-db) to get the all the features in the app:
 Access database:
@@ -48,15 +48,12 @@ For limited_admin, try:
 UPDATE users SET role = 'limited_admin';
 ```
 
-**NOTE**: As of Apirl 2nd 2024:
-- this is a not an ideal since the role information is not documented.
+**NOTE**: As of April 2nd 2024:
+- This is a not an ideal since the role information is not documented.
 - I don't know if there is better way to do this.
 - However, the above works for providing the full range of features to test, so it has some use.
 
-
-
-
-## General architecture
+## General Architecture
 
 ### `platform-hub-web`
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Follow these confluence pages for setting the environments for:
 * [Keycloak proxy](https://collaboration.homeoffice.gov.uk/display/DSASS/ACP+Platform+Hub+-+keycloak+auth+proxy+local+setup).
 * [Backend API](https://collaboration.homeoffice.gov.uk/display/DSASS/ACP+Platform+Hub+-+How+to+setup+API+backend+locally)
 
+### How to
+
 Run the below:
 ```sh
 docker compose up -d
@@ -19,6 +21,26 @@ docker compose up -d
 
 Visit http://host.docker.internal:3000/ to use the app.
 - http://localhost:3000 will not work.
+
+### Using all feature
+
+Run the following in the database to get the all the features in the app:
+```sql
+UPDATE users SET role = 'admin';
+```
+
+For limited_admin, try:
+```sql
+UPDATE users SET role = 'limited_admin';
+```
+
+**NOTE**: As of Apirl 2nd 2024:
+- this is a not an ideal since the role information is not documented.
+- I don't know if there is better way to do this.
+- However, the above works for providing the full range of features to test, so it has some use.
+
+
+
 
 ## General architecture
 

--- a/platform-hub-web/conf/webpack.conf.js
+++ b/platform-hub-web/conf/webpack.conf.js
@@ -64,6 +64,10 @@ module.exports = {
       debug: true
     })
   ],
+  watchOptions: {
+    aggregateTimeout: 200,
+    ignored: /node_modules/
+  },
   devtool: 'source-map',
   output: {
     path: path.join(process.cwd(), conf.paths.tmp),


### PR DESCRIPTION
Adds readme documentation to the application.
- How to setup admin roles.
- more info on the feature flag stuff.
- Improved `webpack` watch options for the container.